### PR TITLE
Add DPlatform as an installation way

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -52,6 +52,12 @@ Nous sommes une communauté amicale.
 5. Tout devrait fonctionner :) En cas de problème, n’hésitez pas à me contacter.
 6. Des paramètres de configuration avancée peuvent être accédés depuis [config.php](./data/config.default.php).
 
+## Installation facile automatisée
+
+La manière la plus facile d'avoir un FreshRSS prêt à l'emploi sur votre serveur Linux
+
+[![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
+
 ## Exemple d’installation complète sur Linux Debian/Ubuntu
 ```sh
 # Si vous utilisez le serveur Web Apache (sinon il faut un autre serveur Web)

--- a/README.fr.md
+++ b/README.fr.md
@@ -52,9 +52,7 @@ Nous sommes une communauté amicale.
 5. Tout devrait fonctionner :) En cas de problème, n’hésitez pas à me contacter.
 6. Des paramètres de configuration avancée peuvent être accédés depuis [config.php](./data/config.default.php).
 
-## Installation facile automatisée
-
-La manière la plus facile d'avoir un FreshRSS prêt à l'emploi sur votre serveur Linux
+## Installation automatisée
 
 [![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ We are a friendly community.
 5. Everything should be working :) If you encounter any problem, feel free to contact me.
 6. Advanced configuration settings can be seen in [config.php](./data/config.default.php).
 
+## Easy automated install
+
+The easiest way to have a ready-to-use FreshRSS in your Linux server
+
+[![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
+
 ## Example of full installation on Linux Debian/Ubuntu
 ```sh
 # If you use an Apache Web server (otherwise you need another Web server)

--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ We are a friendly community.
 5. Everything should be working :) If you encounter any problem, feel free to contact me.
 6. Advanced configuration settings can be seen in [config.php](./data/config.default.php).
 
-## Easy automated install
-
-The easiest way to have a ready-to-use FreshRSS in your Linux server
+## Automated install
 
 [![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
 


### PR DESCRIPTION
Bonjour, je suis le créateur de [DPlatform](https://github.com/j8r/DPlatform), qui a pour but de rendre facile l'installation d'applications auto-hébergées.
J'aime beaucoup votre agrégateur de flux RSS, j'ai donc ajouté son support à mon projet
Je souhaiterais ajouter un lien vers celui-ci sur votre page principale afin que d'autres personnes puissent installer facilement FreshRSS sur leurs serveurs Linux.
