### PR TITLE
commitNewEntries should ignore conflicting keys on migration from ent…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bug fixing
 	* PHP 7.1 compatibility for the API [#1584](https://github.com/FreshRSS/FreshRSS/issues/1584), [#1594](https://github.com/FreshRSS/FreshRSS/pull/1594)
 	* Fix API compatibility bug between PostgreSQL and EasyRSS [#1603](https://github.com/FreshRSS/FreshRSS/pull/1603)
+	* Fix PostgreSQL error when adding new entries [#1610](https://github.com/FreshRSS/FreshRSS/issues/1610), [#1613](https://github.com/FreshRSS/FreshRSS/pull/1613)
 * Misc.
 	* Allow longer database usernames [#1597](https://github.com/FreshRSS/FreshRSS/issues/1597)
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -6,6 +6,7 @@ People are sorted by name so please keep this order.
 
 ---
 
+* [Adrien Dorsaz](https://github.com/Trim): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=Trim), [Web](https://adorsaz.ch/)
 * [Alexandre Alapetite](https://github.com/Alkarex): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=Alkarex), [Web](http://alexandre.alapetite.fr/)
 * [Alexis Degrugillier](https://github.com/aledeg): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=aledeg)
 * [Alwaysin](https://github.com/Alwaysin): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=Alwaysin)

--- a/app/Models/EntryDAOPGSQL.php
+++ b/app/Models/EntryDAOPGSQL.php
@@ -30,7 +30,10 @@ maxrank bigint := (SELECT MAX(id) FROM `' . $this->prefix . 'entrytmp`);
 rank bigint := (SELECT maxrank - COUNT(*) FROM `' . $this->prefix . 'entrytmp`);
 BEGIN
 	INSERT INTO `' . $this->prefix . 'entry` (id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags)
-		(SELECT rank + row_number() OVER(ORDER BY date) AS id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags FROM `' . $this->prefix . 'entrytmp` ORDER BY date);
+		(SELECT rank + row_number() OVER(ORDER BY date) AS id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags
+			FROM `' . $this->prefix . 'entrytmp` AS entrytmp
+			WHERE NOT EXISTS (SELECT 1 FROM `' . $this->prefix . 'entry` AS entry WHERE entrytmp.id_feed = entry.id_feed AND entrytmp.guid = entry.guid)
+			ORDER BY date);
 	DELETE FROM `' . $this->prefix . 'entrytmp` WHERE id <= maxrank;
 END $$;';
 		$hadTransaction = $this->bd->inTransaction();

--- a/app/Models/EntryDAOPGSQL.php
+++ b/app/Models/EntryDAOPGSQL.php
@@ -31,8 +31,8 @@ rank bigint := (SELECT maxrank - COUNT(*) FROM `' . $this->prefix . 'entrytmp`);
 BEGIN
 	INSERT INTO `' . $this->prefix . 'entry` (id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags)
 		(SELECT rank + row_number() OVER(ORDER BY date) AS id, guid, title, author, content, link, date, `lastSeen`, hash, is_read, is_favorite, id_feed, tags
-			FROM `' . $this->prefix . 'entrytmp` AS entrytmp
-			WHERE NOT EXISTS (SELECT 1 FROM `' . $this->prefix . 'entry` AS entry WHERE entrytmp.id_feed = entry.id_feed AND entrytmp.guid = entry.guid)
+			FROM `' . $this->prefix . 'entrytmp` AS etmp
+			WHERE NOT EXISTS (SELECT 1 FROM `' . $this->prefix . 'entry` AS ereal WHERE etmp.id_feed = ereal.id_feed AND etmp.guid = ereal.guid)
 			ORDER BY date);
 	DELETE FROM `' . $this->prefix . 'entrytmp` WHERE id <= maxrank;
 END $$;';


### PR DESCRIPTION
…rytmp to entry

Fixes #1610 by first ignoring all entries from entrytmp which exists
already inside the entry table.