### PR TITLE
Configuration setter bug

### DIFF
--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -117,7 +117,9 @@ class FreshRSS_ConfigurationSetter {
 	private function _queries(&$data, $values) {
 		$data['queries'] = array();
 		foreach ($values as $value) {
-			$data['queries'][] = $value->toArray();
+			if ($value != null) {
+				$data['queries'][] = $value->toArray();
+			}
 		}
 	}
 

--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -117,7 +117,7 @@ class FreshRSS_ConfigurationSetter {
 	private function _queries(&$data, $values) {
 		$data['queries'] = array();
 		foreach ($values as $value) {
-			if ($value != null) {
+			if ($value instanceof FreshRSS_UserQuery) {
 				$data['queries'][] = $value->toArray();
 			}
 		}


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/816
I have not yet looked for the root cause of the bug, but at least no error is generated anymore.
IMO, the new FreshRSS_ConfigurationSetter might have some advantages but as it is written now, it has added quite some complexity/obscurity, particularly due to the use of `call_user_func_array`. It is not obvious which functions are used or not, and it is difficult to search for callers.
I will try to make a stack trace later, to identify the root cause.
