### PR TITLE
Add production ready Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:5.6-apache
+MAINTAINER Guillaume Fillon <guillaume@posteo.de>
+
+
+RUN apt-get update && \
+    apt-get install -y libcurl4-openssl-dev libjpeg62-turbo-dev \
+    libmcrypt-dev libpng12-dev libicu-dev libgmp-dev libsqlite3-dev && \
+    ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h && \
+    docker-php-ext-install curl mbstring gd intl mysql json zip gmp \
+        pdo pdo_mysql pdo_sqlite
+COPY . /var/www/html
+
+RUN chown -R :www-data /var/www/html
+RUN chmod -R g+w /var/www/html/data

--- a/README.fr.md
+++ b/README.fr.md
@@ -43,6 +43,7 @@ Nous sommes une communauté amicale.
 ![Capture d’écran de FreshRSS](http://marienfressinaud.fr/data/images/freshrss/freshrss_default-design.png)
 
 # Installation
+## Classique
 1. Récupérez l’application FreshRSS via la commande git ou [en téléchargeant l’archive](../releases)
 2. Placez l’application sur votre serveur (la partie à exposer au Web est le répertoire `./p/`)
 3. Le serveur Web doit avoir les droits d’écriture dans le répertoire `./data/`
@@ -80,6 +81,32 @@ sudo git reset --hard
 sudo git pull
 sudo chown -R :www-data .
 sudo chmod -R g+w ./data/
+```
+
+## En utilisant Docker
+### En utilisant l'image existante
+#### Avec MySQL
+
+```
+# Lance la BDD MySQL
+sudo docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=motdepasse mysql
+# Lance un conteneur FreshRSS
+sudo docker run -d --name freshrss --link mysql:db -p 8080:80 kokaz/freshrss:latest
+```
+Pendant l'installation vous devez mettre les valeurs pour la configuration MySQL :
+* Hôte : `db`
+* Nom d'utilisateur : `root`
+* Mot de passe : `motdepasse`
+
+#### Sans MySQL
+```
+# Lance un conteneur FreshRSS
+sudo docker run -d --name freshrss -p 8080:80 kokaz/freshrss:latest
+```
+
+### Construire soi-même l'image docker
+```
+sudo docker build -t kokaz/freshrss .
 ```
 
 # Contrôle d’accès

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ We are a friendly community.
 ![FreshRSS screenshot](http://marienfressinaud.fr/data/images/freshrss/freshrss_default-design.png)
 
 # Installation
+## Classical
 1. Get FreshRSS with git or [by downloading the archive](https://github.com/FreshRSS/FreshRSS/archive/master.zip)
 2. Dump the application on your server (expose only the `./p/` folder)
 3. Add write access on `./data/` folder to the webserver user
@@ -50,7 +51,7 @@ We are a friendly community.
 5. Everything should be working :) If you encounter any problem, feel free to contact me.
 6. Advanced configuration settings can be seen in [config.php](./data/config.default.php).
 
-## Example of full installation on Linux Debian/Ubuntu
+### Example of full installation on Linux Debian/Ubuntu
 ```sh
 # If you use an Apache Web server (otherwise you need another Web server)
 sudo apt-get install apache2
@@ -80,6 +81,34 @@ sudo git reset --hard
 sudo git pull
 sudo chown -R :www-data .
 sudo chmod -R g+w ./data/
+```
+
+## Using Docker
+### Using the existing image
+#### With MySQL
+
+```
+# Launch the MySQL DB
+sudo docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=password mysql
+# Launch the FreshRSS container
+sudo docker run -d --name freshrss --link mysql:db -p 8080:80 kokaz/freshrss:latest
+```
+During the installation phase in the MySQL configuration put that:
+* Host: `db`
+* Username: `root`
+* Password: `password`
+
+#### Without MySQL
+
+```
+# Launch the FreshRSS container
+sudo docker run -d --name freshrss -p 8080:80 kokaz/freshrss:latest
+```
+
+### Building the docker image
+
+```
+sudo docker build -t kokaz/freshrss .
 ```
 
 # Access control


### PR DESCRIPTION
Hi FreshRSS community,

Two days ago I stumbled upon the FreshRSS' `Dockerfile` for development purpose but I needed it for production purpose. Facing the lack of FreshRSS images I made it myself. At first I made a separate repository but I think the `Dockerfile` belongs to the project itself and should be directly available in the source repository.

This PR add a `Dockerfile` that build a PHP/Apache image that runs FreshRSS and the update of the README to help running or build the image at home.

Thanks :)
