### PR TITLE
SQLite compatibility with new update mode

### DIFF
--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -2,6 +2,21 @@
 
 class FreshRSS_EntryDAOSQLite extends FreshRSS_EntryDAO {
 
+	protected function autoAddColumn($errorInfo) {
+		if (empty($errorInfo[0]) || $errorInfo[0] == '42S22') {	//ER_BAD_FIELD_ERROR
+			if ($tableInfo = $this->bd->query("SELECT sql FROM sqlite_master where name='entry'")) {
+				$showCreate = $tableInfo->fetchColumn();
+				Minz_Log::debug('FreshRSS_EntryDAOSQLite::autoAddColumn: ' . $showCreate);
+				foreach (array('lastSeen', 'hash') as $column) {
+					if (stripos($showCreate, $column) === false) {
+						return $this->addColumn($column);
+					}
+				}
+			}
+		}
+		return false;
+	}
+
 	protected function sqlConcat($s1, $s2) {
 		return $s1 . '||' . $s2;
 	}

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -330,11 +330,12 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		     . 'AND id NOT IN (SELECT id FROM (SELECT e2.id FROM `' . $this->prefix . 'entry` e2 WHERE e2.id_feed=:id_feed ORDER BY id DESC LIMIT :keep) keep)';	//Double select: MySQL doesn't support 'LIMIT & IN/ALL/ANY/SOME subquery'
 		$stm = $this->bd->prepare($sql);
 
-		$id_max = intval($date_min) . '000000';
-
-		$stm->bindParam(':id_feed', $id, PDO::PARAM_INT);
-		$stm->bindParam(':id_max', $id_max, PDO::PARAM_STR);
-		$stm->bindParam(':keep', $keep, PDO::PARAM_INT);
+		if ($stm) {
+			$id_max = intval($date_min) . '000000';
+			$stm->bindParam(':id_feed', $id, PDO::PARAM_INT);
+			$stm->bindParam(':id_max', $id_max, PDO::PARAM_STR);
+			$stm->bindParam(':keep', $keep, PDO::PARAM_INT);
+		}
 
 		if ($stm && $stm->execute()) {
 			return $stm->rowCount();

--- a/app/SQL/install.sql.mysql.php
+++ b/app/SQL/install.sql.mysql.php
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS `%1$sentry` (
 	`content_bin` blob,	-- v0.7
 	`link` varchar(1023) CHARACTER SET latin1 NOT NULL,
 	`date` int(11),	-- Until year 2038
-	`lastSeen` INT(11) NOT NULL,	-- v1.2, Until year 2038
+	`lastSeen` INT(11) DEFAULT 0,	-- v1.2, Until year 2038
 	`hash` BINARY(16),	-- v1.2
 	`is_read` boolean NOT NULL DEFAULT 0,
 	`is_favorite` boolean NOT NULL DEFAULT 0,

--- a/app/SQL/install.sql.sqlite.php
+++ b/app/SQL/install.sql.sqlite.php
@@ -39,7 +39,7 @@ $SQL_CREATE_TABLES = array(
 	`content` text,
 	`link` varchar(1023) NOT NULL,
 	`date` int(11),	-- Until year 2038
-	`lastSeen` INT(11) NOT NULL,	-- v1.2, Until year 2038
+	`lastSeen` INT(11) DEFAULT 0,	-- v1.2, Until year 2038
 	`hash` BINARY(16),	-- v1.2
 	`is_read` boolean NOT NULL DEFAULT 0,
 	`is_favorite` boolean NOT NULL DEFAULT 0,

--- a/app/install.php
+++ b/app/install.php
@@ -168,8 +168,10 @@ function saveStep3() {
 			$_SESSION['bd_prefix_user'] = $_SESSION['bd_prefix'] .(empty($_SESSION['default_user']) ? '' :($_SESSION['default_user'] . '_'));
 		}
 
+		//TODO: load `config.default.php` as default
 		$config_array = array(
 			'environment' => 'production',
+			'simplepie_syslog_enabled' => true,
 			'salt' => $_SESSION['salt'],
 			'title' => $_SESSION['title'],
 			'default_user' => $_SESSION['default_user'],

--- a/lib/Minz/ModelPdo.php
+++ b/lib/Minz/ModelPdo.php
@@ -134,4 +134,9 @@ class MinzPDO extends PDO {
 		MinzPDO::check($statement);
 		return parent::exec($statement);
 	}
+
+	public function query($statement) {
+		MinzPDO::check($statement);
+		return parent::query($statement);
+	}
 }


### PR DESCRIPTION
X'09AF' hexadecimal literals do not work with SQLite/PDO. Replaced by PHP hex2bin().
https://github.com/FreshRSS/FreshRSS/commit/711530a512b370d79b079205ce1f8376174f7f03
https://github.com/FreshRSS/FreshRSS/issues/798
