### PR TITLE
Config allow robots

### DIFF
--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -10,6 +10,7 @@ class FreshRSS_Context {
 	public static $categories = array();
 
 	public static $name = '';
+	public static $description = '';
 
 	public static $total_unread = 0;
 	public static $total_starred = array(
@@ -94,6 +95,13 @@ class FreshRSS_Context {
 	}
 
 	/**
+	 * Return true iif the current requests target a feed and not a category or all articles.
+	 */
+	public static function isFeed() {
+		return self::$current_get['feed'] != false;
+	}
+
+	/**
 	 * Return true if $get parameter correspond to the $current_get attribute.
 	 */
 	public static function isCurrentGet($get) {
@@ -146,8 +154,8 @@ class FreshRSS_Context {
 			self::$state = self::$state | FreshRSS_Entry::STATE_FAVORITE;
 			break;
 		case 'f':
-			// We try to find the corresponding feed.
-			$feed = FreshRSS_CategoryDAO::findFeed(self::$categories, $id);
+			// We try to find the corresponding feed. When allowing robots, always retrieve the full feed including description
+			$feed = FreshRSS_Context::$system_conf->allow_robots ? null : FreshRSS_CategoryDAO::findFeed(self::$categories, $id);
 			if ($feed === null) {
 				$feedDAO = FreshRSS_Factory::createFeedDao();
 				$feed = $feedDAO->searchById($id);
@@ -160,6 +168,7 @@ class FreshRSS_Context {
 			self::$current_get['feed'] = $id;
 			self::$current_get['category'] = $feed->category();
 			self::$name = $feed->name();
+			self::$description = $feed->description();
 			self::$get_unread = $feed->nbNotRead();
 			break;
 		case 'c':

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -95,7 +95,7 @@ class FreshRSS_Context {
 	}
 
 	/**
-	 * Return true iif the current requests target a feed and not a category or all articles.
+	 * Return true if the current request targets a feed (and not a category or all articles), false otherwise.
 	 */
 	public static function isFeed() {
 		return self::$current_get['feed'] != false;

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -36,7 +36,11 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="black" />
 		<meta name="apple-mobile-web-app-title" content="<?php echo FreshRSS_Context::$system_conf->title; ?>">
 		<meta name="msapplication-TileColor" content="#FFF" />
+<?php if (FreshRSS_Context::$system_conf->allow_robots) { ?>
+		<meta name="description" content="<?php echo htmlspecialchars(FreshRSS_Context::$name . ' | ' . FreshRSS_Context::$description, ENT_NOQUOTES, 'UTF-8'); ?>" />
+<?php } else { ?>
 		<meta name="robots" content="noindex,nofollow" />
+<?php } ?>
 	</head>
 	<body class="<?php echo Minz_Request::param('output', 'normal'); ?>">
 <?php $this->partial('header'); ?>

--- a/data/config.default.php
+++ b/data/config.default.php
@@ -61,6 +61,9 @@ return array(
 	# /!\ It should NOT be enabled if base_url is not reachable by an external server.
 	'pubsubhubbub_enabled' => false,
 
+	# Allow or not Web robots (e.g. search engines) in HTML headers.
+	'allow_robots' => false,
+
 	'limits' => array(
 
 		# Duration in seconds of the SimplePie cache,

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta http-equiv="Refresh" content="0; url=p/" />
 <title>Redirection</title>
-<meta name="robots" content="noindex,nofollow" />
+<meta name="robots" content="noindex" />
 </head>
 
 <body>

--- a/p/index.html
+++ b/p/index.html
@@ -8,7 +8,7 @@
 <link rel="shortcut icon" type="image/x-icon" sizes="16x16 64x64" href="favicon.ico" />
 <link rel="icon msapplication-TileImage apple-touch-icon" type="image/png" sizes="256x256" href="themes/icons/favicon-256.png" />
 <meta name="msapplication-TileColor" content="#FFF" />
-<meta name="robots" content="noindex,nofollow" />
+<meta name="robots" content="noindex" />
 <style>
 body {
 	font-family: sans-serif;


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/938

If `allow_robots` is true, then an HTML meta description is generated (there is only some content when one single feed is shown):

``` html
<meta name="description" content="Le Monde.fr | Toute l'actualité au moment de la connexion" />
```

Otherwise, we still generate the robots exclusion HTML meta tag:

``` html
<meta name="robots" content="noindex,nofollow" />
```
