### PR TITLE
Fix double quotes not escaped in RSS title (share by email)

### DIFF
--- a/data/shares.php
+++ b/data/shares.php
@@ -19,7 +19,7 @@
 return array(
 	'shaarli' => array(
 		'url' => '~URL~?post=~LINK~&amp;title=~TITLE~&amp;source=FreshRSS',
-		'transform' => array('urlencode'),
+		'transform' => array('rawurlencode'),
 		'help' => 'http://sebsauvage.net/wiki/doku.php?id=php:shaarli',
 		'form' => 'advanced',
 	),
@@ -40,31 +40,28 @@ return array(
 	),
 	'diaspora' => array(
 		'url' => '~URL~/bookmarklet?url=~LINK~&amp;title=~TITLE~',
-		'transform' => array('urlencode'),
+		'transform' => array('rawurlencode'),
 		'help' => 'https://diasporafoundation.org/',
 		'form' => 'advanced',
 	),
 	'twitter' => array(
 		'url' => 'https://twitter.com/share?url=~LINK~&amp;text=~TITLE~',
-		'transform' => array('urlencode'),
+		'transform' => array('rawurlencode'),
 		'form' => 'simple',
 	),
 	'g+' => array(
 		'url' => 'https://plus.google.com/share?url=~LINK~',
-		'transform' => array('urlencode'),
+		'transform' => array('rawurlencode'),
 		'form' => 'simple',
 	),
 	'facebook' => array(
 		'url' => 'https://www.facebook.com/sharer.php?u=~LINK~&amp;t=~TITLE~',
-		'transform' => array('urlencode'),
+		'transform' => array('rawurlencode'),
 		'form' => 'simple',
 	),
 	'email' => array(
 		'url' => 'mailto:?subject=~TITLE~&amp;body=~LINK~',
-		'transform' => array(
-			'link' => array('urlencode'),
-			'title' => array(),
-		),
+		'transform' => array('rawurlencode'),
 		'form' => 'simple',
 	),
 	'print' => array(


### PR DESCRIPTION
If an RSS feed title contains double quotes, this prematurely terminates the subject line and prohibits the URL to be added to the email body when using Share->Email.
Replace urlencode() with rawurlencode() for all transform functions.
