### PR TITLE
Change default value for keep history

### DIFF
--- a/data/users/_/config.default.php
+++ b/data/users/_/config.default.php
@@ -3,7 +3,7 @@
 return array (
 	'language' => 'en',
 	'old_entries' => 3,
-	'keep_history_default' => 0,
+	'keep_history_default' => 50,
 	'ttl_default' => 3600,
 	'mail_login' => '',
 	'token' => '',


### PR DESCRIPTION
Larger value by default, for limiting the risk of re-adding an article
previously purged, e.g. with feeds which do not have good dates, which
do not update so often, and for which the list of articles is not so
stable.
