### PR TITLE
Fix feed and category side effect

### DIFF
--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -119,6 +119,8 @@ class FreshRSS_ConfigurationSetter {
 		foreach ($values as $value) {
 			if ($value instanceof FreshRSS_UserQuery) {
 				$data['queries'][] = $value->toArray();
+			} elseif (is_array($value)) {
+				$data['queries'][] = $value;
 			}
 		}
 	}


### PR DESCRIPTION
Before, when deleting a feed or a category, the user queries were deleted as well. No matter if they were related or not.
Now, they are deleted only if they are related.

I this this fix is not the best way to handle that. I think it would be better if we could find a way to create a UserQuery object from the array.
The same applies when displaying the user queries in the interface.

See #980
