### PR TITLE
Update DPlatform to the new URL

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -53,7 +53,7 @@ Nous sommes une communauté amicale.
 6. Des paramètres de configuration avancée peuvent être accédés depuis [config.php](./data/config.default.php).
 
 ## Installation automatisée
-[![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
+[![DP deploy](https://raw.githubusercontent.com/DFabric/DPlatform-ShellCore/gh-pages/img/deploy.png)](https://dfabric.github.io/DPlatform-ShellCore)
 
 ## Exemple d’installation complète sur Linux Debian/Ubuntu
 ```sh

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We are a friendly community.
 6. Advanced configuration settings can be seen in [config.php](./data/config.default.php).
 
 ## Automated install
-[![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
+[![DP deploy](https://raw.githubusercontent.com/DFabric/DPlatform-ShellCore/gh-pages/img/deploy.png)](https://dfabric.github.io/DPlatform-ShellCore)
 
 ## Example of full installation on Linux Debian/Ubuntu
 ```sh


### PR DESCRIPTION
Bonjour, cela fait maintenant un petit moment que le projet DPlatform a été lancé, et depuis il a gagné pas mal d'intérêt auprès des gens, sans doute aussi grâce à FreshRSS.

C'est pourquoi une organisation a été créé, [DFabric](https://github.com/DFabric), pour pouvoir prendre en charge les dépots des projets associés à DPlatform. L'ancien lien du site a donc changé et est maintenant cassé,. Je l'ai mis à jour.
