### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,20 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
   - hhvm
   - nightly
 
 install:
   # newest version without https://github.com/squizlabs/PHP_CodeSniffer/pull/1404
-  - pear install PHP_CodeSniffer-3.0.0RC4
+  - composer global require squizlabs/php_codesniffer "<=3.0.0RC4"
 
 script:
   - phpenv rehash
   - |
     if [[ $VALIDATE_STANDARD == yes ]]; then
-      phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
+      COMPOSER_BIN=$(composer global config --absolute bin-dir)
+      $COMPOSER_BIN/phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
     fi
   - |
     if [[ $CHECK_TRANSLATION == yes ]]; then
@@ -29,18 +31,11 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: "5.3"
-      dist: precise
-    - php: "7.1"
-      env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no
-  allow_failures:
     # PHP 5.3 only runs on Ubuntu 12.04 (precise), not 14.04 (trusty)
     - php: "5.3"
       dist: precise
-    - php: "5.4"
-    - php: "5.5"
-    - php: "5.6"
-    - php: "7.0"
-    - php: hhvm
-    - php: nightly
+    - php: "7.2"
+      env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no
+  allow_failures:
     - env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no
+    - dist: precise

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -240,7 +240,7 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 			$res = recursive_unlink($ext->getPath());
 			if ($res) {
 				Minz_Request::good(_t('feedback.extensions.removed', $ext_name),
-				                  $url_redirect);
+				                   $url_redirect);
 			} else {
 				Minz_Request::bad(_t('feedback.extensions.cannot_delete', $ext_name),
 				                  $url_redirect);


### PR DESCRIPTION
I've enabled tests on PHP 7.2 since it's the latest stable version.
I've also installed phpcs from composer since PEAR is not available for all versions of PHP.