### PR TITLE
Minz getBaseUrl correction and RSS template bug

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -137,6 +137,7 @@ class FreshRSS_index_Controller extends Minz_ActionController {
 		}
 
 		// No layout for RSS output.
+		$this->view->url = empty($_SERVER['QUERY_STRING']) ? '' : '?' . $_SERVER['QUERY_STRING'];
 		$this->view->rss_title = FreshRSS_Context::$name . ' | ' . Minz_View::title();
 		$this->view->_useLayout(false);
 		header('Content-Type: application/rss+xml; charset=utf-8');

--- a/constants.php
+++ b/constants.php
@@ -11,7 +11,8 @@ define('PHP_COMPRESSION', false);
 define('FRESHRSS_PATH', dirname(__FILE__));
 
 	define('PUBLIC_PATH', FRESHRSS_PATH . '/p');
-		define('INDEX_PATH', PUBLIC_PATH . '/i');
+		define('PUBLIC_TO_INDEX_PATH', '/i');
+		define('INDEX_PATH', PUBLIC_PATH . PUBLIC_TO_INDEX_PATH);
 		define('PUBLIC_RELATIVE', '..');
 
 	define('DATA_PATH', FRESHRSS_PATH . '/data');

--- a/lib/Minz/Url.php
+++ b/lib/Minz/Url.php
@@ -10,7 +10,6 @@ class Minz_Url {
 	 *                    $url['c'] = controller
 	 *                    $url['a'] = action
 	 *                    $url['params'] = tableau des paramètres supplémentaires
-	 *                    $url['protocol'] = protocole à utiliser (http par défaut)
 	 *             ou comme une chaîne de caractère
 	 * @param $encodage pour indiquer comment encoder les & (& ou &amp; pour html)
 	 * @return l'url formatée
@@ -25,14 +24,7 @@ class Minz_Url {
 		$url_string = '';
 
 		if ($absolute) {
-			if ($isArray && isset ($url['protocol'])) {
-				$protocol = $url['protocol'];
-			} elseif (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
-				$protocol = 'https:';
-			} else {
-				$protocol = 'http:';
-			}
-			$url_string = $protocol . '//' . Minz_Request::getDomainName () . Minz_Request::getBaseUrl ();
+			$url_string = Minz_Request::getBaseUrl(PUBLIC_TO_INDEX_PATH);
 		} else {
 			$url_string = $isArray ? '.' : PUBLIC_RELATIVE;
 		}


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/848
Corrections in Minz (HTTP_HOST was not sanitized, getURI() was never used and not working anyway with absolute base_url)
$this->url was not defined in rss.phtml , which raised an error and could brake FreshRSS RSS feeds
