### PR TITLE
Change layout for the share options on mobile

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -835,6 +835,15 @@ input:checked + .slide-container .properties {
 	.no-mobile {
 		display: none;
 	}
+	.dropdown-menu {
+		border-radius: 0 !important;
+		bottom: 0;
+		position: fixed;
+		width: 100%;
+	}
+	.dropdown-menu::after {
+		display: none;
+	}
 	.aside .toggle_aside,
 	.nav-login {
 		display: block;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -835,8 +835,8 @@ input:checked + .slide-container .properties {
 	.no-mobile {
 		display: none;
 	}
-	.dropdown-menu {
-		border-radius: 0 !important;
+	.dropdown .dropdown-menu {
+		border-radius: 0;
 		bottom: 0;
 		position: fixed;
 		width: 100%;


### PR DESCRIPTION
Before, it was impossible to click on links to share on small screens.
Now, all dropdowns are opened at the bottom of the screen and stays there.

Linked to #1506