### PR TITLE
Add support for a new shortcut in reader view

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -66,7 +66,7 @@ if (!empty($this->entries)) {
 
 		?><div class="flux_content">
 			<div class="content <?php echo $content_width; ?>">
-				<h1 class="title"><a target="_blank" rel="noreferrer" href="<?php echo $this->entry->link(); ?>"><?php echo $this->entry->title(); ?></a></h1>
+				<h1 class="title"><a target="_blank" rel="noreferrer" class="go_website" href="<?php echo $this->entry->link(); ?>"><?php echo $this->entry->title(); ?></a></h1>
 				<?php
 					$author = $this->entry->author();
 					echo $author != '' ? '<div class="author">' . _t('gen.short.by_author', $author) . '</div>' : '',

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -19,7 +19,7 @@ if (!empty($this->entries)) {
 					$feed = FreshRSS_CategoryDAO::findFeed($this->categories, $item->feed());	//We most likely already have the feed object in cache
 					if (empty($feed)) $feed = $item->feed(true);
 				?>
-				<a href="<?php echo $item->link(); ?>">
+				<a target="_blank" rel="noreferrer" class="go_website" href="<?php echo $item->link(); ?>">
 					<img class="favicon" src="<?php echo $feed->favicon(); ?>" alt="✇" /> <span><?php echo $feed->name(); ?></span>
 				</a>
 				<h1 class="title"><?php echo $item->title(); ?></h1>

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -661,7 +661,7 @@ function init_shortcuts() {
 	});
 
 	shortcut.add(shortcuts.go_website, function () {
-		var url_website = $('.flux.current > .flux_header > .title > a').attr("href");
+		var url_website = $('.flux.current a.go_website').attr("href");
 
 		if (context.auto_mark_site) {
 			$(".flux.current").each(function () {


### PR DESCRIPTION
Now you can open the original page in the reader view with the same shortcut you'll use in the normal view.
I've changed how we identify the link to make it more flexible.
The previous way was too restrictive since the selector used a really strict path to get the url.

There was another way to achieve the same thing without changing the selector.
It was quite ugly since some meaningless class would be added on the markup to match the selector query.

See #1400