### PR TITLE
Force HTTPS for selected embed providers

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -7,3 +7,4 @@ no-cache.txt
 *.lock.txt
 last_update.txt
 update.php
+force-https.txt

--- a/data/force-https.default.txt
+++ b/data/force-https.default.txt
@@ -1,4 +1,6 @@
 dailymotion.com
 feedburner.com
+gstatic.com
 tumblr.com
+wordpress.com
 youtube.com

--- a/data/force-https.default.txt
+++ b/data/force-https.default.txt
@@ -1,3 +1,4 @@
 dailymotion.com
+feedburner.com
 tumblr.com
 youtube.com

--- a/data/force-https.txt
+++ b/data/force-https.txt
@@ -1,0 +1,3 @@
+dailymotion.com
+tumblr.com
+youtube.com

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -1236,7 +1236,7 @@ class SimplePie
 
 	/**
 	 * Set the list of domains for which force HTTPS.
-	 * @see SimplePie_Misc::https_url()
+	 * @see SimplePie_Sanitize::set_https_domains()
 	 * FreshRSS
 	 */
 	public function set_https_domains($domains = array())

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -1123,6 +1123,7 @@ class SimplePie
 			$this->strip_attributes(false);
 			$this->add_attributes(false);
 			$this->set_image_handler(false);
+			$this->set_https_domains(array());
 		}
 	}
 
@@ -1231,6 +1232,19 @@ class SimplePie
 	public function set_url_replacements($element_attribute = null)
 	{
 		$this->sanitize->set_url_replacements($element_attribute);
+	}
+
+	/**
+	 * Set the list of domains for which force HTTPS.
+	 * @see SimplePie_Misc::https_url()
+	 * FreshRSS
+	 */
+	public function set_https_domains($domains = array())
+	{
+		if (is_array($domains))
+		{
+			$this->sanitize->set_https_domains($domains);
+		}
 	}
 
 	/**

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -83,7 +83,13 @@ class SimplePie_Misc
 	 */
 	public static function https_url($url)
 	{
-		return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', 'https://$1', $url);
+		if (strtolower(substr($url, 0, 7)) === 'http://')
+		{
+			$domain = parse_url($url, PHP_URL_HOST);
+			return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', 'https://$1', $url);
+			return substr_replace($url, 's', 4, 0);	//Add the 's' to HTTPS
+		}
+		return $url;
 	}
 
 	public static function absolutize_url($relative, $base)

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -97,7 +97,7 @@ class SimplePie_Misc
 		{
 			return false;
 		}
-		return https_url($iri->get_uri());
+		return SimplePie_Misc::https_url($iri->get_uri());
 	}
 
 	/**

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -97,7 +97,7 @@ class SimplePie_Misc
 		{
 			return false;
 		}
-		return SimplePie_Misc::https_url($iri->get_uri());
+		return $iri->get_uri();
 	}
 
 	/**

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -77,6 +77,15 @@ class SimplePie_Misc
 		return $time;
 	}
 
+	/**
+	 * Force HTTPS for selected Web sites
+	 * FreshRSS
+	 */
+	public static https_url($url)
+	{
+		return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', '//$1', $url);
+	}
+
 	public static function absolutize_url($relative, $base)
 	{
 		if (substr($relative, 0, 2) === '//')
@@ -88,7 +97,7 @@ class SimplePie_Misc
 		{
 			return false;
 		}
-		return $iri->get_uri();
+		return https_url($iri->get_uri());
 	}
 
 	/**

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -81,7 +81,7 @@ class SimplePie_Misc
 	 * Force HTTPS for selected Web sites
 	 * FreshRSS
 	 */
-	public static https_url($url)
+	public static function https_url($url)
 	{
 		return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', '//$1', $url);
 	}

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -77,21 +77,6 @@ class SimplePie_Misc
 		return $time;
 	}
 
-	/**
-	 * Force HTTPS for selected Web sites
-	 * FreshRSS
-	 */
-	public static function https_url($url)
-	{
-		if (strtolower(substr($url, 0, 7)) === 'http://')
-		{
-			$domain = parse_url($url, PHP_URL_HOST);
-			return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', 'https://$1', $url);
-			return substr_replace($url, 's', 4, 0);	//Add the 's' to HTTPS
-		}
-		return $url;
-	}
-
 	public static function absolutize_url($relative, $base)
 	{
 		if (substr($relative, 0, 2) === '//')

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -83,14 +83,14 @@ class SimplePie_Misc
 	 */
 	public static function https_url($url)
 	{
-		return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', '//$1', $url);
+		return preg_replace('%^http://((?:[^/]*?\.)?(?:youtube|dailymotion|tumblr)\.com/)%i', 'https://$1', $url);
 	}
 
 	public static function absolutize_url($relative, $base)
 	{
 		if (substr($relative, 0, 2) === '//')
-		{//Allow protocol-relative URLs "//www.example.net" which will pick HTTP or HTTPS automatically
-			return $relative;
+		{//Protocol-relative URLs "//www.example.net"
+			return 'https:' . $relative;
 		}
 		$iri = SimplePie_IRI::absolutize(new SimplePie_IRI($base), $relative);
 		if ($iri === false)

--- a/lib/SimplePie/SimplePie/Sanitize.php
+++ b/lib/SimplePie/SimplePie/Sanitize.php
@@ -75,11 +75,12 @@ class SimplePie_Sanitize
 
 	/**
 	 * List of domains for which force HTTPS.
-	 * @see SimplePie_Misc::https_url()
-	 * Array is tree split at DNS levels. Example array('biz' => true, 'com' => array('example' => true), 'example' => array('test') => array('www' => true));
+	 * @see SimplePie_Sanitize::set_https_domains()
+	 * Array is tree split at DNS levels. Example:
+	 * array('biz' => true, 'com' => array('example' => true), 'net' => array('example') => array('www' => true))
 	 * FreshRSS
 	 */
-	var $https_domains = array('com' => array('youtube' => true));
+	var $https_domains = array('com' => array('dailymotion' => true, 'youtube' => true));
 
 	public function __construct()
 	{

--- a/lib/SimplePie/SimplePie/Sanitize.php
+++ b/lib/SimplePie/SimplePie/Sanitize.php
@@ -263,23 +263,20 @@ class SimplePie_Sanitize
 		{
 			$domain = trim($domain, ". \t\n\r\0\x0B");
 			$segments = array_reverse(explode('.', $domain));
-			if (count($segments) > 0)
-			{
-				$node =& $this->https_domains;
-				foreach ($segments as $segment)
-				{//Build a tree
-					if ($node === true)
-					{
-						break;
-					}
-					if (!isset($node[$segment]))
-					{
-						$node[$segment] = array();
-					}
-					$node =& $node[$segment];
+			$node =& $this->https_domains;
+			foreach ($segments as $segment)
+			{//Build a tree
+				if ($node === true)
+				{
+					break;
 				}
-				$node = true;
+				if (!isset($node[$segment]))
+				{
+					$node[$segment] = array();
+				}
+				$node =& $node[$segment];
 			}
+			$node = true;
 		}
 	}
 
@@ -291,23 +288,20 @@ class SimplePie_Sanitize
 	{
 		$domain = trim($domain, '. ');
 		$segments = array_reverse(explode('.', $domain));
-		if (count($segments) > 0)
-		{
-			$node =& $this->https_domains;
-			foreach ($segments as $segment)
-			{//Explore the tree
-				if ($node === true)
-				{
-					return true;
-				}
-				if (isset($node[$segment]))
-				{
-					$node =& $node[$segment];
-				}
-				else
-				{
-					break;
-				}
+		$node =& $this->https_domains;
+		foreach ($segments as $segment)
+		{//Explore the tree
+			if ($node === true)
+			{
+				return true;
+			}
+			if (isset($node[$segment]))
+			{
+				$node =& $node[$segment];
+			}
+			else
+			{
+				break;
 			}
 		}
 		return false;

--- a/lib/SimplePie/SimplePie/Sanitize.php
+++ b/lib/SimplePie/SimplePie/Sanitize.php
@@ -73,6 +73,14 @@ class SimplePie_Sanitize
 	var $force_fsockopen = false;
 	var $replace_url_attributes = null;
 
+	/**
+	 * List of domains for which force HTTPS.
+	 * @see SimplePie_Misc::https_url()
+	 * Array is tree split at DNS levels. Example array('biz' => true, 'com' => array('example' => true), 'example' => array('test') => array('www' => true));
+	 * FreshRSS
+	 */
+	var $https_domains = array('com' => array('youtube' => true));
+
 	public function __construct()
 	{
 		// Set defaults
@@ -240,6 +248,81 @@ class SimplePie_Sanitize
 			);
 		}
 		$this->replace_url_attributes = (array) $element_attribute;
+	}
+
+	/**
+	 * Set the list of domains for which force HTTPS.
+	 * @see SimplePie_Misc::https_url()
+	 * Example array('biz', 'example.com', 'example.org', 'www.example.net');
+	 * FreshRSS
+	 */
+	public function set_https_domains($domains)
+	{
+		$this->https_domains = array();
+		foreach ($domains as $domain)
+		{
+			$domain = trim($domain, ". \t\n\r\0\x0B");
+			$segments = array_reverse(explode('.', $domain));
+			if (count($segments) > 0)
+			{
+				$node =& $this->https_domains;
+				foreach ($segments as $segment)
+				{//Build a tree
+					if ($node === true)
+					{
+						break;
+					}
+					if (!isset($node[$segment]))
+					{
+						$node[$segment] = array();
+					}
+					$node =& $node[$segment];
+				}
+				$node = true;
+			}
+		}
+	}
+
+	/**
+	 * Check if the domain is in the list of forced HTTPS
+	 * FreshRSS
+	 */
+	protected function is_https_domain($domain)
+	{
+		$domain = trim($domain, '. ');
+		$segments = array_reverse(explode('.', $domain));
+		if (count($segments) > 0)
+		{
+			$node =& $this->https_domains;
+			foreach ($segments as $segment)
+			{//Explore the tree
+				if ($node === true)
+				{
+					return true;
+				}
+				if (isset($node[$segment]))
+				{
+					$node =& $node[$segment];
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Force HTTPS for selected Web sites
+	 * FreshRSS
+	 */
+	protected function https_url($url)
+	{
+		return (strtolower(substr($url, 0, 7)) === 'http://') &&
+			$this->is_https_domain(parse_url($url, PHP_URL_HOST)) ?
+			substr_replace($url, 's', 4, 0) :	//Add the 's' to HTTPS
+			$url;
 	}
 
 	public function sanitize($data, $type, $base = '')
@@ -451,7 +534,7 @@ class SimplePie_Sanitize
 					if ($element->hasAttribute($attribute))
 					{
 						$value = $this->registry->call('Misc', 'absolutize_url', array($element->getAttribute($attribute), $this->base));
-						$value = SimplePie_Misc::https_url($value);	//FreshRSS
+						$value = $this->https_url($value);	//FreshRSS
 						if ($value)
 						{
 							$element->setAttribute($attribute, $value);

--- a/lib/SimplePie/SimplePie/Sanitize.php
+++ b/lib/SimplePie/SimplePie/Sanitize.php
@@ -451,7 +451,8 @@ class SimplePie_Sanitize
 					if ($element->hasAttribute($attribute))
 					{
 						$value = $this->registry->call('Misc', 'absolutize_url', array($element->getAttribute($attribute), $this->base));
-						if ($value !== false)
+						$value = SimplePie_Misc::https_url($value);	//FreshRSS
+						if ($value)
 						{
 							$element->setAttribute($attribute, $value);
 						}

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -238,6 +238,16 @@ function customSimplePie() {
 			'src',
 		),
 	));
+	$https_domains = array();
+	$force = @file(DATA_PATH . '/force-https.default.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	if (is_array($force)) {
+		$https_domains = array_merge($https_domains, $force);
+	}
+	$force = @file(DATA_PATH . '/force-https.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	if (is_array($force)) {
+		$https_domains = array_merge($https_domains, $force);
+	}
+	$simplePie->set_https_domains($https_domains);
 	return $simplePie;
 }
 


### PR DESCRIPTION
Experiment with YouTube, DailyMotion, Tumblr to start with
https://github.com/FreshRSS/FreshRSS/issues/1083
https://github.com/FreshRSS/FreshRSS/issues/638
https://github.com/FreshRSS/FreshRSS/issues/1081
~~Later, would be good with a customizable list~~ Now with a default and custom text file of domains
