### PR TITLE
Google Reader API: work-around for News+ bug

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -467,6 +467,9 @@ function streamContentsItemsIds($streamId, $start_time, $count, $order, $exclude
 	$entryDAO = FreshRSS_Factory::createEntryDao();
 	$ids = $entryDAO->listIdsWhere($type, $id, $state, $order === 'o' ? 'ASC' : 'DESC', $count, '', new FreshRSS_Search(''), $start_time);
 
+	if (empty($ids)) {	//For News+ bug https://github.com/noinnion/newsplus/issues/84#issuecomment-57834632
+		$ids[] = 0;
+	}
 	$itemRefs = array();
 	foreach ($ids as $id) {
 		$itemRefs[] = array(


### PR DESCRIPTION
https://github.com/noinnion/newsplus/issues/84#issuecomment-57834632
https://github.com/FreshRSS/FreshRSS/issues/443
Copy from @jochenberger https://github.com/noinnion/newsplus/issues/84#issuecomment-57600231

> Imagine there is 1 unread item (let's call it A) in tt-rss and that is synced to News+ correctly, so News+ shows A as unread too.
> Then, I read the item A in tt-rss, so there are no unread items left. Then, I start the sync in News+ again. A is _not_ marked as read in News+.
> If, _however_, a new item B arrives in tt-rss (so there is a new unread item again) and I start the sync in News+, B is fetched and A is marked as unread, leaving only B as unread.
