### PR TITLE
Harmonize share configuration view.

### DIFF
--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -152,7 +152,7 @@ class FreshRSS_Share {
 	 * Return the current name of the share option.
 	 */
 	public function name($real = false) {
-		if ($real || is_null($this->custom_name)) {
+		if ($real || is_null($this->custom_name) || empty($this->custom_name)) {
 			return $this->name;
 		} else {
 			return $this->custom_name;

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -156,6 +156,7 @@ return array(
 		'damn' => 'Verdammt!',
 		'default_category' => 'Unkategorisiert',
 		'no' => 'Nein',
+		'not_applicable' => 'N/A',
 		'ok' => 'OK!',
 		'or' => 'oder',
 		'yes' => 'Ja',

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -156,7 +156,7 @@ return array(
 		'damn' => 'Verdammt!',
 		'default_category' => 'Unkategorisiert',
 		'no' => 'Nein',
-		'not_applicable' => 'N/A',
+		'not_applicable' => 'Nicht verfügbar',
 		'ok' => 'OK!',
 		'or' => 'oder',
 		'yes' => 'Ja',

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -156,7 +156,7 @@ return array(
 		'damn' => 'Damn!',
 		'default_category' => 'Uncategorized',
 		'no' => 'No',
-		'not_applicable' => 'N/A',
+		'not_applicable' => 'Not available',
 		'ok' => 'Ok!',
 		'or' => 'or',
 		'yes' => 'Yes',

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -156,6 +156,7 @@ return array(
 		'damn' => 'Damn!',
 		'default_category' => 'Uncategorized',
 		'no' => 'No',
+		'not_applicable' => 'N/A',
 		'ok' => 'Ok!',
 		'or' => 'or',
 		'yes' => 'Yes',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -156,7 +156,7 @@ return array(
 		'damn' => 'Arf !',
 		'default_category' => 'Sans catégorie',
 		'no' => 'Non',
-		'not_applicable' => 'N/A',
+		'not_applicable' => 'Non disponible',
 		'ok' => 'Ok !',
 		'or' => 'ou',
 		'yes' => 'Oui',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -156,6 +156,7 @@ return array(
 		'damn' => 'Arf !',
 		'default_category' => 'Sans catégorie',
 		'no' => 'Non',
+		'not_applicable' => 'N/A',
 		'ok' => 'Ok !',
 		'or' => 'ou',
 		'yes' => 'Oui',

--- a/app/views/configure/sharing.phtml
+++ b/app/views/configure/sharing.phtml
@@ -4,7 +4,8 @@
 	<a href="<?php echo _url('index', 'index'); ?>"><?php echo _t('gen.action.back_to_rss_feeds'); ?></a>
 
 	<form method="post" action="<?php echo _url('configure', 'sharing'); ?>"
-		data-simple='<div class="form-group" id="group-share-##key##"><label class="group-name">##label##</label><div class="group-controls"><a href="#" class="remove btn btn-attention" data-remove="group-share-##key##"><?php echo _i('close'); ?></a>
+		data-simple='<div class="form-group" id="group-share-##key##"><label class="group-name">##label##</label><div class="group-controls"><div class="stick"><input type="text" id="share_##key##_name" name="share[##key##][name]" class="extend" value="##label##" placeholder="<?php echo _t('conf.sharing.share_name'); ?>" size="64" />
+			<input type="url" id="share_##key##_url" name="share[##key##][url]" class="extend" value="" placeholder="<?php echo _t('gen.short.not_applicable'); ?>" size="64" disabled /><a href="#" class="remove btn btn-attention" data-remove="group-share-##key##"><?php echo _i('close'); ?></a></div>
 			<input type="hidden" id="share_##key##_type" name="share[##key##][type]" value="##type##" /></div></div>'
 		data-advanced='<div class="form-group" id="group-share-##key##"><label class="group-name">##label##</label><div class="group-controls">
 			<input type="hidden" id="share_##key##_type" name="share[##key##][type]" value="##type##" />
@@ -26,16 +27,17 @@
 				</label>
 				<div class="group-controls">
 					<input type='hidden' id='share_<?php echo $key; ?>_type' name="share[<?php echo $key; ?>][type]" value='<?php echo $share->type(); ?>' />
+					<div class="stick">
+						<input type="text" id="share_<?php echo $key; ?>_name" name="share[<?php echo $key; ?>][name]" class="extend" value="<?php echo $share->name(); ?>" placeholder="<?php echo _t('conf.sharing.share_name'); ?>" size="64" />
 					<?php if ($share->formType() === 'advanced') { ?>
-						<div class="stick">
-							<input type="text" id="share_<?php echo $key; ?>_name" name="share[<?php echo $key; ?>][name]" class="extend" value="<?php echo $share->name(); ?>" placeholder="<?php echo _t('conf.sharing.share_name'); ?>" size="64" />
-							<input type="url" id="share_<?php echo $key; ?>_url" name="share[<?php echo $key; ?>][url]" class="extend" value="<?php echo $share->baseUrl(); ?>" placeholder="<?php echo _t('conf.sharing.share_url'); ?>" size="64" />
-							<a href='#' class='remove btn btn-attention' data-remove="group-share-<?php echo $key; ?>"><?php echo _i('close'); ?></a>
-						</div>
-
-						<a target="_blank" class="btn" title="<?php echo _t('conf.sharing.more_information'); ?>" href="<?php echo $share->help(); ?>"><?php echo _i('help'); ?></a>
+						<input type="url" id="share_<?php echo $key; ?>_url" name="share[<?php echo $key; ?>][url]" class="extend" value="<?php echo $share->baseUrl(); ?>" placeholder="<?php echo _t('conf.sharing.share_url'); ?>" size="64" />
 					<?php } else { ?>
-					<a href='#' class='remove btn btn-attention' data-remove="group-share-<?php echo $key; ?>"><?php echo _i('close'); ?></a>
+						<input type="url" id="share_<?php echo $key; ?>_url" name="share[<?php echo $key; ?>][url]" class="extend" value="<?php echo $share->baseUrl(); ?>" placeholder="<?php echo _t('gen.short.not_applicable'); ?>" size="64" disabled/>
+					<?php } ?>
+						<a href='#' class='remove btn btn-attention' data-remove="group-share-<?php echo $key; ?>"><?php echo _i('close'); ?></a>
+					</div>
+					<?php if ($share->formType() === 'advanced') { ?>
+						<a target="_blank" class="btn" title="<?php echo _t('conf.sharing.more_information'); ?>" href="<?php echo $share->help(); ?>"><?php echo _i('help'); ?></a>
 					<?php } ?>
 				</div>
 			</div>

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1097,7 +1097,7 @@ function init_share_observers() {
 	$('.share.add').on('click', function(e) {
 		var opt = $(this).siblings('select').find(':selected');
 		var row = $(this).parents('form').data(opt.data('form'));
-		row = row.replace('##label##', opt.html(), 'g');
+		row = row.replace('##label##', opt.html().trim(), 'g');
 		row = row.replace('##type##', opt.val(), 'g');
 		row = row.replace('##help##', opt.data('help'), 'g');
 		row = row.replace('##key##', shares, 'g');


### PR DESCRIPTION
Before, for shares that don't need options, only a button to remove it was visible. It was source of confusion for users.
I changed the look of those shares by using the same layout as others (minus the help). As there is no configuration possible for the url, the field is disabled but it is possible to change the name of the share.

See #787
