### PR TITLE
Update panel shows latest version message as success

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -102,7 +102,7 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 				$version = 'git';
 			} else {
 				$this->view->message = array(
-					'status' => 'bad',
+					'status' => 'latest',
 					'title' => _t('gen.short.damn'),
 					'body' => _t('feedback.update.none')
 				);
@@ -138,7 +138,7 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 			$status = $res_array[0];
 			if (strpos($status, 'UPDATE') !== 0) {
 				$this->view->message = array(
-					'status' => 'bad',
+					'status' => 'latest',
 					'title' => _t('gen.short.damn'),
 					'body' => _t('feedback.update.none')
 				);

--- a/app/views/update/index.phtml
+++ b/app/views/update/index.phtml
@@ -14,7 +14,21 @@
 	</p>
 
 	<?php if (!empty($this->message)) { ?>
-	<p class="alert <?php echo $this->message['status'] === 'bad' ? 'alert-error' : 'alert-warn'; ?>">
+    <?php
+        $class = 'alert-warn';
+        switch ($this->message['status']) {
+            case 'bad':
+                $class = 'alert-error';
+                break;
+            case 'latest':
+                $class = 'alert-success';
+                break;
+            default:
+                $class = 'alert-warn';
+                break;
+        }
+    ?>
+	<p class="alert <?php echo $class; ?>">
 		<span class="alert-head"><?php echo $this->message['title']; ?></span>
 		<?php echo $this->message['body']; ?>
 	</p>

--- a/app/views/update/index.phtml
+++ b/app/views/update/index.phtml
@@ -14,20 +14,20 @@
 	</p>
 
 	<?php if (!empty($this->message)) { ?>
-    <?php
-        $class = 'alert-warn';
-        switch ($this->message['status']) {
-            case 'bad':
-                $class = 'alert-error';
-                break;
-            case 'latest':
-                $class = 'alert-success';
-                break;
-            default:
-                $class = 'alert-warn';
-                break;
-        }
-    ?>
+	<?php
+		$class = 'alert-warn';
+		switch ($this->message['status']) {
+		case 'bad':
+			$class = 'alert-error';
+			break;
+		case 'latest':
+			$class = 'alert-success';
+			break;
+		default:
+			$class = 'alert-warn';
+			break;
+		}
+	?>
 	<p class="alert <?php echo $class; ?>">
 		<span class="alert-head"><?php echo $this->message['title']; ?></span>
 		<?php echo $this->message['body']; ?>


### PR DESCRIPTION
This PR changes the display of the "you are running the latest version" message.

Currently it shows that message as "alert-error" which was not only irritating to me, see also #1586.
My PR changes that message to "alert-success" to indicate a positive state. 

FIXES #1586

Further enhancement idea:
Change the wording from "Blast! No update to apply" to "Congratulations, you are running the latest version" - IMO its always better to give a positive message, but thats not part of this PR.

