### PR TITLE
Make feedlist padding a bit dynamic

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -541,7 +541,16 @@ function init_column_categories() {
 				feed_web = $(this).data('fweb'),
 				template = $('#feed_config_template').html().replace(/------/g, feed_id).replace('http://example.net/', feed_web);
 			$(this).attr('href', '#dropdown-' + feed_id).prev('.dropdown-target').attr('id', 'dropdown-' + feed_id).parent().append(template);
+			$('.tree-folder-items .dropdown-close a').click(function(){
+				$('.tree').removeClass('treepadding');
+				$(document.body).trigger("sticky_kit:recalc");
+			});
 		}
+	});
+
+	$('.tree-folder-items .dropdown-toggle').click(function(){
+		$('.tree').addClass('treepadding');
+		$(document.body).trigger("sticky_kit:recalc");
 	});
 
 	init_sticky_column();

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -346,10 +346,15 @@ a.btn {
 /*=== Tree */
 .tree {
 	margin: 0;
-	padding: 0 0 15em 0;
+	padding: 0 0 2em 0;
 	list-style: none;
 	text-align: left;
 }
+
+.treepadding {
+	padding: 0 0 15em 0;
+}
+
 .tree-folder-items {
 	padding: 0;
 	list-style: none;


### PR DESCRIPTION
With the fix #1489 (Bottom padding menu) for issue #1479 (UI: lowest subscription's popup gets hidden) now I had always a huge unnecessary space below the feed list while scrolling up… (about 1/3rd of the screen)

With this change I reduced the padding a lot (but not completely) and made sure that the padding is big enough again when a dropdown-menu is open to enable scrolling it into the field of view…

I think this is a good compromise…