### PR TITLE
Update shares.php : add share for https://www.journalduhacker.net/

### DIFF
--- a/data/shares.php
+++ b/data/shares.php
@@ -75,4 +75,9 @@ return array(
 		'transform' => array(),
 		'form' => 'simple',
 	),
+	'jdh' => array(
+                'url' => 'https://www.journalduhacker.net/stories/new?url=~LINK~&title=~TITLE~',
+                'transform' => array('rawurlencode'),
+                'form' => 'simple',
+        ),
 );


### PR DESCRIPTION
Nouveau partage pour le Jdh:
Le Journal du Hacker a pour ambition de présenter l'activité des hackers francophones, du mouvement du Logiciel Libre et open source en langue française, mais aussi des startups et du mouvement entrepreunariale de la communauté francophone.
