### PR TITLE
Add a visual alert on categories

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,6 +6,7 @@ class FreshRSS_Category extends Minz_Model {
 	private $nbFeed = -1;
 	private $nbNotRead = -1;
 	private $feeds = null;
+	private $hasFeedsWithError = false;
 
 	public function __construct($name = '', $feeds = null) {
 		$this->_name($name);
@@ -16,6 +17,7 @@ class FreshRSS_Category extends Minz_Model {
 			foreach ($feeds as $feed) {
 				$this->nbFeed++;
 				$this->nbNotRead += $feed->nbNotRead();
+				$this->hasFeedsWithError |= $feed->inError();
 			}
 		}
 	}
@@ -51,10 +53,15 @@ class FreshRSS_Category extends Minz_Model {
 			foreach ($this->feeds as $feed) {
 				$this->nbFeed++;
 				$this->nbNotRead += $feed->nbNotRead();
+				$this->hasFeedsWithError |= $feed->inError();
 			}
 		}
 
 		return $this->feeds;
+	}
+
+	public function hasFeedsWithError() {
+		return $this->hasFeedsWithError;
 	}
 
 	public function _id($value) {

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -45,7 +45,7 @@
 		<li class="tree-folder category<?php echo $c_active ? ' active' : ''; ?>" data-unread="<?php echo $cat->nbNotRead(); ?>">
 			<div class="tree-folder-title">
 				<a class="dropdown-toggle" href="#"><?php echo _i($c_show ? 'up' : 'down'); ?></a>
-				<a class="title" data-unread="<?php echo format_number($cat->nbNotRead()); ?>" href="<?php echo _url('index', 'index', 'get', 'c_' . $cat->id()); ?>"><?php echo $cat->name(); ?></a>
+				<a class="title<?php echo $cat->hasFeedsWithError() ? ' error' : ''; ?>" data-unread="<?php echo format_number($cat->nbNotRead()); ?>" href="<?php echo _url('index', 'index', 'get', 'c_' . $cat->id()); ?>"><?php echo $cat->name(); ?></a>
 			</div>
 
 			<ul class="tree-folder-items<?php echo $c_show ? ' active' : ''; ?>">

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -776,6 +776,9 @@ input:checked + .slide-container .properties {
 .category .title:not([data-unread="0"]):after {
 	content: attr(data-unread);
 }
+.category .title.error::before {
+	content: "⚠";
+}
 .feed .item-title:not([data-unread="0"]):before {
 	content: "(" attr(data-unread) ") ";
 }


### PR DESCRIPTION
When a category has one or more feeds with errors, a visual warning is displayed before the name of the category.

See  #965
