### PR TITLE
Split the search into values

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -478,11 +478,13 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 				}
 			}
 			if ($filter->getSearch()) {
-				$search .= 'AND ' . $this->sqlconcat('e1.title', $this->isCompressed() ? 'UNCOMPRESS(content_bin)' : 'content') . ' LIKE ? ';
-				$values[] = "%{$filter->getSearch()}%";
+				$search_values = $filter->getSearch();
+				foreach ($search_values as $search_value) {
+					$search .= 'AND ' . $this->sqlconcat('e1.title', $this->isCompressed() ? 'UNCOMPRESS(content_bin)' : 'content') . ' LIKE ? ';
+					$values[] = "%{$search_value}%";
+				}
 			}
 		}
-
 		return array($values,
 			'SELECT e1.id FROM `' . $this->prefix . 'entry` e1 '
 			. ($joinFeed ? 'INNER JOIN `' . $this->prefix . 'feed` f ON e1.id_feed=f.id ' : '')

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -34,9 +34,9 @@ class FreshRSS_Search {
 		$input = $this->parsePubdateSearch($input);
 		$input = $this->parseDateSearch($input);
 		$input = $this->parseTagsSeach($input);
-		$this->search = $this->cleanSearch($input);
+		$this->parseSearch($input);
 	}
-	
+
 	public function __toString() {
 		return $this->getRawInput();
 	}
@@ -185,6 +185,34 @@ class FreshRSS_Search {
 			return str_replace($matches[0], '', $input);
 		}
 		return $input;
+	}
+
+	/**
+	 * Parse the search string to find search values.
+	 * Every word is a distinct search value, except when using a delimiter.
+	 * Supported delimiters are single quote (') and double quotes (").
+	 *
+	 * @param string $input
+	 * @return string
+	 */
+	private function parseSearch($input) {
+		$input = $this->cleanSearch($input);
+		if (strcmp($input, '') == 0) {
+			return;
+		}
+		if (preg_match_all('/(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
+			$this->search = $matches['search'];
+			$input = str_replace($matches[0], '', $input);
+		}
+		$input = $this->cleanSearch($input);
+		if (strcmp($input, '') == 0) {
+			return;
+		}
+		if (is_array($this->search)) {
+			$this->search = array_merge($this->search, explode(' ', $input));
+		} else {
+			$this->search = explode(' ', $input);
+		}
 	}
 
 	/**

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -51,20 +51,21 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 	public function provideIntitleSearch() {
 		return array(
 		    array('intitle:word1', 'word1', null),
-		    array('intitle:word1 word2', 'word1', 'word2'),
+		    array('intitle:word1 word2', 'word1', array('word2')),
 		    array('intitle:"word1 word2"', 'word1 word2', null),
 		    array("intitle:'word1 word2'", 'word1 word2', null),
-		    array('word1 intitle:word2', 'word2', 'word1'),
-		    array('word1 intitle:word2 word3', 'word2', 'word1 word3'),
-		    array('word1 intitle:"word2 word3"', 'word2 word3', 'word1'),
-		    array("word1 intitle:'word2 word3'", 'word2 word3', 'word1'),
-		    array('intitle:word1 intitle:word2', 'word1', 'intitle:word2'),
-		    array('intitle: word1 word2', null, 'word1 word2'),
+		    array('word1 intitle:word2', 'word2', array('word1')),
+		    array('word1 intitle:word2 word3', 'word2', array('word1', 'word3')),
+		    array('word1 intitle:"word2 word3"', 'word2 word3', array('word1')),
+		    array("word1 intitle:'word2 word3'", 'word2 word3', array('word1')),
+		    array('intitle:word1 intitle:word2', 'word1', array('intitle:word2')),
+		    array('intitle: word1 word2', null, array('word1', 'word2')),
 		    array('intitle:123', '123', null),
-		    array('intitle:"word1 word2" word3"', 'word1 word2', 'word3"'),
-		    array("intitle:'word1 word2' word3'", 'word1 word2', "word3'"),
+		    array('intitle:"word1 word2" word3"', 'word1 word2', array('word3"')),
+		    array("intitle:'word1 word2' word3'", 'word1 word2', array("word3'")),
 		    array('intitle:"word1 word2\' word3"', "word1 word2' word3", null),
 		    array("intitle:'word1 word2\" word3'", 'word1 word2" word3', null),
+		    array("intitle:word1 'word2 word3' word4", 'word1', array('word2 word3', 'word4')),
 		);
 	}
 
@@ -86,20 +87,21 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 	public function provideAuthorSearch() {
 		return array(
 		    array('author:word1', 'word1', null),
-		    array('author:word1 word2', 'word1', 'word2'),
+		    array('author:word1 word2', 'word1', array('word2')),
 		    array('author:"word1 word2"', 'word1 word2', null),
 		    array("author:'word1 word2'", 'word1 word2', null),
-		    array('word1 author:word2', 'word2', 'word1'),
-		    array('word1 author:word2 word3', 'word2', 'word1 word3'),
-		    array('word1 author:"word2 word3"', 'word2 word3', 'word1'),
-		    array("word1 author:'word2 word3'", 'word2 word3', 'word1'),
-		    array('author:word1 author:word2', 'word1', 'author:word2'),
-		    array('author: word1 word2', null, 'word1 word2'),
+		    array('word1 author:word2', 'word2', array('word1')),
+		    array('word1 author:word2 word3', 'word2', array('word1', 'word3')),
+		    array('word1 author:"word2 word3"', 'word2 word3', array('word1')),
+		    array("word1 author:'word2 word3'", 'word2 word3', array('word1')),
+		    array('author:word1 author:word2', 'word1', array('author:word2')),
+		    array('author: word1 word2', null, array('word1', 'word2')),
 		    array('author:123', '123', null),
-		    array('author:"word1 word2" word3"', 'word1 word2', 'word3"'),
-		    array("author:'word1 word2' word3'", 'word1 word2', "word3'"),
+		    array('author:"word1 word2" word3"', 'word1 word2', array('word3"')),
+		    array("author:'word1 word2' word3'", 'word1 word2', array("word3'")),
 		    array('author:"word1 word2\' word3"', "word1 word2' word3", null),
 		    array("author:'word1 word2\" word3'", 'word1 word2" word3', null),
+		    array("author:word1 'word2 word3' word4", 'word1', array('word2 word3', 'word4')),
 		);
 	}
 
@@ -121,10 +123,11 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 	public function provideInurlSearch() {
 		return array(
 		    array('inurl:word1', 'word1', null),
-		    array('inurl: word1', null, 'word1'),
+		    array('inurl: word1', null, array('word1')),
 		    array('inurl:123', '123', null),
-		    array('inurl:word1 word2', 'word1', 'word2'),
-		    array('inurl:"word1 word2"', '"word1', 'word2"'),
+		    array('inurl:word1 word2', 'word1', array('word2')),
+		    array('inurl:"word1 word2"', '"word1', array('word2"')),
+		    array("inurl:word1 'word2 word3' word4", 'word1', array('word2 word3', 'word4')),
 		);
 	}
 
@@ -198,11 +201,12 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 	public function provideTagsSearch() {
 		return array(
 		    array('#word1', array('word1'), null),
-		    array('# word1', null, '# word1'),
+		    array('# word1', null, array('#', 'word1')),
 		    array('#123', array('123'), null),
-		    array('#word1 word2', array('word1'), 'word2'),
-		    array('#"word1 word2"', array('"word1'), 'word2"'),
+		    array('#word1 word2', array('word1'), array('word2')),
+		    array('#"word1 word2"', array('"word1'), array('word2"')),
 		    array('#word1 #word2', array('word1', 'word2'), null),
+		    array("#word1 'word2 word3' word4", array('word1'), array('word2 word3', 'word4')),
 		);
 	}
 
@@ -257,7 +261,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 			'1172725200',
 			'1210564799',
 			array('word4', 'word5'),
-			'word6',
+			array('word6'),
 		    ),
 		    array(
 			'word6 intitle:word2 inurl:word3 pubdate:2007-03-01/2008-05-11 #word4 author:word1 #word5 word7 date:2007-03-01/2008-05-11',
@@ -269,7 +273,19 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 			'1172725200',
 			'1210564799',
 			array('word4', 'word5'),
-			'word6 word7',
+			array('word6', 'word7'),
+		    ),
+		    array(
+			'word6 intitle:word2 inurl:word3 pubdate:2007-03-01/2008-05-11 #word4 author:word1 #word5 "word7 word8" date:2007-03-01/2008-05-11',
+			'word1',
+			'1172725200',
+			'1210564799',
+			'word2',
+			'word3',
+			'1172725200',
+			'1210564799',
+			array('word4', 'word5'),
+			array('word7 word8', 'word6'),
 		    ),
 		);
 	}


### PR DESCRIPTION
Before, the search was a single value.
Now it is splited in chuncks when separated by spaces.
Except if they are enclosed by single quotes or double quotes.

For some reasons, the unit tests are working for both single and double quotes but the
search box isn't. It is working only with single quotes.
We need to investigate the reason of this behavior.

See #823
