### PR TITLE
(minor) Eng i18n: "Damn" to "blast"

### DIFF
--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -174,7 +174,7 @@ return array(
 		'blank_to_disable' => 'Leave blank to disable',
 		'by_author' => 'By <em>%s</em>',
 		'by_default' => 'By default',
-		'damn' => 'Damn!',
+		'damn' => 'Blast!',
 		'default_category' => 'Uncategorized',
 		'no' => 'No',
 		'not_applicable' => 'Not available',


### PR DESCRIPTION
I think French *arf*/*zut* would be better translated as something like *blast* or *rats* than *damn*. The word *arf* doesn't have a lemma in my *Petit Robert*, so since French is my fourth and worst language I can't be completely sure. But even if I'm wrong about the French, the word *damn* simply seems slightly too expletive for an English localization. By contrast, in Dutch I'm not sure if anything even exceeds the level of offensiveness reached by a mild expletive like *damn* in English. English speakers are just much more sensitive to words in and of themselves regardless of context.