### PR TITLE
Fix a warning when retrieving the list of entries

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -203,7 +203,7 @@ class FreshRSS_index_Controller extends Minz_ActionController {
 		$entryDAO = FreshRSS_Factory::createEntryDao();
 
 		$get = FreshRSS_Context::currentGet(true);
-		if (count($get) > 1) {
+		if (is_array($get)) {
 			$type = $get[0];
 			$id = $get[1];
 		} else {


### PR DESCRIPTION
When retrieving the list of entries when the context was 'all' or 'starred', there was the following warning:

> Warning: count(): Parameter must be an array or an object that implements Countable in /home/alexis/FreshRSS/app/Controllers/indexController.php on line 206

I fixed that by changing how the array is tested.