### PR TITLE
Added extension hook for reading modes

### DIFF
--- a/app/Models/ReadingMode.php
+++ b/app/Models/ReadingMode.php
@@ -107,7 +107,7 @@ class FreshRSS_ReadingMode {
 	public static function getReadingModes() {
 		$actualView = Minz_Request::actionName();
 		$defaultCtrl = Minz_Request::defaultControllerName();
-		$isDefaultCtrl = Minz_Request::controllerName() == $defaultCtrl;
+		$isDefaultCtrl = Minz_Request::controllerName() === $defaultCtrl;
 		$urlOutput = Minz_Request::currentRequest();
 
 		$readingModes = array(

--- a/app/Models/ReadingMode.php
+++ b/app/Models/ReadingMode.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Manage the reading modes in FreshRSS.
+ */
+class FreshRSS_ReadingMode {
+
+	/**
+	 * @var string
+	 */
+	protected $name;
+	/**
+	 * @var string
+	 */
+	protected $title;
+	/**
+	 * @var string[]
+	 */
+	protected $urlParams;
+	/**
+	 * @var bool
+	 */
+	protected $isActive = false;
+
+	/**
+	 * ReadingMode constructor.
+	 * @param string $name
+	 * @param string $title
+	 * @param string[] $urlParams
+	 * @param bool $active
+	 */
+	public function __construct($name, $title, $urlParams, $active) {
+		$this->name = $name;
+		$this->title = $title;
+		$this->urlParams = $urlParams;
+		$this->isActive = $active;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * @return FreshRSS_ReadingMode
+	 */
+	public function setName($name) {
+		$this->name = $name;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTitle() {
+		return $this->title;
+	}
+
+	/**
+	 * @param string $title
+	 * @return FreshRSS_ReadingMode
+	 */
+	public function setTitle($title) {
+		$this->title = $title;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getUrlParams() {
+		return $this->urlParams;
+	}
+
+	/**
+	 * @param string $urlParams
+	 * @return FreshRSS_ReadingMode
+	 */
+	public function setUrlParams($urlParams) {
+		$this->urlParams = $urlParams;
+		return $this;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isActive() {
+		return $this->isActive;
+	}
+
+	/**
+	 * @param bool $isActive
+	 * @return FreshRSS_ReadingMode
+	 */
+	public function setIsActive($isActive) {
+		$this->isActive = $isActive;
+		return $this;
+	}
+
+	/**
+	 * Returns the built-in reading modes.
+	 * return ReadingMode[]
+	 */
+	public static function getReadingModes() {
+		$actualView = Minz_Request::actionName();
+		$defaultCtrl = Minz_Request::defaultControllerName();
+		$isDefaultCtrl = Minz_Request::controllerName() == $defaultCtrl;
+		$urlOutput = Minz_Request::currentRequest();
+
+		$readingModes = array(
+			new FreshRSS_ReadingMode(
+				_i("view-normal"),
+				_t('index.menu.normal_view'),
+				array_merge($urlOutput, array('c' => $defaultCtrl, 'a' => 'normal')),
+				($isDefaultCtrl && $actualView === 'normal')
+			),
+			new FreshRSS_ReadingMode(
+				_i("view-global"),
+				_t('index.menu.global_view'),
+				array_merge($urlOutput, array('c' => $defaultCtrl, 'a' => 'global')),
+				($isDefaultCtrl && $actualView === 'global')
+			),
+			new FreshRSS_ReadingMode(
+				_i("view-reader"),
+				_t('index.menu.reader_view'),
+				array_merge($urlOutput, array('c' => $defaultCtrl, 'a' => 'reader')),
+				($isDefaultCtrl && $actualView === 'reader')
+			),
+		);
+
+		return $readingModes;
+	}
+}

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -136,7 +136,7 @@
 		$readingModes = Minz_ExtensionManager::callHook('nav_reading_modes', $readingModes);
 
 		/** @var FreshRSS_ReadingMode $mode */
-		foreach($readingModes as $mode) {
+		foreach ($readingModes as $mode) {
 			?>
 			<a class="view_normal btn <?php if ($mode->isActive()) { echo 'active'; } ?>" title="<?php echo $mode->getTitle(); ?>" href="<?php echo Minz_Url::display($mode->getUrlParams()); ?>">
 				<?php echo $mode->getName(); ?>

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -132,36 +132,17 @@
 	<?php $url_output = Minz_Request::currentRequest(); ?>
 	<div class="stick" id="nav_menu_views">
 		<?php
-		$readingModes = array(
-			'normal' => array(
-				'name' => _i("view-normal"),
-				'title' => _t('index.menu.normal_view'),
-				'url' => array_merge($url_output, array('c' => Minz_Request::defaultControllerName(), 'a' => 'normal')),
-				'active' => (Minz_Request::controllerName() == Minz_Request::defaultControllerName() && $actual_view == 'normal'),
-			),
-			'global' => array(
-				'name' => _i("view-global"),
-				'title' => _t('index.menu.global_view'),
-				'url' => array_merge($url_output, array('c' => Minz_Request::defaultControllerName(), 'a' => 'global')),
-				'active' => (Minz_Request::controllerName() == Minz_Request::defaultControllerName() && $actual_view == 'global'),
-			),
-			'reader' => array(
-				'name' => _i("view-reader"),
-				'title' => _t('index.menu.reader_view'),
-				'url' => array_merge($url_output, array('c' => Minz_Request::defaultControllerName(), 'a' => 'reader')),
-				'active' => (Minz_Request::controllerName() == Minz_Request::defaultControllerName() && $actual_view == 'reader'),
-			),
-		);
-
+		$readingModes = FreshRSS_ReadingMode::getReadingModes();
 		$readingModes = Minz_ExtensionManager::callHook('nav_reading_modes', $readingModes);
 
-		foreach($readingModes as $key => $mode) {
-				?>
-				<a class="view_normal btn <?php if ($mode['active']) { echo 'active'; } ?>" title="<?php echo $mode['title']; ?>" href="<?php echo Minz_Url::display($mode['url']); ?>">
-					<?php echo $mode['name']; ?>
-				</a>
-				<?php
-			}
+		/** @var FreshRSS_ReadingMode $mode */
+		foreach($readingModes as $mode) {
+			?>
+			<a class="view_normal btn <?php if ($mode->isActive()) { echo 'active'; } ?>" title="<?php echo $mode->getTitle(); ?>" href="<?php echo Minz_Url::display($mode->getUrlParams()); ?>">
+				<?php echo $mode->getName(); ?>
+			</a>
+			<?php
+		}
 		?>
 
 		<?php

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -131,20 +131,38 @@
 
 	<?php $url_output = Minz_Request::currentRequest(); ?>
 	<div class="stick" id="nav_menu_views">
-		<?php $url_output['a'] = 'normal'; ?>
-		<a class="view_normal btn <?php echo $actual_view == 'normal'? 'active' : ''; ?>" title="<?php echo _t('index.menu.normal_view'); ?>" href="<?php echo Minz_Url::display($url_output); ?>">
-			<?php echo _i("view-normal"); ?>
-		</a>
+		<?php
+		$readingModes = array(
+			'normal' => array(
+				'name' => _i("view-normal"),
+				'title' => _t('index.menu.normal_view'),
+				'url' => array_merge($url_output, array('c' => Minz_Request::defaultControllerName(), 'a' => 'normal')),
+				'active' => (Minz_Request::controllerName() == Minz_Request::defaultControllerName() && $actual_view == 'normal'),
+			),
+			'global' => array(
+				'name' => _i("view-global"),
+				'title' => _t('index.menu.global_view'),
+				'url' => array_merge($url_output, array('c' => Minz_Request::defaultControllerName(), 'a' => 'global')),
+				'active' => (Minz_Request::controllerName() == Minz_Request::defaultControllerName() && $actual_view == 'global'),
+			),
+			'reader' => array(
+				'name' => _i("view-reader"),
+				'title' => _t('index.menu.reader_view'),
+				'url' => array_merge($url_output, array('c' => Minz_Request::defaultControllerName(), 'a' => 'reader')),
+				'active' => (Minz_Request::controllerName() == Minz_Request::defaultControllerName() && $actual_view == 'reader'),
+			),
+		);
 
-		<?php $url_output['a'] = 'global'; ?>
-		<a class="view_global btn <?php echo $actual_view == 'global'? 'active' : ''; ?>" title="<?php echo _t('index.menu.global_view'); ?>" href="<?php echo Minz_Url::display($url_output); ?>">
-			<?php echo _i("view-global"); ?>
-		</a>
+		$readingModes = Minz_ExtensionManager::callHook('nav_reading_modes', $readingModes);
 
-		<?php $url_output['a'] = 'reader'; ?>
-		<a class="view_reader btn <?php echo $actual_view == 'reader'? 'active' : ''; ?>" title="<?php echo _t('index.menu.reader_view'); ?>" href="<?php echo Minz_Url::display($url_output); ?>">
-			<?php echo _i("view-reader"); ?>
-		</a>
+		foreach($readingModes as $key => $mode) {
+				?>
+				<a class="view_normal btn <?php if ($mode['active']) { echo 'active'; } ?>" title="<?php echo $mode['title']; ?>" href="<?php echo Minz_Url::display($mode['url']); ?>">
+					<?php echo $mode['name']; ?>
+				</a>
+				<?php
+			}
+		?>
 
 		<?php
 			$url_output['a'] = 'rss';

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -31,6 +31,10 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'NoneToNone',
 		),
+		'nav_reading_modes' => array(  // function($readingModes = array) -> array | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
 	);
 	private static $ext_to_hooks = array();
 


### PR DESCRIPTION
I am currently working on a full-fledged extension, which uses its own controllers and views.

Problem is: I cannot route the user to the page (controller/action) that I want him to see as there is currently no way of displaying additional links in the main UI.

To achieve my goal, I refactored the reading modes to be a simple array structure which gets injected into the hook. Extensions can then work on that navigation structure like that:

```
class MyExtension extends Minz_Extension
{
    public function init() {
	$this->registerHook('nav_reading_modes', array($this, 'addReadingModeToMenu'));
    }

    public function addReadingModeToMenu($menu) {
    	$request = Minz_Request::currentRequest();
	$menu[] = new FreshRSS_ReadingMode(
		'example',
		'example title',
		array_merge($request, array('c' => 'my', 'a' => 'any')),
		($request['c'] == 'my' && $request['a'] == 'any')
	);
	return $menu;
    }
}
```

Now extensions are capable of adding their own reading modes into the menu.

What do you think of this approach?