### PR TITLE
Load configuration by recursion

### DIFF
--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -85,11 +85,6 @@ class Minz_Configuration {
 	private $data = array();
 
 	/**
-	 * The default values, an empty array by default.
-	 */
-	private $data_default = array();
-
-	/**
 	 * An object which help to set good values in configuration.
 	 */
 	private $configuration_setter = null;
@@ -119,21 +114,22 @@ class Minz_Configuration {
 	                             $configuration_setter = null) {
 		$this->namespace = $namespace;
 		$this->config_filename = $config_filename;
+		$this->default_filename = $default_filename;
+		$this->_configurationSetter($configuration_setter);
+
+		if (!is_null($this->default_filename)) {
+			$this->data = self::load($this->default_filename);
+		}
 
 		try {
-			$this->data = self::load($this->config_filename);
+			$this->data = array_replace_recursive(
+				$this->data, self::load($this->config_filename)
+			);
 		} catch (Minz_FileNotExistException $e) {
-			if (is_null($default_filename)) {
+			if (is_null($this->default_filename)) {
 				throw $e;
 			}
 		}
-
-		$this->default_filename = $default_filename;
-		if (!is_null($this->default_filename)) {
-			$this->data_default = self::load($this->default_filename);
-		}
-
-		$this->_configurationSetter($configuration_setter);
 	}
 
 	/**
@@ -160,8 +156,6 @@ class Minz_Configuration {
 			return $this->data[$key];
 		} elseif (!is_null($default)) {
 			return $default;
-		} elseif (isset($this->data_default[$key])) {
-			return $this->data_default[$key];
 		} else {
 			Minz_Log::warning($key . ' does not exist in configuration');
 			return null;


### PR DESCRIPTION
- Remove Minz_Configuration::$data_default
- Default values are loaded first in $data
- $data values are replaced by values from config file

Fix https://github.com/FreshRSS/FreshRSS/issues/923
