### PR TITLE
Fixed empty db-prefix in do-install.php

### DIFF
--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -73,7 +73,7 @@ if ((!empty($config['base_url'])) && server_is_public($config['base_url'])) {
 
 foreach ($dBparams as $dBparam) {
 	$dBparam = rtrim($dBparam, ':');
-	if (!empty($options[$dBparam])) {
+	if (isset($options[$dBparam])) {
 		$param = substr($dBparam, strlen('db-'));
 		$config['db'][$param] = $options[$dBparam];
 	}


### PR DESCRIPTION
The existing code did not take an empty string as `db-prefix`.

This pull request is part of a series that aims to make FreshRSS more Cloudron-friendly.