### PR TITLE
Validate creator field

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -80,7 +80,7 @@ class FreshRSS_Entry extends Minz_Model {
 		$tags_close = $this->_classify_tag($string, '/(?<tag>\<\/(?<keyword>\w)+.*?\>)/', 'close');
 		$tags_self = $this->_classify_tag($string, '/(?<tag>\<(?<keyword>\w)+.*?\/\>)/', 'selfclosing');
 		$tags = array_merge($tags_open, $tags_close, $tags_self);
-		usort($tags, '_sort_by_pos');
+		usort($tags, array('FreshRss_Entry', '_sort_by_pos'));
 		$stack = array();
 		foreach ($tags as $key => $value) {
 			if ($value[3] == 'open') {
@@ -107,8 +107,11 @@ class FreshRSS_Entry extends Minz_Model {
 		/*
 		 * NOTE: Validate HTML
 		 * because author field is limited to 255 bytes
+		 * TODO: is it safe to hard-code 255?
 		 */
-		$author = $this->_validate_html($author) ? $author : '(Parse error)';
+		if (strlen($author) >= 255) {
+			$author = $this->_validate_html($author) ? $author : '(Parse error)';
+		}
 		return $author;
 	}
 	public function content() {

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -43,8 +43,63 @@ class FreshRSS_Entry extends Minz_Model {
 	public function title() {
 		return $this->title;
 	}
+	private function _classify_tag($string, $regex, $label) {
+		preg_match_all($regex, $string, $regex_result, PREG_OFFSET_CAPTURE);
+		$tags = $regex_result['tag'];
+		$keywords = $regex_result['keyword'];
+		foreach ($tags as $key => $value) {
+			$tags[$key][2] = $keywords[$key][0];
+			$tags[$key][3] = $label;
+		}
+		return $tags;
+	}
+	private function _sort_by_pos($a, $b) {
+		if ($a[1] == $b[1]) {
+			return 0;
+		}
+		return ($a[1] < $b[1]) ? -1 : 1;
+	}
+	private function _validate_html($string) {
+		/*
+		 * NOTE: named group requries PHP >= 5.2.2
+		 * libxml and other things are not used
+		 * because they misbehave (IN THIS CASE)
+		 * TODO: looks ugly and inefficient
+		 */
+		$tags_open = $this->_classify_tag($string, '/(?<tag>\<(?<keyword>\w)+.*?\>)/', 'open');
+		$tags_close = $this->_classify_tag($string, '/(?<tag>\<\/(?<keyword>\w)+.*?\>)/', 'close');
+		$tags_self = $this->_classify_tag($string, '/(?<tag>\<(?<keyword>\w)+.*?\/\>)/', 'selfclosing');
+		$tags = array_merge($tags_open, $tags_close, $tags_self);
+		usort($tags, '_sort_by_pos');
+		$stack = array();
+		foreach ($tags as $key => $value) {
+			if ($value[3] == 'open') {
+				array_push($stack, $value[2]);
+				$string = str_replace($value[0], '', $string);
+				continue;
+			}
+			if ($value[3] == 'close') {
+				if (end($stack) == $value[2]) {
+					array_pop($stack);
+					$string = str_replace($value[0], '', $string);
+					continue;
+				}
+			}
+			if ($value[3] == 'selfclosing') {
+				$string = str_replace($value[0], '', $string);
+				continue;
+			}
+		}
+		return empty($stack) && !strpos($string, '<') && !strpos($string, '>');
+	}
 	public function author() {
-		return $this->author === null ? '' : $this->author;
+		$author = $this->author === null ? '' : $this->author;
+		/*
+		 * NOTE: Validate HTML
+		 * because author field is limited to 255 bytes
+		 */
+		$author = $this->_validate_html($author) ? $author : '(Parse error)';
+		return $author;
 	}
 	public function content() {
 		return $this->content;

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -44,6 +44,13 @@ class FreshRSS_Entry extends Minz_Model {
 		return $this->title;
 	}
 	private function _classify_tag($string, $regex, $label) {
+		/*
+		 * NOTE: $tags array structure
+		 * $tags[i] = {[0] = <full tag>,
+		 *             [1] = position,
+		 *             [2] = <tag keyword>,
+		 *             [3] = <label>}
+		 */
 		preg_match_all($regex, $string, $regex_result, PREG_OFFSET_CAPTURE);
 		$tags = $regex_result['tag'];
 		$keywords = $regex_result['keyword'];
@@ -54,6 +61,9 @@ class FreshRSS_Entry extends Minz_Model {
 		return $tags;
 	}
 	private function _sort_by_pos($a, $b) {
+		/*
+		 * Sort $tags by its position
+		 */
 		if ($a[1] == $b[1]) {
 			return 0;
 		}
@@ -63,7 +73,7 @@ class FreshRSS_Entry extends Minz_Model {
 		/*
 		 * NOTE: named group requries PHP >= 5.2.2
 		 * libxml and other things are not used
-		 * because they misbehave (IN THIS CASE)
+		 * because they misbehave (IN THIS SPECIFIC CASE)
 		 * TODO: looks ugly and inefficient
 		 */
 		$tags_open = $this->_classify_tag($string, '/(?<tag>\<(?<keyword>\w)+.*?\>)/', 'open');

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -110,7 +110,7 @@ class FreshRSS_Entry extends Minz_Model {
 		 * TODO: is it safe to hard-code 255?
 		 */
 		if (strlen($author) >= 255) {
-			$author = $this->_validate_html($author) ? $author : '(Parse error)';
+			$author = $this->_validate_html($author) ? $author : _t('gen.error.author');
 		}
 		return $author;
 	}

--- a/app/i18n/cz/gen.php
+++ b/app/i18n/cz/gen.php
@@ -181,4 +181,7 @@ return array(
 		'or' => 'nebo',
 		'yes' => 'Ano',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -182,4 +182,7 @@ return array(
 		'or' => 'oder',
 		'yes' => 'Ja',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -183,4 +183,7 @@ return array(
 		'or' => 'or',
 		'yes' => 'Yes',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.',
+	),
 );

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -182,4 +182,7 @@ return array(
 		'or' => 'ou',
 		'yes' => 'Oui',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -182,4 +182,7 @@ return array(
 		'or' => 'o',
 		'yes' => 'Si',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/kr/gen.php
+++ b/app/i18n/kr/gen.php
@@ -183,4 +183,7 @@ return array(
 		'or' => '또는',
 		'yes' => '네',
 	),
+	'error' => array(
+		'author' => '저자 정보를 올바르게 해석할 수 없습니다.',
+	),
 );

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -182,4 +182,7 @@ return array(
 		'or' => 'of',
 		'yes' => 'Ja',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -182,4 +182,7 @@ return array(
 		'or' => 'or',
 		'yes' => 'Yes',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -182,4 +182,7 @@ return array(
 		'or' => 'ya da',
 		'yes' => 'Evet',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -183,4 +183,7 @@ return array(
 		'or' => '或',
 		'yes' => '是',
 	),
+	'error' => array(
+		'author' => 'Cannot parse author information properly.', // TODO
+	),
 );


### PR DESCRIPTION
Realted Issue: https://github.com/FreshRSS/FreshRSS/issues/1590#issuecomment-313914174

## Summary

Some feeds (e.g., arXiv) include hyperlinks in author fields (`<dc:creator>`). FreshRSS has a limited author field length of 255 bytes. This may make author information to have an invalid HTML format.

## Changes

Before displaying an entry, validate author information, if not, replace it with some warning e.g., *Cannot parse author information properly*

### Before

<img width="1425" alt="2017-07-12 2 55 18" src="https://user-images.githubusercontent.com/6747391/28082618-f00f55b2-66ad-11e7-9d66-797a09e80a06.png">

Other entries are hidden due to malformed author information of 1st entry

<img width="1422" alt="2017-07-12 2 55 27" src="https://user-images.githubusercontent.com/6747391/28082605-e0e0f17c-66ad-11e7-965c-15562da72a3d.png">

When 1st entry is opened, the others appear, but seem broken

### After

<img width="1425" alt="2017-07-12 2 55 46" src="https://user-images.githubusercontent.com/6747391/28082598-dac21d0c-66ad-11e7-8355-bd5a50b8aaec.png">

## Consideration

Changes are made in `Models/Entry.php` and `i18n/*/gen.php`. But I am not sure other users and developers agree with my code style, error handling policy, or something.

## Future work

Validate author information before pushing it to database.