### PR TITLE
Fix redirection while deleting a feed

### DIFF
--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -6,10 +6,10 @@
 	<h1><?php echo _t('admin.stats.idle'); ?></h1>
 
 	<?php
-		$current_url = urlencode(Minz_Url::display(
+		$current_url = Minz_Url::display(
 			array('c' => 'stats', 'a' => 'idle'),
 			'php', true
-		));
+		);
 		$nothing = true;
 		foreach ($this->idleFeeds as $period => $feeds) {
 			if (!empty($feeds)) {

--- a/lib/Minz/Url.php
+++ b/lib/Minz/Url.php
@@ -27,6 +27,8 @@ class Minz_Url {
 			$url_string = Minz_Request::getBaseUrl(PUBLIC_TO_INDEX_PATH);
 			if ($url_string === PUBLIC_TO_INDEX_PATH) {
 				$url_string = Minz_Request::guessBaseUrl();
+			} else {
+				$url_string .= '/';
 			}
 		} else {
 			$url_string = $isArray ? '.' : PUBLIC_RELATIVE;


### PR DESCRIPTION
Before, when deleting a feed from the statistics idle page, there was an error in the redirection process.
Now, the redirection works properly and redirects to the idle page.

See #1047 
