### PR TITLE
Add config option to disable and hide self-update

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -162,7 +162,7 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 	}
 
 	public function applyAction() {
-		if (!file_exists(UPDATE_FILENAME) || !is_writable(FRESHRSS_PATH)) {
+		if (!file_exists(UPDATE_FILENAME) || !is_writable(FRESHRSS_PATH) || Minz_Configuration::get('system')->disable_update) {
 			Minz_Request::forward(array('c' => 'update'), true);
 		}
 

--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -41,9 +41,11 @@
 	                          Minz_Request::actionName() === 'checkInstall' ? ' active' : ''; ?>">
 		<a href="<?php echo _url('update', 'checkInstall'); ?>"><?php echo _t('gen.menu.check_install'); ?></a>
 	</li>
+	<?php if (!Minz_Configuration::get('system')->disable_update) { ?>
 	<li class="item<?php echo Minz_Request::controllerName() === 'update' &&
 	                          Minz_Request::actionName() === 'index' ? ' active' : ''; ?>">
 		<a href="<?php echo _url('update', 'index'); ?>"><?php echo _t('gen.menu.update'); ?></a>
 	</li>
+	<?php } ?>
 	<?php } ?>
 </ul>

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -71,7 +71,9 @@ if (FreshRSS_Auth::accessNeedsAction()) {
 				<li class="item"><a href="<?php echo _url('user', 'manage'); ?>"><?php echo _t('gen.menu.user_management'); ?></a></li>
 				<li class="item"><a href="<?php echo _url('auth', 'index'); ?>"><?php echo _t('gen.menu.authentication'); ?></a></li>
 				<li class="item"><a href="<?php echo _url('update', 'checkInstall'); ?>"><?php echo _t('gen.menu.check_install'); ?></a></li>
+				<?php if (!Minz_Configuration::get('system')->disable_update) { ?>
 				<li class="item"><a href="<?php echo _url('update', 'index'); ?>"><?php echo _t('gen.menu.update'); ?></a></li>
+				<?php } ?>
 				<?php } ?>
 				<li class="separator"></li>
 				<li class="item"><a href="<?php echo _url('stats', 'index'); ?>"><?php echo _t('gen.menu.stats'); ?></a></li>

--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -13,6 +13,7 @@ $params = array(
 		'auth_type:',
 		'api_enabled',
 		'allow_robots',
+		'disable_update',
 	);
 
 $dBparams = array(
@@ -31,7 +32,7 @@ if (empty($options['default_user'])) {
 		" --environment production --base_url https://rss.example.net/" .
 		" --title FreshRSS --allow_anonymous --api_enabled" .
 		" --db-type mysql --db-host localhost:3306 --db-user freshrss --db-password dbPassword123" .
-		" --db-base freshrss --db-prefix freshrss_ )");
+		" --db-base freshrss --db-prefix freshrss_ --disable_update )");
 }
 
 fwrite(STDERR, 'FreshRSS install…' . "\n");

--- a/data/config.default.php
+++ b/data/config.default.php
@@ -146,4 +146,7 @@ return array(
 
 	# List of enabled FreshRSS extensions.
 	'extensions_enabled' => array(),
+
+	# Disable self-update,
+	'disable_update' => false,
 );


### PR DESCRIPTION
This PR contains the following changes:
* Add a config option `disable_update` to default config (default: `false`)
* Hide the "Update" entry in header an configuration menu when this option is set
* Disable the update action when this option is set

This pull request is part of a series that aims to make FreshRSS more Cloudron-friendly.