### PR TITLE
Generate base_url during installation

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -295,14 +295,17 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		// Calculate date of oldest entries we accept in DB.
 		$nb_month_old = max(FreshRSS_Context::$user_conf->old_entries, 1);
 		$date_min = time() - (3600 * 24 * 30 * $nb_month_old);
-		$pshbMinAge = time() - (3600 * 24);	//TODO: Make a configuration.
+
+		// PubSubHubbub support
+		$pubsubhubbubEnabledGeneral = FreshRSS_Context::$system_conf->pubsubhubbub_enabled;
+		$pshbMinAge = time() - (3600 * 24);  //TODO: Make a configuration.
 
 		$updated_feeds = 0;
 		$is_read = FreshRSS_Context::$user_conf->mark_when['reception'] ? 1 : 0;
 		foreach ($feeds as $feed) {
 			$url = $feed->url();	//For detection of HTTP 301
 
-			$pubSubHubbubEnabled = $feed->pubSubHubbubEnabled();
+			$pubSubHubbubEnabled = $pubsubhubbubEnabledGeneral && $feed->pubSubHubbubEnabled();
 			if ((!$simplePiePush) && (!$id) && $pubSubHubbubEnabled && ($feed->lastUpdate() > $pshbMinAge)) {
 				$text = 'Skip pull of feed using PubSubHubbub: ' . $url;
 				//Minz_Log::debug($text);
@@ -442,7 +445,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 			}
 
 			$feed->faviconPrepare();
-			if ($feed->pubSubHubbubPrepare()) {
+			if ($pubsubhubbubEnabledGeneral && $feed->pubSubHubbubPrepare()) {
 				Minz_Log::notice('PubSubHubbub subscribe ' . $feed->url());
 				if (!$feed->pubSubHubbubSubscribe(true)) {	//Subscribe
 					Minz_Log::warning('Error while PubSubHubbub subscribing to ' . $feed->url());

--- a/app/install.php
+++ b/app/install.php
@@ -212,8 +212,11 @@ function saveStep3() {
 			$_SESSION['bd_prefix_user'] = $_SESSION['bd_prefix'] . (empty($_SESSION['default_user']) ? '' : ($_SESSION['default_user'] . '_'));
 		}
 
+		// We use dirname to remove the /i part
+		$base_url = dirname(Minz_Request::guessBaseUrl());
 		$config_array = array(
 			'salt' => $_SESSION['salt'],
+			'base_url' => $base_url,
 			'title' => $_SESSION['title'],
 			'default_user' => $_SESSION['default_user'],
 			'auth_type' => $_SESSION['auth_type'],

--- a/app/install.php
+++ b/app/install.php
@@ -229,6 +229,7 @@ function saveStep3() {
 				'prefix' => $_SESSION['bd_prefix'],
 				'pdo_options' => array(),
 			),
+			'enable_pubsubhubbub' => server_is_public($base_url),
 		);
 
 		@unlink(join_path(DATA_PATH, 'config.php'));	//To avoid access-rights problems

--- a/app/install.php
+++ b/app/install.php
@@ -229,7 +229,7 @@ function saveStep3() {
 				'prefix' => $_SESSION['bd_prefix'],
 				'pdo_options' => array(),
 			),
-			'enable_pubsubhubbub' => server_is_public($base_url),
+			'pubsubhubbub_enabled' => server_is_public($base_url),
 		);
 
 		@unlink(join_path(DATA_PATH, 'config.php'));	//To avoid access-rights problems

--- a/data/config.default.php
+++ b/data/config.default.php
@@ -57,6 +57,10 @@ return array(
 	#	SimplePie, which is retrieving RSS feeds via HTTP requests.
 	'simplepie_syslog_enabled' => true,
 
+	# Enable or not support of PubSubHubbub.
+	# /!\ It should NOT be enabled if base_url is not reachable by an external server.
+	'pubsubhubbub_enabled' => false,
+
 	'limits' => array(
 
 		# Duration in seconds of the SimplePie cache,

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -83,6 +83,33 @@ function checkUrl($url) {
 	}
 }
 
+
+/**
+ * Test if a given server address is publicly accessible.
+ *
+ * Note: for the moment it tests only if address is corresponding to a
+ * localhost address.
+ *
+ * @param $address the address to test, can be an IP or a URL.
+ * @return true if server is accessible, false else.
+ * @todo improve test with a more valid technique (e.g. test with an external server?)
+ */
+function server_is_public($address) {
+	$host = parse_url($address, PHP_URL_HOST);
+
+	$is_public = !in_array($host, array(
+		'127.0.0.1',
+		'localhost',
+		'localhost.localdomain',
+		'[::1]',
+		'localhost6',
+		'localhost6.localdomain6',
+	));
+
+	return $is_public;
+}
+
+
 function format_number($n, $precision = 0) {
 	// number_format does not seem to be Unicode-compatible
 	return str_replace(' ', ' ',  //Espace fine insécable


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/issues/865
- `base_url` is stored without `/i` (e.g. http://localhost/FreshRSS/p)
- Add a `pubsubhubbub_enabled` configuration key
- Add a very basic `server_is_public()` function to test if the server is reachable by an external service. Note it tests only if host is a localhost address,it can be improved if you have ideas.
- `pubsubhubbub_enabled` is set to `false` if the server is not public
- PubSubHubbub process is not handled if `pubsubhubbub_enabled` is `false`
