### PR TITLE
Use font with international glyphs

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1,10 +1,8 @@
 @charset "UTF-8";
 
 /*=== FONTS */
-@font-face {
-	font-family: "OpenSans";
-	src: url("../fonts/openSans.woff") format("woff");
-}
+@import url(https://fonts.googleapis.com/css?family=Open+Sans&subset=latin,cyrillic-ext,cyrillic,latin-ext,greek-ext,greek);
+font-family: 'Open Sans', sans-serif;
 
 /*=== GENERAL */
 /*============*/


### PR DESCRIPTION
I saw that OpenSans font used for default UI theme (`Origine`) doesn't use international font glyphs (cyrillic and greek).
I proposed to use fonts from Google.
