### PR TITLE
A share for Wallabag v2

### DIFF
--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -164,7 +164,8 @@ return array(
 		'print' => 'Drucken',
 		'shaarli' => 'Shaarli',
 		'twitter' => 'Twitter',
-		'wallabag' => 'wallabag',
+		'wallabag' => 'wallabag v1',
+		'wallabagv2' => 'wallabag v2',
 		'jdh' => 'Journal du hacker',
 	),
 	'short' => array(

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -164,7 +164,8 @@ return array(
 		'print' => 'Print',
 		'shaarli' => 'Shaarli',
 		'twitter' => 'Twitter',
-		'wallabag' => 'wallabag',
+		'wallabag' => 'wallabag v1',
+		'wallabagv2' => 'wallabag v2',
 		'jdh' => 'Journal du hacker',
 	),
 	'short' => array(

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -164,7 +164,8 @@ return array(
 		'print' => 'Imprimer',
 		'shaarli' => 'Shaarli',
 		'twitter' => 'Twitter',
-		'wallabag' => 'wallabag',
+		'wallabag' => 'wallabag v1',
+		'wallabagv2' => 'wallabag v2',
 		'jdh' => 'Journal du hacker',
 	),
 	'short' => array(

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -163,7 +163,8 @@ return array(
 		'print' => 'Stampa',
 		'shaarli' => 'Shaarli',
 		'twitter' => 'Twitter',
-		'wallabag' => 'wallabag',
+		'wallabag' => 'wallabag v1',
+		'wallabagv2' => 'wallabag v2',
 		'jdh' => 'Journal du hacker',
 	),
 	'short' => array(

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -164,7 +164,8 @@ return array(
 		'print' => 'Print',
 		'shaarli' => 'Shaarli',
 		'twitter' => 'Twitter',
-		'wallabag' => 'wallabag',                
+		'wallabag' => 'wallabag v1',
+		'wallabagv2' => 'wallabag v2',             
 		'jdh' => 'Journal du hacker',
 	),
 	'short' => array(

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -164,7 +164,8 @@ return array(
 		'print' => 'Print',
 		'shaarli' => 'Shaarli',
 		'twitter' => 'Twitter',
-		'wallabag' => 'wallabag',
+		'wallabag' => 'wallabag v1',
+		'wallabagv2' => 'wallabag v2',
 		'jdh' => 'Journal du hacker',
 	),
 	'short' => array(

--- a/data/shares.php
+++ b/data/shares.php
@@ -38,6 +38,15 @@ return array(
 		'help' => 'http://www.wallabag.org/',
 		'form' => 'advanced',
 	),
+	'wallabagv2' => array(
+		'url' => '~URL~/bookmarklet?url=~LINK~',
+		'transform' => array(
+			'link' => array('rawurlencode'),
+			'title' => array(),
+		),
+		'help' => 'http://www.wallabag.org/',
+		'form' => 'advanced',
+	),
 	'diaspora' => array(
 		'url' => '~URL~/bookmarklet?url=~LINK~&amp;title=~TITLE~',
 		'transform' => array('rawurlencode'),


### PR DESCRIPTION
The new version of Wallabag (2) was rewrote completly, and the sharer changed.

This PR keeps the old Wallabag v1 sharer, for people still using it, and adds a new one for Wallabag v2. The old sharer for wallabag v1 is renamed to `wallabag v1` (instead of `wallabag`).

Please note that as this changes a couple of translations, it may impact #1085.
