### PR TITLE
Fix favicon for open_basedir

### DIFF
--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -36,7 +36,7 @@ function downloadHttp(&$url, $curlOptions = array()) {
 			CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 			CURLOPT_MAXREDIRS => 10,
 		));
-	if (!empty(ini_get('open_basedir'))) {
+	if (ini_get('open_basedir') == '') { // see PHP bug 65646
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 	}
 	if (defined('CURLOPT_ENCODING')) {

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -37,8 +37,8 @@ function downloadHttp(&$url, $curlOptions = array()) {
 			CURLOPT_MAXREDIRS => 10,
 		));
 	if (!empty(ini_get('open_basedir'))) {
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);    //Keep option separated for open_basedir bug
-    }
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+	}
 	if (defined('CURLOPT_ENCODING')) {
 		curl_setopt($ch, CURLOPT_ENCODING, '');	//Enable all encodings
 	}

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -24,7 +24,7 @@ function isImgMime($content) {
 function downloadHttp(&$url, $curlOptions = array()) {
 	syslog(LOG_INFO, 'FreshRSS Favicon GET ' . $url);
 	if (substr($url, 0, 2) === '//') {
-		$url = 'https:' . $favicon;
+		$url = 'https:' . $url;
 	}
 	if ($url == '' || filter_var($url, FILTER_VALIDATE_URL) === false) {
 		return '';
@@ -36,7 +36,9 @@ function downloadHttp(&$url, $curlOptions = array()) {
 			CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 			CURLOPT_MAXREDIRS => 10,
 		));
-	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);	//Keep option separated for open_basedir bug
+	if (!empty(ini_get('open_basedir'))) {
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);    //Keep option separated for open_basedir bug
+    }
 	if (defined('CURLOPT_ENCODING')) {
 		curl_setopt($ch, CURLOPT_ENCODING, '');	//Enable all encodings
 	}


### PR DESCRIPTION
PHP error log says:
`PHP message: PHP Warning:  curl_setopt(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set in /freshrss/lib/favicons.php on line 39`

That is already known, as stated in favicons.php but not handled.
I applied a possible fix, but I do not know how to trigger that code to test my fix, please advice.

I also fixed a unknown variable problem, inside an if block that is probably not executed very often...