### PR TITLE
SimplePie logging of HTTP requests

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -240,7 +240,7 @@ class FreshRSS_Feed extends Minz_Model {
 					$subscribe_url = $feed->subscribe_url(true);
 				}
 
-				$clean_url = url_remove_credentials($subscribe_url);
+				$clean_url = SimplePie_Misc::url_remove_credentials($subscribe_url);
 				if ($subscribe_url !== null && $subscribe_url !== $url) {
 					$this->_url($clean_url);
 				}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -246,10 +246,10 @@ class FreshRSS_Feed extends Minz_Model {
 				}
 
 				if (($mtime === true) ||($mtime > $this->lastUpdate)) {
-					Minz_Log::notice('FreshRSS no cache ' . $mtime . ' > ' . $this->lastUpdate . ' for ' . $clean_url);
+					//Minz_Log::debug('FreshRSS no cache ' . $mtime . ' > ' . $this->lastUpdate . ' for ' . $clean_url);
 					$this->loadEntries($feed);	// et on charge les articles du flux
 				} else {
-					Minz_Log::notice('FreshRSS use cache for ' . $clean_url);
+					//Minz_Log::debug('FreshRSS use cache for ' . $clean_url);
 					$this->entries = array();
 				}
 

--- a/data/config.default.php
+++ b/data/config.default.php
@@ -12,6 +12,7 @@ return array(
 	'auth_type' => 'none',
 	'api_enabled' => false,
 	'unsafe_autologin_enabled' => false,
+	'simplepie_syslog_enabled' => true,
 	'limits' => array(
 		'cache_duration' => 800,
 		'timeout' => 10,

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -1554,14 +1554,14 @@ class SimplePie
 						if ($this->data['md5'] === $md5) {
 							if ($this->syslog_enabled)
 							{
-								syslog(LOG_DEBUG, 'SimplePie MD5 cache match for ' . $this->feed_url);
+								syslog(LOG_DEBUG, 'SimplePie MD5 cache match for ' . SimplePie_Misc::url_remove_credentials($this->feed_url));
 							}
 							$cache->touch();
 							return true;	//Content unchanged even though server did not send a 304
 						} else {
 							if ($this->syslog_enabled)
 							{
-								syslog(LOG_DEBUG, 'SimplePie MD5 cache no match for ' . $this->feed_url);
+								syslog(LOG_DEBUG, 'SimplePie MD5 cache no match for ' . SimplePie_Misc::url_remove_credentials($this->feed_url));
 							}
 							$this->data['md5'] = $md5;
 						}

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -75,6 +75,12 @@ define('SIMPLEPIE_USERAGENT', SIMPLEPIE_NAME . '/' . SIMPLEPIE_VERSION . ' (Feed
 define('SIMPLEPIE_LINKBACK', '<a href="' . SIMPLEPIE_URL . '" title="' . SIMPLEPIE_NAME . ' ' . SIMPLEPIE_VERSION . '">' . SIMPLEPIE_NAME . '</a>');
 
 /**
+ * Use syslog to report HTTP requests done by SimplePie.
+ * @see SimplePie::set_syslog()
+ */
+define('SIMPLEPIE_SYSLOG', true);	//FreshRSS
+
+/**
  * No Autodiscovery
  * @see SimplePie::set_autodiscovery_level()
  */
@@ -623,6 +629,12 @@ class SimplePie
 	public $strip_htmltags = array('base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style');
 
 	/**
+	 * Use syslog to report HTTP requests done by SimplePie.
+	 * @see SimplePie::set_syslog()
+	 */
+	public $syslog_enabled = SIMPLEPIE_SYSLOG;
+
+	/**
 	 * The SimplePie class contains feed level data and options
 	 *
 	 * To use SimplePie, create the SimplePie object with no parameters. You can
@@ -1136,13 +1148,21 @@ class SimplePie
 		$this->sanitize->strip_attributes($attribs);
 	}
 
-	public function add_attributes($attribs = '')
+	public function add_attributes($attribs = '')	//FreshRSS
 	{
 		if ($attribs === '')
 		{
 			$attribs = $this->add_attributes;
 		}
 		$this->sanitize->add_attributes($attribs);
+	}
+
+	/**
+	 * Use syslog to report HTTP requests done by SimplePie.
+	 */
+	public function set_syslog($value = SIMPLEPIE_SYSLOG)	//FreshRSS
+	{
+		$this->syslog_enabled = $value == true;
 	}
 
 	/**
@@ -1231,7 +1251,8 @@ class SimplePie
 		$this->enable_exceptions = $enable;
 	}
 
-	function cleanMd5($rss) {	//FreshRSS
+	function cleanMd5($rss)	//FreshRSS
+	{
 		return md5(preg_replace(array('#<(lastBuildDate|pubDate|updated|feedDate|dc:date|slash:comments)>[^<]+</\\1>#', '#<!--.+?-->#s'), '', $rss));
 	}
 
@@ -1329,7 +1350,8 @@ class SimplePie
 
 			list($headers, $sniffed) = $fetched;
 
-			if (isset($this->data['md5'])) {	//FreshRSS
+			if (isset($this->data['md5']))	//FreshRSS
+			{
 				$md5 = $this->data['md5'];
 			}
 		}
@@ -1455,7 +1477,8 @@ class SimplePie
 		{
 			// Load the Cache
 			$this->data = $cache->load();
-			if ($cache->mtime() + $this->cache_duration > time()) {	//FreshRSS
+			if ($cache->mtime() + $this->cache_duration > time())	//FreshRSS
+			{
 				$this->raw_data = false;
 				return true;	// If the cache is still valid, just return true
 			}
@@ -1529,11 +1552,17 @@ class SimplePie
 					{	//FreshRSS
 						$md5 = $this->cleanMd5($file->body);
 						if ($this->data['md5'] === $md5) {
-							// syslog(LOG_DEBUG, 'SimplePie MD5 cache match for ' . $this->feed_url);
+							if ($this->syslog_enabled)
+							{
+								syslog(LOG_DEBUG, 'SimplePie MD5 cache match for ' . $this->feed_url);
+							}
 							$cache->touch();
 							return true;	//Content unchanged even though server did not send a 304
 						} else {
-							// syslog(LOG_DEBUG, 'SimplePie MD5 cache no match for ' . $this->feed_url);
+							if ($this->syslog_enabled)
+							{
+								syslog(LOG_DEBUG, 'SimplePie MD5 cache no match for ' . $this->feed_url);
+							}
 							$this->data['md5'] = $md5;
 						}
 					}

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -66,7 +66,7 @@ class SimplePie_File
 	var $method = SIMPLEPIE_FILE_SOURCE_NONE;
 	var $permanent_url;	//FreshRSS
 
-	public function __construct($url, $timeout = 10, $redirects = 5, $headers = null, $useragent = null, $force_fsockopen = false)
+	public function __construct($url, $timeout = 10, $redirects = 5, $headers = null, $useragent = null, $force_fsockopen = false, $syslog_enabled = SIMPLEPIE_SYSLOG)
 	{
 		if (class_exists('idna_convert'))
 		{
@@ -79,7 +79,10 @@ class SimplePie_File
 		$this->useragent = $useragent;
 		if (preg_match('/^http(s)?:\/\//i', $url))
 		{
-			// syslog(LOG_INFO, 'SimplePie GET ' . $url);	//FreshRSS
+			if ($syslog_enabled)
+			{
+				syslog(LOG_INFO, 'SimplePie GET ' . $url);	//FreshRSS
+			}
 			if ($useragent === null)
 			{
 				$useragent = ini_get('user_agent');

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -81,7 +81,7 @@ class SimplePie_File
 		{
 			if ($syslog_enabled)
 			{
-				syslog(LOG_INFO, 'SimplePie GET ' . $url);	//FreshRSS
+				syslog(LOG_INFO, 'SimplePie GET ' . SimplePie_Misc::url_remove_credentials($url));	//FreshRSS
 			}
 			if ($useragent === null)
 			{

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -2248,7 +2248,7 @@ function embed_wmedia(width, height, link) {
 	 */
 	function url_remove_credentials($url)	//FreshRSS
 	{
-		return preg_replace('#(?<=//)[^/:@]+:[^/:@]+@#', '', $url);
+		return preg_replace('#(?<=^https?://)[^/:@]+:[^/:@]+@#', '', $url);
 	}
 }
 

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -2248,7 +2248,7 @@ function embed_wmedia(width, height, link) {
 	 */
 	function url_remove_credentials($url)	//FreshRSS
 	{
-		return preg_replace('#(?<=//)[^/:@]+:[^/:@]+@#', '', $url);
+		return preg_replace('#^(https?://)[^/:@]+:[^/:@]+@#i', '$1', $url);
 	}
 }
 

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -2240,5 +2240,15 @@ function embed_wmedia(width, height, link) {
 	{
 		// No-op
 	}
+
+	/**
+	 * Sanitize a URL by removing HTTP credentials.
+	 * @param $url the URL to sanitize.
+	 * @return the same URL without HTTP credentials.
+	 */
+	function url_remove_credentials($url)	//FreshRSS
+	{
+		return preg_replace('#(?<=//)[^/:@]+:[^/:@]+@#', '', $url);
+	}
 }
 

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -2248,7 +2248,7 @@ function embed_wmedia(width, height, link) {
 	 */
 	function url_remove_credentials($url)	//FreshRSS
 	{
-		return preg_replace('#(?<=^https?://)[^/:@]+:[^/:@]+@#', '', $url);
+		return preg_replace('#(?<=//)[^/:@]+:[^/:@]+@#', '', $url);
 	}
 }
 

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -2246,7 +2246,7 @@ function embed_wmedia(width, height, link) {
 	 * @param $url the URL to sanitize.
 	 * @return the same URL without HTTP credentials.
 	 */
-	function url_remove_credentials($url)	//FreshRSS
+	public static function url_remove_credentials($url)	//FreshRSS
 	{
 		return preg_replace('#^(https?://)[^/:@]+:[^/:@]+@#i', '$1', $url);
 	}

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -181,7 +181,7 @@ function sanitizeHTML($data, $base = '') {
 function get_content_by_parsing ($url, $path) {
 	require_once (LIB_PATH . '/lib_phpQuery.php');
 
-	Minz_Log::notice('FreshRSS GET ' . url_remove_credentials($url));
+	Minz_Log::notice('FreshRSS GET ' . SimplePie_Misc::url_remove_credentials($url));
 	$html = file_get_contents ($url);
 
 	if ($html) {
@@ -429,14 +429,4 @@ function array_push_unique(&$array, $value) {
  */
 function array_remove(&$array, $value) {
 	$array = array_diff($array, array($value));
-}
-
-
-/**
- * Sanitize a URL by removing HTTP credentials.
- * @param $url the URL to sanitize.
- * @return the same URL without HTTP credentials.
- */
-function url_remove_credentials($url) {
-	return preg_replace('/[^\/]*:[^:]*@/', '', $url);
 }

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -123,6 +123,7 @@ function customSimplePie() {
 	$limits = $system_conf->limits;
 	$simplePie = new SimplePie();
 	$simplePie->set_useragent(_t('gen.freshrss') . '/' . FRESHRSS_VERSION . ' (' . PHP_OS . '; ' . FRESHRSS_WEBSITE . ') ' . SIMPLEPIE_NAME . '/' . SIMPLEPIE_VERSION);
+	$simplePie->set_syslog($system_conf->simplepie_syslog_enabled);
 	$simplePie->set_cache_location(CACHE_PATH);
 	$simplePie->set_cache_duration($limits['cache_duration']);
 	$simplePie->set_timeout($limits['timeout']);


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/711
New option (in FreshRSS and in SimplePie) to turn on/off the logging (via syslog) of HTTP requests done by SimplePie.
Passwords are removed from URLs before logging. The regular expression has been slightly updated since https://github.com/FreshRSS/FreshRSS/pull/715 (should be faster and safer), taking advantage of RFC 3986.
