### PR TITLE
Fix entry DAO query usage

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -465,7 +465,7 @@ function streamContentsItemsIds($streamId, $start_time, $count, $order, $exclude
 	}
 
 	$entryDAO = FreshRSS_Factory::createEntryDao();
-	$ids = $entryDAO->listIdsWhere($type, $id, $state, $order === 'o' ? 'ASC' : 'DESC', $count, '', '', $start_time);
+	$ids = $entryDAO->listIdsWhere($type, $id, $state, $order === 'o' ? 'ASC' : 'DESC', $count, '', new FreshRSS_Search(''), $start_time);
 
 	$itemRefs = array();
 	foreach ($ids as $id) {


### PR DESCRIPTION
I did not fix the call in the previous commit. I hope this one is the last change needed.

We definitely need a templating engine so we could use the same controller to output different things.
This will remove code duplication between the api and the web interface.
It will allows us to build other type of api, and also refactor the rss feed as a different view of the same dataset.

Should solve #801 problem
