### PR TITLE
Fix bug share

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -139,7 +139,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 	 */
 	public function sharingAction() {
 		if (Minz_Request::isPost()) {
-			$params = Minz_Request::fetchGET();
+			$params = Minz_Request::fetchPOST();
 			FreshRSS_Context::$user_conf->sharing = $params['share'];
 			FreshRSS_Context::$user_conf->save();
 			invalidateHttpCache();

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1153,10 +1153,10 @@ function init_share_observers() {
 	$('.share.add').on('click', function(e) {
 		var opt = $(this).siblings('select').find(':selected');
 		var row = $(this).parents('form').data(opt.data('form'));
-		row = row.replace('##label##', opt.html().trim(), 'g');
-		row = row.replace('##type##', opt.val(), 'g');
-		row = row.replace('##help##', opt.data('help'), 'g');
-		row = row.replace('##key##', shares, 'g');
+		row = row.replace(/##label##/g, opt.html().trim());
+		row = row.replace(/##type##/g, opt.val());
+		row = row.replace(/##help##/g, opt.data('help'));
+		row = row.replace(/##key##/g, shares);
 		$(this).parents('.form-group').before(row);
 		shares++;
 


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/1289
Was using deprecated non-standard parameter in string.replace()

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Firefox-specific_notes
