### PR TITLE
Remove warning for CURLOPT_FOLLOWLOCATION with open_basedir

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -491,7 +491,9 @@ class FreshRSS_Feed extends Minz_Model {
 					CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 					CURLOPT_MAXREDIRS => 10,
 				));
-			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);	//Keep option separated for open_basedir bug
+			if (version_compare(PHP_VERSION, '5.6.0') >= 0 || ini_get('open_basedir') == '') {
+				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);	//Keep option separated for open_basedir PHP bug 65646
+			}
 			if (defined('CURLOPT_ENCODING')) {
 				curl_setopt($ch, CURLOPT_ENCODING, '');	//Enable all encodings
 			}

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -36,8 +36,8 @@ function downloadHttp(&$url, $curlOptions = array()) {
 			CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 			CURLOPT_MAXREDIRS => 10,
 		));
-	if (ini_get('open_basedir') == '') { // see PHP bug 65646
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+	if (version_compare(PHP_VERSION, '5.6.0') >= 0 || ini_get('open_basedir') == '') {
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);	//Keep option separated for open_basedir PHP bug 65646
 	}
 	if (defined('CURLOPT_ENCODING')) {
 		curl_setopt($ch, CURLOPT_ENCODING, '');	//Enable all encodings


### PR DESCRIPTION
For PHP 5.6.0- http://www.php.net/ChangeLog-5.php#5.6.0
https://bugs.php.net/bug.php?id=65646
https://github.com/FreshRSS/FreshRSS/pull/1733
https://github.com/FreshRSS/FreshRSS/pull/1657
https://github.com/FreshRSS/FreshRSS/issues/1655