### PR TITLE
Error message when accessing entry controller by GET

### DIFF
--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -46,6 +46,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 		if ($id === false) {
 			// id is false? It MUST be a POST request!
 			if (!Minz_Request::isPost()) {
+				Minz_Request::bad(_t('feedback.access.not_found'), array('c' => 'index', 'a' => 'index'));
 				return;
 			}
 


### PR DESCRIPTION
Sometime during network problems, the user might land on a page for which a POST request just failed, and might manually restart the navigation, which makes an erroneous GET.
