### PR TITLE
Remove limitation on toggleContent

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -266,11 +266,9 @@ function toggleContent(new_active, old_active) {
 				new_pos += old_scroll;
 			}
 
-			if (old_active[0] !== new_active[0]) {
-				new_active.children(".flux_content").first().each(function () {
-					box_to_move.scrollTop(new_pos).scrollTop();
-				});
-			}
+			new_active.children(".flux_content").first().each(function () {
+				box_to_move.scrollTop(new_pos).scrollTop();
+			});
 		} else {
 			if (relative_move) {
 				new_pos += old_scroll;
@@ -386,13 +384,8 @@ function last_category() {
 }
 
 function collapse_entry() {
-	isCollapsed = !isCollapsed;
-
 	var flux_current = $(".flux.current");
-	flux_current.toggleClass("active");
-	if (isCollapsed && context.auto_mark_article) {
-		mark_read(flux_current, true);
-	}
+	toggleContent(flux_current, flux_current);
 }
 
 function user_filter(key) {


### PR DESCRIPTION
Before, articles were repositioned only when the new and the old article were different. When they were the same, it was just closed.
It was frustrating with long articles, especially during reading.

Now, when an article is collapsed, it is repositionned no matter the collapsing method.

This should fix #1177