### PR TITLE
Skip steps during installation

### DIFF
--- a/app/i18n/cz/install.php
+++ b/app/i18n/cz/install.php
@@ -96,6 +96,9 @@ return array(
 	'delete_articles_after' => 'Smazat články starší než',
 	'fix_errors_before' => 'Chyby prosím před přechodem na další krok opravte.',
 	'javascript_is_better' => 'Práce s FreshRSS je příjemnější se zapnutým JavaScriptem',
+	'js' => array(
+		'confirm_reinstall' => 'You will lose your previous configuration by reinstalling FreshRSS. Are you sure you want to continue?',  // TODO: translate
+	),
 	'language' => array(
 		'_' => 'Jazyk',
 		'choose' => 'Vyberte jazyk FreshRSS',

--- a/app/i18n/cz/install.php
+++ b/app/i18n/cz/install.php
@@ -4,7 +4,9 @@ return array(
 	'action' => array(
 		'finish' => 'Dokončit instalaci',
 		'fix_errors_before' => 'Chyby prosím před přechodem na další krok opravte.',
+		'keep_install' => 'Keep previous installation',  // TODO: translate
 		'next_step' => 'Přejít na další krok',
+		'reinstall' => 'Reinstall FreshRSS',  // TODO: translate
 	),
 	'auth' => array(
 		'email_persona' => 'Email pro přihlášení<br /><small>(pro <a href="https://persona.org/" rel="external">Mozilla Persona</a>)</small>',
@@ -31,6 +33,7 @@ return array(
 	),
 	'check' => array(
 		'_' => 'Kontrola',
+		'already_installed' => 'We have detected that FreshRSS is already installed!',  // TODO: translate
 		'cache' => array(
 			'nok' => 'Zkontrolujte oprávnění adresáře <em>./data/cache</em>. HTTP server musí mít do tohoto adresáře práva zápisu',
 			'ok' => 'Oprávnění adresáře cache jsou v pořádku.',

--- a/app/i18n/de/install.php
+++ b/app/i18n/de/install.php
@@ -4,7 +4,9 @@ return array(
 	'action' => array(
 		'finish' => 'Installation fertigstellen',
 		'fix_errors_before' => 'Bitte Fehler korrigieren, bevor zum nächsten Schritt gesprungen wird.',
+		'keep_install' => 'Keep previous installation',  // TODO: translate
 		'next_step' => 'Zum nächsten Schritt springen',
+		'reinstall' => 'Reinstall FreshRSS',  // TODO: translate
 	),
 	'auth' => array(
 		'email_persona' => 'Anmelde-E-Mail-Adresse<br /><small>(für <a href="https://persona.org/" rel="external">Mozilla Persona</a>)</small>',
@@ -31,6 +33,7 @@ return array(
 	),
 	'check' => array(
 		'_' => 'Überprüfungen',
+		'already_installed' => 'We have detected that FreshRSS is already installed!',  // TODO: translate
 		'cache' => array(
 			'nok' => 'Überprüfen Sie die Berechtigungen des Verzeichnisses <em>./data/cache</em>. Der HTTP-Server muss Schreibrechte besitzen.',
 			'ok' => 'Die Berechtigungen des Verzeichnisses <em>./data/cache</em> sind in Ordnung.',

--- a/app/i18n/de/install.php
+++ b/app/i18n/de/install.php
@@ -96,6 +96,9 @@ return array(
 	'delete_articles_after' => 'Entferne Artikel nach',
 	'fix_errors_before' => 'Bitte den Fehler korrigieren, bevor zum nächsten Schritt gesprungen wird.',
 	'javascript_is_better' => 'FreshRSS ist ansprechender mit aktiviertem JavaScript',
+	'js' => array(
+		'confirm_reinstall' => 'You will lose your previous configuration by reinstalling FreshRSS. Are you sure you want to continue?',  // TODO: translate
+	),
 	'language' => array(
 		'_' => 'Sprache',
 		'choose' => 'Wählen Sie eine Sprache für FreshRSS',

--- a/app/i18n/en/install.php
+++ b/app/i18n/en/install.php
@@ -96,6 +96,9 @@ return array(
 	'delete_articles_after' => 'Remove articles after',
 	'fix_errors_before' => 'Please fix errors before skipping to the next step.',
 	'javascript_is_better' => 'FreshRSS is more pleasant with JavaScript enabled',
+	'js' => array(
+		'confirm_reinstall' => 'You will lose your previous configuration by reinstalling FreshRSS. Are you sure you want to continue?',
+	),
 	'language' => array(
 		'_' => 'Language',
 		'choose' => 'Choose a language for FreshRSS',

--- a/app/i18n/en/install.php
+++ b/app/i18n/en/install.php
@@ -4,7 +4,9 @@ return array(
 	'action' => array(
 		'finish' => 'Complete installation',
 		'fix_errors_before' => 'Please fix errors before skipping to the next step.',
+		'keep_install' => 'Keep previous installation',
 		'next_step' => 'Go to the next step',
+		'reinstall' => 'Reinstall FreshRSS',
 	),
 	'auth' => array(
 		'email_persona' => 'Login email address<br /><small>(for <a href="https://persona.org/" rel="external">Mozilla Persona</a>)</small>',
@@ -31,6 +33,7 @@ return array(
 	),
 	'check' => array(
 		'_' => 'Checks',
+		'already_installed' => 'We have detected that FreshRSS is already installed!',
 		'cache' => array(
 			'nok' => 'Check permissions on <em>./data/cache</em> directory. HTTP server must have rights to write into',
 			'ok' => 'Permissions on cache directory are good.',

--- a/app/i18n/fr/install.php
+++ b/app/i18n/fr/install.php
@@ -96,6 +96,9 @@ return array(
 	'delete_articles_after' => 'Supprimer les articles après',
 	'fix_errors_before' => 'Veuillez corriger les erreurs avant de passer à l’étape suivante.',
 	'javascript_is_better' => 'FreshRSS est plus agréable à utiliser avec JavaScript activé',
+	'js' => array(
+		'confirm_reinstall' => 'Réinstaller FreshRSS vous fera perdre la configuration précédente. Êtes-vous sûr de vouloir continuer ?',
+	),
 	'language' => array(
 		'_' => 'Langue',
 		'choose' => 'Choisissez la langue pour FreshRSS',

--- a/app/i18n/fr/install.php
+++ b/app/i18n/fr/install.php
@@ -4,7 +4,9 @@ return array(
 	'action' => array(
 		'finish' => 'Terminer l’installation',
 		'fix_errors_before' => 'Veuillez corriger les erreurs avant de passer à l’étape suivante.',
+		'keep_install' => 'Garder l’ancienne configuration',
 		'next_step' => 'Passer à l’étape suivante',
+		'reinstall' => 'Réinstaller FreshRSS',
 	),
 	'auth' => array(
 		'email_persona' => 'Adresse courriel de connexion<br /><small>(pour <a href="https://persona.org/" rel="external">Mozilla Persona</a>)</small>',
@@ -31,6 +33,7 @@ return array(
 	),
 	'check' => array(
 		'_' => 'Vérifications',
+		'already_installed' => 'FreshRSS semble avoir déjà été installé !',
 		'cache' => array(
 			'nok' => 'Veuillez vérifier les droits sur le répertoire <em>./data/cache</em>. Le serveur HTTP doit être capable d’écrire dedans',
 			'ok' => 'Les droits sur le répertoire de cache sont bons.',

--- a/app/install.php
+++ b/app/install.php
@@ -9,9 +9,8 @@ session_name('FreshRSS');
 session_set_cookie_params(0, dirname(empty($_SERVER['REQUEST_URI']) ? '/' : dirname($_SERVER['REQUEST_URI'])), null, false, true);
 session_start();
 
-// TODO: use join_path() instead
-Minz_Configuration::register('default_system', DATA_PATH . '/config.default.php');
-Minz_Configuration::register('default_user', USERS_PATH . '/_/config.default.php');
+Minz_Configuration::register('default_system', join_path(DATA_PATH, 'config.default.php'));
+Minz_Configuration::register('default_user', join_path(USERS_PATH, '_', 'config.default.php'));
 
 if (isset($_GET['step'])) {
 	define('STEP',(int)$_GET['step']);
@@ -81,24 +80,22 @@ function saveLanguage() {
 }
 
 function saveStep1() {
-	// TODO: rename reinstall in install
-	if (isset($_POST['freshrss-keep-reinstall']) &&
-			$_POST['freshrss-keep-reinstall'] === '1') {
+	if (isset($_POST['freshrss-keep-install']) &&
+			$_POST['freshrss-keep-install'] === '1') {
 		// We want to keep our previous installation of FreshRSS
 		// so we need to make next steps valid by setting $_SESSION vars
 		// with values from the previous installation
 
 		// First, we try to get previous configurations
-		// TODO: use join_path() instead
 		Minz_Configuration::register('system',
-		                             DATA_PATH . '/config.php',
-		                             DATA_PATH . '/config.default.php');
+		                             join_path(DATA_PATH, 'config.php'),
+		                             join_path(DATA_PATH, 'config.default.php'));
 		$system_conf = Minz_Configuration::get('system');
 
 		$current_user = $system_conf->default_user;
 		Minz_Configuration::register('user',
-		                             USERS_PATH . '/' . $current_user . '/config.php',
-		                             USERS_PATH . '/_/config.default.php');
+		                             join_path(USERS_PATH, $current_user, 'config.php'),
+		                             join_path(USERS_PATH, '_', 'config.default.php'));
 		$user_conf = Minz_Configuration::get('user');
 
 		// Then, we set $_SESSION vars
@@ -611,7 +608,7 @@ function printStep1() {
 	<p class="alert alert-warn"><span class="alert-head"><?php echo _t('gen.short.attention'); ?></span> <?php echo _t('install.check.freshrss_alreadyy_installed'); ?></p>
 
 	<form action="index.php?step=1" method="post">
-		<input type="hidden" name="freshrss-keep-reinstall" value="1" />
+		<input type="hidden" name="freshrss-keep-install" value="1" />
 		<button type="submit" class="btn btn-important" tabindex="1" ><?php echo _t('install.action.keep_install'); ?></button>
 		<a class="btn btn-attention next-step" href="?step=2" tabindex="2" ><?php echo _t('install.action.reinstall'); ?></a>
 	</form>

--- a/app/install.php
+++ b/app/install.php
@@ -609,9 +609,31 @@ function printStep1() {
 
 	<form action="index.php?step=1" method="post">
 		<input type="hidden" name="freshrss-keep-install" value="1" />
-		<button type="submit" class="btn btn-important" tabindex="1" ><?php echo _t('install.action.keep_install'); ?></button>
-		<a class="btn btn-attention next-step" href="?step=2" tabindex="2" ><?php echo _t('install.action.reinstall'); ?></a>
+		<button type="submit" class="btn btn-important next-step" tabindex="1" ><?php echo _t('install.action.keep_install'); ?></button>
+		<a class="btn btn-attention next-step confirm" data-str-confirm="<?php echo _t('install.js.confirm_reinstall'); ?>" href="?step=2" tabindex="2" ><?php echo _t('install.action.reinstall'); ?></a>
 	</form>
+
+	<script>
+		function ask_confirmation(e) {
+			var str_confirmation = this.getAttribute('data-str-confirm');
+			if (!str_confirmation) {
+				str_confirmation = "<?php echo _t('gen.js.confirm_action'); ?>";
+			}
+
+			if (!confirm(str_confirmation)) {
+				e.preventDefault();
+			}
+		}
+
+		function init_confirm() {
+			confirms = document.getElementsByClassName('confirm');
+			for (var i = 0 ; i < confirms.length ; i++) {
+				confirms[i].addEventListener('click', ask_confirmation);
+			}
+		}
+
+		init_confirm();
+	</script>
 	<?php } elseif ($res['all'] == 'ok') { ?>
 	<a class="btn btn-important next-step" href="?step=2" tabindex="1" ><?php echo _t('install.action.next_step'); ?></a>
 	<?php } else { ?>

--- a/app/install.php
+++ b/app/install.php
@@ -605,7 +605,7 @@ function printStep1() {
 	<?php } ?>
 
 	<?php if (freshrss_already_installed() && $res['all'] == 'ok') { ?>
-	<p class="alert alert-warn"><span class="alert-head"><?php echo _t('gen.short.attention'); ?></span> <?php echo _t('install.check.freshrss_alreadyy_installed'); ?></p>
+	<p class="alert alert-warn"><span class="alert-head"><?php echo _t('gen.short.attention'); ?></span> <?php echo _t('install.check.already_installed'); ?></p>
 
 	<form action="index.php?step=1" method="post">
 		<input type="hidden" name="freshrss-keep-install" value="1" />

--- a/app/install.php
+++ b/app/install.php
@@ -79,6 +79,31 @@ function saveLanguage() {
 	}
 }
 
+function saveStep1() {
+	if (isset($_POST['freshrss-keep-reinstall']) &&
+			$_POST['freshrss-keep-reinstall'] === '1') {
+		// We want to keep our previous installation of FreshRSS
+		// so we need to make next steps valid by setting $_SESSION vars
+		// with values from the previous installation
+
+		// TODO: set $_SESSION vars
+		$_SESSION['title'] = '';
+		$_SESSION['old_entries'] = '';
+		$_SESSION['mail_login'] = '';
+		$_SESSION['default_user'] =  '';
+
+		$_SESSION['bd_type'] = '';
+		$_SESSION['bd_host'] = '';
+		$_SESSION['bd_user'] = '';
+		$_SESSION['bd_password'] = '';
+		$_SESSION['bd_base'] = '';
+		$_SESSION['bd_prefix'] = '';
+		$_SESSION['bd_error'] = '';
+
+		header('Location: index.php?step=4');
+	}
+}
+
 function saveStep2() {
 	$user_default_config = Minz_Configuration::get('user');
 	if (!empty($_POST)) {
@@ -300,6 +325,10 @@ function checkStep1() {
 		         $data && $cache && $users && $favicons && $persona && $http_referer ?
 		         'ok' : 'ko'
 	);
+}
+
+function freshrss_already_installed() {
+	return false;
 }
 
 function checkStep2() {
@@ -537,7 +566,15 @@ function printStep1() {
 	<p class="alert alert-error"><span class="alert-head"><?php echo _t('gen.short.damn'); ?></span> <?php echo _t('install.check.http_referer.nok'); ?></p>
 	<?php } ?>
 
-	<?php if ($res['all'] == 'ok') { ?>
+	<?php if (freshrss_already_installed() && $res['all'] == 'ok') { ?>
+	<p class="alert alert-warn"><span class="alert-head"><?php echo _t('gen.short.attention'); ?></span> <?php echo _t('install.check.freshrss_alreadyy_installed'); ?></p>
+
+	<form action="index.php?step=1" method="post">
+		<input type="hidden" name="freshrss-keep-reinstall" value="1" />
+		<button type="submit" class="btn btn-important" tabindex="1" ><?php echo _t('install.action.keep_install'); ?></button>
+		<a class="btn btn-attention next-step" href="?step=2" tabindex="2" ><?php echo _t('install.action.reinstall'); ?></a>
+	</form>
+	<?php } elseif ($res['all'] == 'ok') { ?>
 	<a class="btn btn-important next-step" href="?step=2" tabindex="1" ><?php echo _t('install.action.next_step'); ?></a>
 	<?php } else { ?>
 	<p class="alert alert-error"><?php echo _t('install.action.fix_errors_before'); ?></p>
@@ -788,6 +825,7 @@ default:
 	saveLanguage();
 	break;
 case 1:
+	saveStep1();
 	break;
 case 2:
 	saveStep2();


### PR DESCRIPTION
If we detect an existing configuration during the installation, we offer to the user to skip the configuration steps. It should be tested.

**How does it work?**

At step 1, if we detect an existing configuration, we set the `$_SESSION` variables needed at both steps 2 and 3 to make them valid. **We don't save the configuration again**. If user goes back at step 2 or 3 and save one of these steps, it will erase previous configuration. I'm not sure it's what we want so tell me what you think.

Fix https://github.com/FreshRSS/FreshRSS/issues/909
