### PR TITLE
commitNewEntries should ignore conflicting keys on migration from ent…

### DIFF
--- a/app/Models/EntryDAOPGSQL.php
+++ b/app/Models/EntryDAOPGSQL.php
@@ -30,7 +30,8 @@ maxrank bigint := (SELECT MAX(id) FROM `' . $this->prefix . 'entrytmp`);
 rank bigint := (SELECT maxrank - COUNT(*) FROM `' . $this->prefix . 'entrytmp`);
 BEGIN
 	INSERT INTO `' . $this->prefix . 'entry` (id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags)
-		(SELECT rank + row_number() OVER(ORDER BY date) AS id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags FROM `' . $this->prefix . 'entrytmp` ORDER BY date);
+		(SELECT rank + row_number() OVER(ORDER BY date) AS id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags FROM `' . $this->prefix . 'entrytmp` ORDER BY date)
+		ON CONFLICT DO NOTHING;
 	DELETE FROM `' . $this->prefix . 'entrytmp` WHERE id <= maxrank;
 END $$;';
 		$hadTransaction = $this->bd->inTransaction();


### PR DESCRIPTION
…rytmp to entry

Fixes #1610 by using PostgreSQL >=9.5 ON CONFLICT feature.