### PR TITLE
fix: Fix update via ZIP archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 		* (Require manual update for existing installations)
 	* Do not require PHP extension `fileinfo` for favicons [#1461](https://github.com/FreshRSS/FreshRSS/issues/1461)
 	* Fix UI lowest subscription popup hidden [#1479](https://github.com/FreshRSS/FreshRSS/issues/1479)
+	* Fix update system via ZIP archive [#1498](https://github.com/FreshRSS/FreshRSS/pull/1498)
 * I18n
 	* Improve English [#1465](https://github.com/FreshRSS/FreshRSS/pull/1465)
 * Misc.

--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -190,6 +190,7 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 			if (self::isGit()) {
 				$res = self::gitPull();
 			} else {
+				require(UPDATE_FILENAME);
 				if (Minz_Request::isPost()) {
 					save_info_update();
 				}


### PR DESCRIPTION
Code from the update server was not loaded anymore before the update
process. This commit brings back missing `require`.