### PR TITLE
Updated log visibility

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -253,7 +253,7 @@ class FreshRSS_auth_Controller extends Minz_ActionController {
 				FreshRSS_Auth::giveAccess();
 				invalidateHttpCache();
 			} else {
-				Minz_Log::error($reason);
+				Minz_Log::warning($reason);
 
 				$res = array();
 				$res['status'] = 'failure';

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -322,7 +322,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 					$feed->load(false);
 				}
 			} catch (FreshRSS_Feed_Exception $e) {
-				Minz_Log::notice($e->getMessage());
+				Minz_Log::warning($e->getMessage());
 				$feedDAO->updateLastUpdate($feed->id(), true);
 				$feed->unlock();
 				continue;

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -47,7 +47,7 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 		$status_file = $file['error'];
 
 		if ($status_file !== 0) {
-			Minz_Log::error('File cannot be uploaded. Error code: ' . $status_file);
+			Minz_Log::warning('File cannot be uploaded. Error code: ' . $status_file);
 			Minz_Request::bad(_t('feedback.import_export.file_cannot_be_uploaded'),
 			                  array('c' => 'importExport', 'a' => 'index'));
 		}
@@ -69,7 +69,7 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 
 			if (!is_resource($zip)) {
 				// zip_open cannot open file: something is wrong
-				Minz_Log::error('Zip archive cannot be imported. Error code: ' . $zip);
+				Minz_Log::warning('Zip archive cannot be imported. Error code: ' . $zip);
 				Minz_Request::bad(_t('feedback.import_export.zip_error'),
 				                  array('c' => 'importExport', 'a' => 'index'));
 			}
@@ -77,7 +77,7 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 			while (($zipfile = zip_read($zip)) !== false) {
 				if (!is_resource($zipfile)) {
 					// zip_entry() can also return an error code!
-					Minz_Log::error('Zip file cannot be imported. Error code: ' . $zipfile);
+					Minz_Log::warning('Zip file cannot be imported. Error code: ' . $zipfile);
 				} else {
 					$type_zipfile = $this->guessFileType(zip_entry_name($zipfile));
 					if ($type_file !== 'unknown') {

--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -63,7 +63,7 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 		curl_close($c);
 
 		if ($c_status !== 200) {
-			Minz_Log::error(
+			Minz_Log::warning(
 				'Error during update (HTTP code ' . $c_status . '): ' . $c_error
 			);
 

--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -13,7 +13,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 			return $this->bd->lastInsertId();
 		} else {
 			$info = $stm == null ? array(2 => 'syntax error') : $stm->errorInfo();
-			Minz_Log::error('SQL error addCategory: ' . $info[2]	);
+			Minz_Log::error('SQL error addCategory: ' . $info[2]);
 			return false;
 		}
 	}


### PR DESCRIPTION
In particular, ensure that ERROR is only used for errors that may affect
FreshRSS integrity, and ensure that feed errors are visible also in
production, i.e. visibility of WARNING
https://github.com/FreshRSS/FreshRSS/issues/885
https://github.com/FreshRSS/FreshRSS/issues/884
