### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+
+[*.php]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true


### PR DESCRIPTION
What?
A cross IDE setting for basic code formats, see http://editorconfig.org/

Why?
Because its annoying to remember project specific code style settings and change IDE settings for new projects. That would help new contributors a lot.

How to use it?
There are plugins available, see http://editorconfig.org/#download
- https://plugins.jetbrains.com/plugin/7294-editorconfig
- https://github.com/sindresorhus/atom-editorconfig
...