### PR TITLE
Show existing extensions in admin panel

### DIFF
--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -25,13 +25,17 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 			'user' => array(),
 		);
 
+		$this->view->extensions_installed = array();
+
 		$extensions = Minz_ExtensionManager::listExtensions();
 		foreach ($extensions as $ext) {
 			$this->view->extension_list[$ext->getType()][] = $ext;
+            $this->view->extensions_installed[$ext->getEntrypoint()] = $ext->getVersion();
 		}
 
         $availableExtensions = $this->getAvailableExtensionList();
         $this->view->available_extensions = $availableExtensions;
+
     }
 
     /**
@@ -44,7 +48,7 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
         $list = json_decode($json, true);
 
         if (empty($list)) {
-            return [];
+            return array();
         }
 
         // we could use that for comparing and caching later

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -29,7 +29,35 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 		foreach ($extensions as $ext) {
 			$this->view->extension_list[$ext->getType()][] = $ext;
 		}
-	}
+
+        $availableExtensions = $this->getAvailableExtensionList();
+        $this->view->available_extensions = $availableExtensions;
+    }
+
+    /**
+     * fetch extension list from GitHub
+     */
+    protected function getAvailableExtensionList()
+    {
+        $extensionListUrl = 'https://raw.githubusercontent.com/kevinpapst/Extensions/extension-list/extensions.json';
+        $json = file_get_contents($extensionListUrl);
+        $list = json_decode($json, true);
+
+        if (empty($list)) {
+            return [];
+        }
+
+        // we could use that for comparing and caching later
+        $version = $list['version'];
+
+        // By now, all the needed data is kept in the main extension file.
+        // In the future we could fetch detail information from the extensions metadata.json, but I tend to stick wit
+        // the current implementation for now, unless it becomes to much effort maintain the extension list manually
+        $extensions = $list['extensions'];
+
+        return $extensions;
+    }
+
 
 	/**
 	 * This action handles configuration of a given extension.

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -30,12 +30,11 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 		$extensions = Minz_ExtensionManager::listExtensions();
 		foreach ($extensions as $ext) {
 			$this->view->extension_list[$ext->getType()][] = $ext;
-            $this->view->extensions_installed[$ext->getEntrypoint()] = $ext->getVersion();
+			$this->view->extensions_installed[$ext->getEntrypoint()] = $ext->getVersion();
 		}
 
         $availableExtensions = $this->getAvailableExtensionList();
         $this->view->available_extensions = $availableExtensions;
-
     }
 
     /**
@@ -45,9 +44,17 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
     {
         $extensionListUrl = 'https://raw.githubusercontent.com/kevinpapst/Extensions/extension-list/extensions.json';
         $json = file_get_contents($extensionListUrl);
-        $list = json_decode($json, true);
 
+        // we ran into problems, simply ignore them
+        if ($json === false) {
+			Minz_Log::error('Could not fetch available extension from GitHub');
+			return array();
+		}
+
+		// fetch the list as an array
+        $list = json_decode($json, true);
         if (empty($list)) {
+			Minz_Log::warning('Failed to convert extension file list');
             return array();
         }
 
@@ -55,8 +62,8 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
         $version = $list['version'];
 
         // By now, all the needed data is kept in the main extension file.
-        // In the future we could fetch detail information from the extensions metadata.json, but I tend to stick wit
-        // the current implementation for now, unless it becomes to much effort maintain the extension list manually
+        // In the future we could fetch detail information from the extensions metadata.json, but I tend to stick with
+        // the current implementation for now, unless it becomes too much effort maintain the extension list manually
         $extensions = $list['extensions'];
 
         return $extensions;

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -33,42 +33,41 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 			$this->view->extensions_installed[$ext->getEntrypoint()] = $ext->getVersion();
 		}
 
-        $availableExtensions = $this->getAvailableExtensionList();
-        $this->view->available_extensions = $availableExtensions;
+		$availableExtensions = $this->getAvailableExtensionList();
+		$this->view->available_extensions = $availableExtensions;
     }
 
-    /**
-     * fetch extension list from GitHub
-     */
-    protected function getAvailableExtensionList()
-    {
-        $extensionListUrl = 'https://raw.githubusercontent.com/kevinpapst/Extensions/extension-list/extensions.json';
-        $json = file_get_contents($extensionListUrl);
+	/**
+	 * fetch extension list from GitHub
+	 */
+	protected function getAvailableExtensionList()
+	{
+		$extensionListUrl = 'https://raw.githubusercontent.com/kevinpapst/Extensions/extension-list/extensions.json';
+		$json = file_get_contents($extensionListUrl);
 
-        // we ran into problems, simply ignore them
-        if ($json === false) {
+		// we ran into problems, simply ignore them
+		if ($json === false) {
 			Minz_Log::error('Could not fetch available extension from GitHub');
 			return array();
 		}
 
 		// fetch the list as an array
-        $list = json_decode($json, true);
-        if (empty($list)) {
+		$list = json_decode($json, true);
+		if (empty($list)) {
 			Minz_Log::warning('Failed to convert extension file list');
-            return array();
-        }
+			return array();
+		}
 
-        // we could use that for comparing and caching later
-        $version = $list['version'];
+		// we could use that for comparing and caching later
+		$version = $list['version'];
 
-        // By now, all the needed data is kept in the main extension file.
-        // In the future we could fetch detail information from the extensions metadata.json, but I tend to stick with
-        // the current implementation for now, unless it becomes too much effort maintain the extension list manually
-        $extensions = $list['extensions'];
+		// By now, all the needed data is kept in the main extension file.
+		// In the future we could fetch detail information from the extensions metadata.json, but I tend to stick with
+		// the current implementation for now, unless it becomes too much effort maintain the extension list manually
+		$extensions = $list['extensions'];
 
-        return $extensions;
-    }
-
+		return $extensions;
+	}
 
 	/**
 	 * This action handles configuration of a given extension.

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -41,7 +41,7 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 	 * fetch extension list from GitHub
 	 */
 	protected function getAvailableExtensionList() {
-		$extensionListUrl = 'https://raw.githubusercontent.com/kevinpapst/Extensions/extension-list/extensions.json';
+		$extensionListUrl = 'https://raw.githubusercontent.com/FreshRSS/Extensions/master/extensions.json';
 		$json = file_get_contents($extensionListUrl);
 
 		// we ran into problems, simply ignore them

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -35,13 +35,12 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 
 		$availableExtensions = $this->getAvailableExtensionList();
 		$this->view->available_extensions = $availableExtensions;
-    }
+	}
 
 	/**
 	 * fetch extension list from GitHub
 	 */
-	protected function getAvailableExtensionList()
-	{
+	protected function getAvailableExtensionList() {
 		$extensionListUrl = 'https://raw.githubusercontent.com/kevinpapst/Extensions/extension-list/extensions.json';
 		$json = file_get_contents($extensionListUrl);
 

--- a/app/i18n/cz/admin.php
+++ b/app/i18n/cz/admin.php
@@ -155,7 +155,7 @@ return array(
 			'help' => '0 znamená žádná omezení účtu',
 			'number' => 'Maximální počet účtů',
 		),
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/cz/admin.php
+++ b/app/i18n/cz/admin.php
@@ -155,6 +155,13 @@ return array(
 			'help' => '0 znamená žádná omezení účtu',
 			'number' => 'Maximální počet účtů',
 		),
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'update' => array(
 		'_' => 'Aktualizace systému',

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Erweiterungen',
 		'user' => 'Benutzer-Erweiterungen',
-		'community' => 'Verfügbare Community Erweiterungen zum Download',
+		'community' => 'Verfügbare Community Erweiterungen',
 		'name' => 'Name',
 		'version' => 'Version',
 		'description' => 'Beschreibungen',

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Erweiterungen',
 		'user' => 'Benutzer-Erweiterungen',
+		'community' => 'Verfügbare Community Erweiterungen zum Download',
+		'name' => 'Name',
+		'version' => 'Version',
+		'description' => 'Beschreibungen',
+		'author' => 'Autor',
+		'latest' => 'Installiert',
+		'update' => 'Update verfügbar',
 	),
 	'stats' => array(
 		'_' => 'Statistiken',

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -112,13 +112,13 @@ return array(
 		),
 		'title' => 'Extensions',
 		'user' => 'User extensions',
-        'community' => 'Available community extensions for download',
-        'name' => 'Name',
-        'version' => 'Version',
-        'description' => 'Description',
-        'author' => 'Author',
-        'latest' => 'Installed',
-        'update' => 'Update available'
+		'community' => 'Available community extensions for download',
+		'name' => 'Name',
+		'version' => 'Version',
+		'description' => 'Description',
+		'author' => 'Author',
+		'latest' => 'Installed',
+		'update' => 'Update available'
 	),
 	'stats' => array(
 		'_' => 'Statistics',

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Extensions',
 		'user' => 'User extensions',
-		'community' => 'Available community extensions for download',
+		'community' => 'Available community extensions',
 		'name' => 'Name',
 		'version' => 'Version',
 		'description' => 'Description',

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -112,6 +112,11 @@ return array(
 		),
 		'title' => 'Extensions',
 		'user' => 'User extensions',
+        'community' => 'Available community extensions for download',
+        'name' => 'Name',
+        'version' => 'Version',
+        'description' => 'Description',
+        'author' => 'Author',
 	),
 	'stats' => array(
 		'_' => 'Statistics',

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -117,6 +117,8 @@ return array(
         'version' => 'Version',
         'description' => 'Description',
         'author' => 'Author',
+        'latest' => 'Installed',
+        'update' => 'Update available'
 	),
 	'stats' => array(
 		'_' => 'Statistics',

--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Extensiones',
 		'user' => 'Extensiones de usuario',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'Estadísticas',

--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Extensiones',
 		'user' => 'Extensiones de usuario',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -103,22 +103,22 @@ return array(
 	),
 	'extensions' => array(
 		'disabled' => 'Désactivée',
-		'empty_list' => 'Il n’y a aucune extension installée.',
+		'empty_list' => 'Aucune extension installée',
 		'enabled' => 'Activée',
-		'no_configure_view' => 'Cette extension ne peut pas être configurée.',
+		'no_configure_view' => 'Cette extension n’a pas à être configurée',
 		'system' => array(
 			'_' => 'Extensions système',
-			'no_rights' => 'Extension système (vous n’avez aucun droit dessus)',
+			'no_rights' => 'Extensions système (contrôlées par l’administrateur)',
 		),
 		'title' => 'Extensions',
 		'user' => 'Extensions utilisateur',
-		'community' => 'Extensions utilisateur disponibles', // @todo translate
-		'name' => 'Nom', // @todo translate
-		'version' => 'Version', // @todo translate
-		'description' => 'Description', // @todo translate
-		'author' => 'Author', // @todo translate
-		'latest' => 'Installed', // @todo translate
-		'update' => 'Update available', // @todo translate
+		'community' => 'Extensions utilisateur disponibles',
+		'name' => 'Nom',
+		'version' => 'Version',
+		'description' => 'Description',
+		'author' => 'Auteur',
+		'latest' => 'Installée',
+		'update' => 'Mise à jour disponible',
 	),
 	'stats' => array(
 		'_' => 'Statistiques',

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Extensions',
 		'user' => 'Extensions utilisateur',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'Statistiques',

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -112,8 +112,8 @@ return array(
 		),
 		'title' => 'Extensions',
 		'user' => 'Extensions utilisateur',
-		'community' => 'Available community extensions for download', // @todo translate
-		'name' => 'Name', // @todo translate
+		'community' => 'Extensions utilisateur disponibles', // @todo translate
+		'name' => 'Nom', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate
 		'author' => 'Author', // @todo translate

--- a/app/i18n/it/admin.php
+++ b/app/i18n/it/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Estensioni',
 		'user' => 'Estensioni utente',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'Statistiche',

--- a/app/i18n/it/admin.php
+++ b/app/i18n/it/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Estensioni',
 		'user' => 'Estensioni utente',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/kr/admin.php
+++ b/app/i18n/kr/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => '확장 기능',
 		'user' => '사용자 확장 기능',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/kr/admin.php
+++ b/app/i18n/kr/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => '확장 기능',
 		'user' => '사용자 확장 기능',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => '통계',

--- a/app/i18n/nl/admin.php
+++ b/app/i18n/nl/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Uitbreidingen',
 		'user' => 'Gebruikersuitbreidingen',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'Statistieken',

--- a/app/i18n/nl/admin.php
+++ b/app/i18n/nl/admin.php
@@ -112,13 +112,13 @@ return array(
 		),
 		'title' => 'Uitbreidingen',
 		'user' => 'Gebruikersuitbreidingen',
-		'community' => 'Available community extensions for download', // @todo translate
-		'name' => 'Name', // @todo translate
-		'version' => 'Version', // @todo translate
-		'description' => 'Description', // @todo translate
-		'author' => 'Author', // @todo translate
-		'latest' => 'Installed', // @todo translate
-		'update' => 'Update available', // @todo translate
+		'community' => 'Gebruikersuitbreidingen beschikbaar voor download',
+		'name' => 'Naam',
+		'version' => 'Versie',
+		'description' => 'Beschrijving',
+		'author' => 'Auteur',
+		'latest' => 'Geïnstalleerd',
+		'update' => 'Update beschikbaar',
 	),
 	'stats' => array(
 		'_' => 'Statistieken',

--- a/app/i18n/nl/admin.php
+++ b/app/i18n/nl/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Uitbreidingen',
 		'user' => 'Gebruikersuitbreidingen',
-		'community' => 'Gebruikersuitbreidingen beschikbaar voor download',
+		'community' => 'Gebruikersuitbreidingen beschikbaar',
 		'name' => 'Naam',
 		'version' => 'Versie',
 		'description' => 'Beschrijving',

--- a/app/i18n/pt-br/admin.php
+++ b/app/i18n/pt-br/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Extensões',
 		'user' => 'Extensões do usuário',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'Estatísticas',

--- a/app/i18n/pt-br/admin.php
+++ b/app/i18n/pt-br/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Extensões',
 		'user' => 'Extensões do usuário',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/ru/admin.php
+++ b/app/i18n/ru/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Расширения',
 		'user' => 'Расширения пользователя',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'Статистика',

--- a/app/i18n/ru/admin.php
+++ b/app/i18n/ru/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Расширения',
 		'user' => 'Расширения пользователя',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/tr/admin.php
+++ b/app/i18n/tr/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => 'Eklentiler',
 		'user' => 'Kullanıcı eklentileri',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/i18n/tr/admin.php
+++ b/app/i18n/tr/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => 'Eklentiler',
 		'user' => 'Kullanıcı eklentileri',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => 'İstatistikler',

--- a/app/i18n/zh-cn/admin.php
+++ b/app/i18n/zh-cn/admin.php
@@ -112,6 +112,13 @@ return array(
 		),
 		'title' => '扩展',
 		'user' => '用户扩展',
+		'community' => 'Available community extensions for download', // @todo translate
+		'name' => 'Name', // @todo translate
+		'version' => 'Version', // @todo translate
+		'description' => 'Description', // @todo translate
+		'author' => 'Author', // @todo translate
+		'latest' => 'Installed', // @todo translate
+		'update' => 'Update available', // @todo translate
 	),
 	'stats' => array(
 		'_' => '统计',

--- a/app/i18n/zh-cn/admin.php
+++ b/app/i18n/zh-cn/admin.php
@@ -112,7 +112,7 @@ return array(
 		),
 		'title' => '扩展',
 		'user' => '用户扩展',
-		'community' => 'Available community extensions for download', // @todo translate
+		'community' => 'Available community extensions', // @todo translate
 		'name' => 'Name', // @todo translate
 		'version' => 'Version', // @todo translate
 		'description' => 'Description', // @todo translate

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -26,15 +26,15 @@
 		}
 	?>
 	<?php
-		}
+	}
 
-		if (empty($this->extension_list['system']) && empty($this->extension_list['user'])) {
+	if (empty($this->extension_list['system']) && empty($this->extension_list['user'])) {
 	?>
 	<p class="alert alert-warn"><?php echo _t('admin.extensions.empty_list'); ?></p>
 	<?php } ?>
 	</form>
 
-    <?php if (!empty($this->available_extensions)) { ?>
+	<?php if (!empty($this->available_extensions)) { ?>
 		<h2><?php echo _t('admin.extensions.community'); ?></h2>
 		<table>
 			<tr>
@@ -43,29 +43,29 @@
 				<th><?php echo _t('admin.extensions.author'); ?></th>
 				<th><?php echo _t('admin.extensions.description'); ?></th>
 			</tr>
-        	<?php foreach ($this->available_extensions as $ext) { ?>
-			<tr>
-				<td><a href="<?php echo $ext['url']; ?>" target="_blank"><?php echo $ext['name']; ?></a></td>
-				<td><?php echo $ext['version']; ?></td>
-				<td><?php echo $ext['author']; ?></td>
-				<td>
-					<?php echo $ext['description']; ?>
-                    <?php if (isset($this->extensions_installed[$ext['name']])) { ?>
-                        <?php if ($this->extensions_installed[$ext['name']] == $ext['version']) { ?>
-							<span class="alert alert-success">
-								<?php echo _t('admin.extensions.latest'); ?>
-							</span>
-                        <?php } else if ($this->extensions_installed[$ext['name']] != $ext['version']) { ?>
-							<span class="alert alert-warn">
-								<?php echo _t('admin.extensions.update'); ?>
-							</span>
+			<?php foreach ($this->available_extensions as $ext) { ?>
+				<tr>
+					<td><a href="<?php echo $ext['url']; ?>" target="_blank"><?php echo $ext['name']; ?></a></td>
+					<td><?php echo $ext['version']; ?></td>
+					<td><?php echo $ext['author']; ?></td>
+					<td>
+						<?php echo $ext['description']; ?>
+						<?php if (isset($this->extensions_installed[$ext['name']])) { ?>
+							<?php if ($this->extensions_installed[$ext['name']] == $ext['version']) { ?>
+								<span class="alert alert-success">
+									<?php echo _t('admin.extensions.latest'); ?>
+								</span>
+							<?php } else  if ($this->extensions_installed[$ext['name']] != $ext['version']) { ?>
+								<span class="alert alert-warn">
+									<?php echo _t('admin.extensions.update'); ?>
+								</span>
+							<?php } ?>
 						<?php } ?>
-                    <?php } ?>
-				</td>
-			</tr>
-        	<?php } ?>
+					</td>
+				</tr>
+			<?php } ?>
 		</table>
-    <?php } ?>
+	<?php } ?>
 </div>
 
 <?php $class = isset($this->extension) ? ' class="active"' : ''; ?>

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -51,7 +51,7 @@
 					<td>
 						<?php echo $ext['description']; ?>
 						<?php if (isset($this->extensions_installed[$ext['name']])) { ?>
-							<?php if ($this->extensions_installed[$ext['name']] == $ext['version']) { ?>
+							<?php if (version_compare($this->extensions_installed[$ext['name']], $ext['version']) >= 0) { ?>
 								<span class="alert alert-success">
 									<?php echo _t('admin.extensions.latest'); ?>
 								</span>

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -33,6 +33,26 @@
 	<p class="alert alert-warn"><?php echo _t('admin.extensions.empty_list'); ?></p>
 	<?php } ?>
 	</form>
+
+    <?php if (!empty($this->available_extensions)) { ?>
+		<h2><?php echo _t('admin.extensions.community'); ?></h2>
+		<table>
+			<tr>
+				<th><?php echo _t('admin.extensions.name'); ?></th>
+				<th><?php echo _t('admin.extensions.version'); ?></th>
+				<th><?php echo _t('admin.extensions.author'); ?></th>
+				<th><?php echo _t('admin.extensions.description'); ?></th>
+			</tr>
+        	<?php foreach ($this->available_extensions as $ext) { ?>
+			<tr>
+				<td><a href="<?php echo $ext['url']; ?>" target="_blank"><?php echo $ext['name']; ?></a></td>
+				<td><?php echo $ext['version']; ?></td>
+				<td><?php echo $ext['author']; ?></td>
+				<td><?php echo $ext['description']; ?></td>
+			</tr>
+        	<?php } ?>
+		</table>
+    <?php } ?>
 </div>
 
 <?php $class = isset($this->extension) ? ' class="active"' : ''; ?>

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -48,7 +48,20 @@
 				<td><a href="<?php echo $ext['url']; ?>" target="_blank"><?php echo $ext['name']; ?></a></td>
 				<td><?php echo $ext['version']; ?></td>
 				<td><?php echo $ext['author']; ?></td>
-				<td><?php echo $ext['description']; ?></td>
+				<td>
+					<?php echo $ext['description']; ?>
+                    <?php if (isset($this->extensions_installed[$ext['name']])) { ?>
+                        <?php if ($this->extensions_installed[$ext['name']] == $ext['version']) { ?>
+							<span class="alert alert-success">
+								<?php echo _t('admin.extensions.latest'); ?>
+							</span>
+                        <?php } else if ($this->extensions_installed[$ext['name']] != $ext['version']) { ?>
+							<span class="alert alert-warn">
+								<?php echo _t('admin.extensions.update'); ?>
+							</span>
+						<?php } ?>
+                    <?php } ?>
+				</td>
 			</tr>
         	<?php } ?>
 		</table>


### PR DESCRIPTION
Hi guys,

I thought about promoting the extensions feature more, so we get the community not only better informed about existing extension but also in the hope that new people sit down and add more.

First, how does it look like:
<img width="1600" alt="bildschirmfoto 2017-12-03 um 16 11 24" src="https://user-images.githubusercontent.com/533162/33526680-0234232c-d845-11e7-8cec-34925409408c.png">

What it does:
Currently it fetches a json file from the extensions repo, so all extensions need to be added there manually. It will list all extensions in the admin-extension flyout and compare them with the installed ones, also showing if there is an update.

There is a lot of future improvement possible, for example:
- caching the packages file, so it doesn't get fetched on every flyout load
- we could add one-click installation
- probably fetching the data dynamically instead of hard-coding it in the packages file (but thats not necessary unless we have dozens of extensions)

This pull request is only a first proposal to start a discussion, I know that there are improvements necessary:
- whitespace vs tabs issues
- currently only english translation
- error handling missing for the file load