### PR TITLE
Fix API to use the search object

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -371,7 +371,7 @@ function streamContents($path, $include_target, $start_time, $count, $order, $ex
 	}
 
 	$entryDAO = FreshRSS_Factory::createEntryDao();
-	$entries = $entryDAO->listWhere($type, $include_target, $state, $order === 'o' ? 'ASC' : 'DESC', $count, $continuation, '', $start_time);
+	$entries = $entryDAO->listWhere($type, $include_target, $state, $order === 'o' ? 'ASC' : 'DESC', $count, $continuation, new FreshRSS_Search(''), $start_time);
 
 	$items = array();
 	foreach ($entries as $entry) {


### PR DESCRIPTION
Since the internal of the listWhere method was changed, the API wasn't working. It was still calling the method with the old parameters.
I didn't test it but now, it should work.

See #796 
