### PR TITLE
fix font-sizes of input fields for exotic browsers

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -44,3 +44,4 @@ People are sorted by name so please keep this order.
 * [Thomas Citharel](https://github.com/tcitworld): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:tomgue), [Web](https://www.tcit.fr/)
 * [tomgue](https://github.com/tomgue): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=tomgue)
 * [Wanabo](https://github.com/Wanabo): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=Wanabo)
+* [mszkb](https://github.com/mszkb): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=mszkb)

--- a/p/themes/BlueLagoon/template.css
+++ b/p/themes/BlueLagoon/template.css
@@ -2,7 +2,7 @@
 
 /*=== GENERAL */
 /*============*/
-html, body { 
+html, body {
 	margin: 0;
 	padding: 0;
 	font-size: 92%;
@@ -79,6 +79,7 @@ textarea {
 input, select, textarea {
 	display: inline-block;
 	max-width: 100%;
+	font-size: 0.8rem;
 }
 input[type="radio"],
 input[type="checkbox"] {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -88,7 +88,7 @@ input.extend:focus {
 input, select, textarea {
 	display: inline-block;
 	max-width: 100%;
-	font-size: inital;
+	font-size: initial;
 }
 input[type="radio"],
 input[type="checkbox"] {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -88,6 +88,7 @@ input.extend:focus {
 input, select, textarea {
 	display: inline-block;
 	max-width: 100%;
+	font-size: inital;
 }
 input[type="radio"],
 input[type="checkbox"] {
@@ -345,7 +346,7 @@ a.btn {
 /*=== Tree */
 .tree {
 	margin: 0;
-	padding: 0 0 15em 0;
+	padding: 0;
 	list-style: none;
 	text-align: left;
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -88,7 +88,7 @@ input.extend:focus {
 input, select, textarea {
 	display: inline-block;
 	max-width: 100%;
-	font-size: initial;
+	font-size: 0.8rem;
 }
 input[type="radio"],
 input[type="checkbox"] {
@@ -346,7 +346,7 @@ a.btn {
 /*=== Tree */
 .tree {
 	margin: 0;
-	padding: 0;
+	padding: 0 0 15em 0;
 	list-style: none;
 	text-align: left;
 }


### PR DESCRIPTION
There was no Placeholder inside input fields. Also the written text inside password-fields and adding subscription were super small (font-size: 0; inherited from .stick origine.css:115)

See my comment below for screenshots.

