### PR TITLE
Call idn_to_ascii with INTL_IDNA_VARIANT_UTS46

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,6 +13,7 @@ People are sorted by name so please keep this order.
 * [Amaury Carrade](https://github.com/AmauryCarrade): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=AmauryCarrade), [Web](https://amaury.carrade.eu/)
 * [Anton Smirnov](https://github.com/sandfoxme): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:sandfoxme), [Web](http://sandfox.me/)
 * [ASMfreaK](https://github.com/ASMfreaK): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=ASMfreaK)
+* [Craig Andrews](https://github.com/candrews): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:candrews), [Web](http://candrews.integralblue.com/)
 * [Crupuk](https://github.com/Crupuk): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Crupuk)
 * [Damstre](https://github.com/Damstre): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Damstre)
 * [danc](https://github.com/danc): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=danc), [Web](http://tintouli.free.fr/)

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -68,7 +68,6 @@ function idn_to_puny($url) {
 			} else {
 				$puny = idn_to_ascii($idn);
 			}
-			$puny = idn_to_ascii($idn);
 			$pos = strpos($url, $idn);
 			if ($pos !== false) {
 				return substr_replace($url, $puny, $pos, strlen($idn));

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -62,6 +62,12 @@ function idn_to_puny($url) {
 		$parts = parse_url($url);
 		if (!empty($parts['host'])) {
 			$idn = $parts['host'];
+			// INTL_IDNA_VARIANT_UTS46 is defined starting in PHP 5.4
+			if (defined('INTL_IDNA_VARIANT_UTS46')) {
+				$puny = idn_to_ascii($idn, 0, INTL_IDNA_VARIANT_UTS46);
+			} else {
+				$puny = idn_to_ascii($idn);
+			}
 			$puny = idn_to_ascii($idn);
 			$pos = strpos($url, $idn);
 			if ($pos !== false) {


### PR DESCRIPTION
Under PHP 7.2, calling `idn_to_ascii($idn)` results in a deprecation warning: 'INTL_IDNA_VARIANT_2003 is deprecated'
See https://secure.php.net/manual/en/function.idn-to-ascii.php 

Therefore, if possible, `idn_to_ascii($idn, 0, INTL_IDNA_VARIANT_UTS46)` should be used instead. `INTL_IDNA_VARIANT_UTS46` was introduced in PHP 5.4, so on versions before that, `idn_to_ascii($idn)` must still be used.

Fixed #1699