### PR TITLE
Minz::Log bug when currentUser is empty string

### DIFF
--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -42,7 +42,11 @@ class Minz_Log {
 		       || ($env === 'production'
 		       && ($level >= Minz_Log::NOTICE)))) {
 			if ($file_name === null) {
-				$file_name = join_path(USERS_PATH, Minz_Session::param('currentUser', '_'), 'log.txt');
+				$username = Minz_Session::param('currentUser', '');
+				if ($username == '') {
+					$username = '_';
+				}
+				$file_name = join_path(USERS_PATH, $username, 'log.txt');
 			}
 
 			switch ($level) {


### PR DESCRIPTION
`Minz_Session::param('currentUser', '_')` could return an empty string
