### PR TITLE
Replace CSS pseudo-element syntax

### DIFF
--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -349,7 +349,7 @@ a.btn {
 	text-align: left;
 	background: #222;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -384,7 +384,7 @@ a.btn {
 	background: -webkit-linear-gradient(top,  #0090FF 0%, #0062BE 100%);
 	color: #fff;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -626,7 +626,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .tree-folder-title > .title:not([data-unread="0"]):after {
+.aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
 	position: absolute;
 	right: 3px;
 	padding: 1px 5px;
@@ -646,7 +646,7 @@ a.btn {
 .feed.item.error > a {
 	color: #BD362F;
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -988,7 +988,7 @@ opacity: 1;
 	color: #222;
 	font-weight: bold;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -1018,7 +1018,7 @@ opacity: 1;
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/BlueLagoon/template.css
+++ b/p/themes/BlueLagoon/template.css
@@ -92,7 +92,7 @@ input.extend:focus {
 /*=== COMPONENTS */
 /*===============*/
 /*=== Forms */
-.form-group:after {
+.form-group::after {
 	content: "";
 	display: block;
 	clear: both;
@@ -184,7 +184,7 @@ a.btn {
 .dropdown-menu > .item > span {
 	display: block;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	content: '✓';
 }
 .dropdown-menu .input {
@@ -315,7 +315,7 @@ a.btn {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }
-.category .btn:not([data-unread="0"]):after {
+.category .btn:not([data-unread="0"])::after {
 	content: attr(data-unread);
 }
 
@@ -334,7 +334,7 @@ a.btn {
 	text-overflow: ellipsis;
 	vertical-align: middle;
 }
-.categories .feeds .feed:not([data-unread="0"]):before {
+.categories .feeds .feed:not([data-unread="0"])::before {
 	content: "(" attr(data-unread) ") ";
 }
 .categories .feeds .dropdown-menu {
@@ -688,7 +688,7 @@ a.btn {
 	.flux_content .content a {
 		color: #000;
 	}
-	.flux_content .content a:after {
+	.flux_content .content a::after {
 		content: " [" attr(href) "] ";
 		font-style: italic;
 	}

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -312,7 +312,7 @@ a.btn {
 	border: 1px solid #888;
 	border-radius: 5px;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -347,7 +347,7 @@ a.btn {
 	background: #26303F;
 	color: #888;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -551,7 +551,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .tree-folder-title > .title:not([data-unread="0"]):after {
+.aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
 	position: absolute;
 	right: 0;
 	margin: 10px 0;
@@ -584,7 +584,7 @@ a.btn {
 .feed.item.error.active > a {
 	color: #fff;
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -858,7 +858,7 @@ a.btn {
 	color: #fff;
 	font-weight: bold;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -894,7 +894,7 @@ a.btn {
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -102,7 +102,7 @@ form th {
 	border: 1px solid transparent;
 	border-radius: 3px;
 }
-.form-group:after {
+.form-group::after {
 	content: "";
 	display: block;
 	clear: both;
@@ -312,7 +312,7 @@ a.btn {
 	border: 1px solid #95a5a6;
 	border-radius: 3px;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -347,7 +347,7 @@ a.btn {
 	background: #2980b9;
 	color: #fff;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -557,7 +557,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .tree-folder-title > .title:not([data-unread="0"]):after {
+.aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
 	position: absolute;
 	right: 0;
 	margin: 10px 0;
@@ -588,7 +588,7 @@ a.btn {
 .feed.item.error.active > a {
 	color: #fff;
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -864,7 +864,7 @@ a.btn {
 	font-weight: bold;
 	color: #fff;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -887,7 +887,7 @@ a.btn {
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -336,7 +336,7 @@ a.btn {
 	font-size: 0.8rem;
 	text-align: left;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -373,7 +373,7 @@ a.btn {
 	background: #0062BE;
 	color: #fff;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -591,7 +591,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .category .title:not([data-unread="0"]):after {
+.aside_feed .category .title:not([data-unread="0"])::after {
 	position: absolute;
 	right: 0;
 	margin: 10px 0;
@@ -622,7 +622,7 @@ a.btn {
 .feed.item.error.active > a {
 	color: #fff;
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -908,7 +908,7 @@ a.btn {
 	color: #fff;
 	font-weight: bold;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -932,7 +932,7 @@ a.btn {
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -319,7 +319,7 @@ a.btn {
 	font-size: 0.8rem;
 	text-align: left;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -362,7 +362,7 @@ a.btn {
 	background: #eee;
 	color: #666;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -590,7 +590,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .tree-folder-title > .title:not([data-unread="0"]):after {
+.aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 0.25rem; right: 3px;
 	padding: 0px 5px;
@@ -633,7 +633,7 @@ a.btn {
 .feed.item.error.active > a {
 	color: #fff;
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -918,7 +918,7 @@ a.btn {
 	font-weight: bold;
 	color: #fff;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -943,7 +943,7 @@ a.btn {
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -349,7 +349,7 @@ a.btn {
 	text-align: left;
 	background: #222;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -385,7 +385,7 @@ a.btn {
 	background: #171717;
 	color: #fff;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -621,7 +621,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .tree-folder-title > .title:not([data-unread="0"]):after {
+.aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
 	position: absolute;
 	right: 3px;
 	padding: 1px 5px;
@@ -641,7 +641,7 @@ a.btn {
 .feed.item.error > a {
 	color: #BD362F;
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -986,7 +986,7 @@ opacity: 1;
 	color: #222;
 	font-weight: bold;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -1016,7 +1016,7 @@ opacity: 1;
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -231,7 +231,7 @@ a.btn {
 	font-size: 0.8rem;
 	text-align: left;
 }
-.dropdown-menu:after {
+.dropdown-menu::after {
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -262,7 +262,7 @@ a.btn {
 }
 .dropdown-menu > .item:hover {
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	font-weight: bold;
 	margin: 0 0 0 -14px;
 }
@@ -431,7 +431,7 @@ a.btn {
 }
 
 /*=== Aside main page (categories) */
-.aside_feed .tree-folder-title > .title:not([data-unread="0"]):after {
+.aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
 	position: absolute;
 	right: 0;
 	margin: 10px 0;
@@ -456,7 +456,7 @@ a.btn {
 .feed.item.empty.active > a,
 .feed.item.error.active > a {
 }
-.aside_feed .tree-folder-items .dropdown-menu:after {
+.aside_feed .tree-folder-items .dropdown-menu::after {
 	left: 2px;
 }
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
@@ -675,7 +675,7 @@ a.btn {
 .box.category:not([data-unread="0"]) .box-title .title {
 	font-weight: bold;
 }
-.box.category .title:not([data-unread="0"]):after {
+.box.category .title:not([data-unread="0"])::after {
 	position: absolute;
 	top: 5px; right: 10px;
 	border: 0;
@@ -698,7 +698,7 @@ a.btn {
 .aside.aside_feed .nav-form .dropdown .dropdown-menu {
 	right: -20px;
 }
-.aside.aside_feed .nav-form .dropdown .dropdown-menu:after {
+.aside.aside_feed .nav-form .dropdown .dropdown-menu::after {
 	right: 33px;
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -111,7 +111,7 @@ td.numeric {
 /*=== COMPONENTS */
 /*===============*/
 /*=== Forms */
-.form-group:after {
+.form-group::after {
 	content: "";
 	display: block;
 	clear: both;
@@ -206,7 +206,7 @@ a.btn {
 	display: block;
 	min-width: 200px;
 }
-.dropdown-menu > .item[aria-checked="true"] > a:before {
+.dropdown-menu > .item[aria-checked="true"] > a::before {
 	content: '✓';
 }
 .dropdown-menu .input {
@@ -773,10 +773,10 @@ input:checked + .slide-container .properties {
 
 /*=== DIVERS */
 /*===========*/
-.category .title:not([data-unread="0"]):after {
+.category .title:not([data-unread="0"])::after {
 	content: attr(data-unread);
 }
-.feed .item-title:not([data-unread="0"]):before {
+.feed .item-title:not([data-unread="0"])::before {
 	content: "(" attr(data-unread) ") ";
 }
 .feed .item-title:not([data-unread="0"]) {
@@ -889,7 +889,7 @@ input:checked + .slide-container .properties {
 	.flux_content .content a {
 		color: #000;
 	}
-	.flux_content .content a:after {
+	.flux_content .content a::after {
 		content: " [" attr(href) "] ";
 		font-style: italic;
 	}


### PR DESCRIPTION
Before, in the CSS files, :after and :before were in use. But those are not pseudo-classes in CSS3.
They are pseudo-elements. The syntax should use ::before and ::after instead.

See http://www.w3.org/TR/css3-selectors/#gen-content
