### PR TITLE
CSS line-height bug with sup in dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * I18n
 	* Fix some messages during installation [#1339](https://github.com/FreshRSS/FreshRSS/pull/1339)
 * UI
+	* Fix CSS line-height bug with <sup> in dates (English, Russian, Turkish) [#1340](https://github.com/FreshRSS/FreshRSS/pull/1340)
 	* Download icon 💾 for podcasts [#1236](https://github.com/FreshRSS/FreshRSS/issues/1236)
 * SimplePie
 	* Fix auto-discovery of RSS feeds in Web pages served as `text/xml` [#1264](https://github.com/FreshRSS/FreshRSS/issues/1264)

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -44,6 +44,12 @@ p {
 	margin: 1em 0 0.5em;
 	font-size: 1em;
 }
+sup {
+	line-height: 25px;
+	position: relative;
+	top: -0.8em;
+	vertical-align: baseline;
+}
 
 /*=== Images */
 img {


### PR DESCRIPTION
Not visible in Firefox, but in Chrome / Internet Explorer / Edge.
https://github.com/FreshRSS/FreshRSS/issues/534#issuecomment-255519269
https://github.com/FreshRSS/FreshRSS/issues/1328
https://www.cs.tut.fi/~jkorpela/www/linespacing.html
