### PR TITLE
Replace "keep history" magic value by a constant

### DIFF
--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -177,9 +177,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 
 		foreach ($feeds as $feed) {
 			$feed_history = $feed->keepHistory();
-			if ($feed_history == -2) {
-				// TODO: -2 must be a constant!
-				// -2 means we take the default value from configuration
+			if (FreshRSS_Feed::KEEP_HISTORY_DEFAULT === $feed_history) {
 				$feed_history = FreshRSS_Context::$user_conf->keep_history_default;
 			}
 

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -317,10 +317,8 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 
 			$feed_history = $feed->keepHistory();
 			if ($isNewFeed) {
-				$feed_history = -1; //∞
-			} elseif ($feed_history == -2) {
-				// TODO: -2 must be a constant!
-				// -2 means we take the default value from configuration
+				$feed_history = FreshRSS_Feed::KEEP_HISTORY_INFINITE;
+			} elseif (FreshRSS_Feed::KEEP_HISTORY_DEFAULT === $feed_history) {
 				$feed_history = FreshRSS_Context::$user_conf->keep_history_default;
 			}
 			$needFeedCacheRefresh = false;

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -104,7 +104,7 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 				'pathEntries' => Minz_Request::param('path_entries', ''),
 				'priority' => intval(Minz_Request::param('priority', FreshRSS_Feed::PRIORITY_MAIN_STREAM)),
 				'httpAuth' => $httpAuth,
-				'keep_history' => intval(Minz_Request::param('keep_history', -2)),
+				'keep_history' => intval(Minz_Request::param('keep_history', FreshRSS_Feed::KEEP_HISTORY_DEFAULT)),
 				'ttl' => $ttl * ($mute ? -1 : 1),
 			);
 

--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -81,7 +81,7 @@ class FreshRSS_ConfigurationSetter {
 
 	private function _keep_history_default(&$data, $value) {
 		$value = intval($value);
-		$data['keep_history_default'] = $value >= -1 ? $value : 0;
+		$data['keep_history_default'] = $value >= FreshRSS_Feed::KEEP_HISTORY_INFINITE ? $value : 0;
 	}
 
 	// It works for system config too!
@@ -154,7 +154,7 @@ class FreshRSS_ConfigurationSetter {
 
 	private function _ttl_default(&$data, $value) {
 		$value = intval($value);
-		$data['ttl_default'] = $value >= -1 ? $value : 3600;
+		$data['ttl_default'] = $value > FreshRSS_Feed::TTL_DEFAULT ? $value : 3600;
 	}
 
 	private function _view_mode(&$data, $value) {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -7,6 +7,9 @@ class FreshRSS_Feed extends Minz_Model {
 
 	const TTL_DEFAULT = 0;
 
+	const KEEP_HISTORY_DEFAULT = -2;
+	const KEEP_HISTORY_INFINITE = -1;
+
 	private $id = 0;
 	private $url;
 	private $category = 1;
@@ -21,7 +24,7 @@ class FreshRSS_Feed extends Minz_Model {
 	private $pathEntries = '';
 	private $httpAuth = '';
 	private $error = false;
-	private $keep_history = -2;
+	private $keep_history = self::KEEP_HISTORY_DEFAULT;
 	private $ttl = self::TTL_DEFAULT;
 	private $mute = false;
 	private $hash = null;
@@ -222,7 +225,7 @@ class FreshRSS_Feed extends Minz_Model {
 	public function _keepHistory($value) {
 		$value = intval($value);
 		$value = min($value, 1000000);
-		$value = max($value, -2);
+		$value = max($value, self::KEEP_HISTORY_DEFAULT);
 		$this->keep_history = $value;
 	}
 	public function _ttl($value) {

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -18,7 +18,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 					ttl
 				)
 				VALUES
-				(?, ?, ?, ?, ?, ?, 10, ?, 0, -2, ?)';
+				(?, ?, ?, ?, ?, ?, 10, ?, 0, ?, ?)';
 		$stm = $this->bd->prepare($sql);
 
 		$valuesTmp['url'] = safe_ascii($valuesTmp['url']);
@@ -32,6 +32,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 			substr($valuesTmp['description'], 0, 1023),
 			$valuesTmp['lastUpdate'],
 			base64_encode($valuesTmp['httpAuth']),
+			FreshRSS_Feed::KEEP_HISTORY_DEFAULT,
 			FreshRSS_Feed::TTL_DEFAULT,
 		);
 
@@ -406,7 +407,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 			$myFeed->_pathEntries(isset($dao['pathEntries']) ? $dao['pathEntries'] : '');
 			$myFeed->_httpAuth(isset($dao['httpAuth']) ? base64_decode($dao['httpAuth']) : '');
 			$myFeed->_error(isset($dao['error']) ? $dao['error'] : 0);
-			$myFeed->_keepHistory(isset($dao['keep_history']) ? $dao['keep_history'] : -2);
+			$myFeed->_keepHistory(isset($dao['keep_history']) ? $dao['keep_history'] : FreshRSS_Feed::KEEP_HISTORY_DEFAULT);
 			$myFeed->_ttl(isset($dao['ttl']) ? $dao['ttl'] : FreshRSS_Feed::TTL_DEFAULT);
 			$myFeed->_nbNotRead(isset($dao['cache_nbUnreads']) ? $dao['cache_nbUnreads'] : 0);
 			$myFeed->_nbEntries(isset($dao['cache_nbEntries']) ? $dao['cache_nbEntries'] : 0);

--- a/app/views/configure/archiving.phtml
+++ b/app/views/configure/archiving.phtml
@@ -19,7 +19,7 @@
 			<label class="group-name" for="keep_history_default"><?php echo _t('conf.archiving.keep_history_by_feed'); ?></label>
 			<div class="group-controls">
 				<select class="number" name="keep_history_default" id="keep_history_default" required="required" data-leave-validation="<?php echo FreshRSS_Context::$user_conf->keep_history_default; ?>"><?php
-					foreach (array('' => '', 0 => '0', 10 => '10', 50 => '50', 100 => '100', 500 => '500', 1000 => '1 000', 5000 => '5 000', 10000 => '10 000', -1 => '∞') as $v => $t) {
+					foreach (array('' => '', 0 => '0', 10 => '10', 50 => '50', 100 => '100', 500 => '500', 1000 => '1 000', 5000 => '5 000', 10000 => '10 000', FreshRSS_Feed::KEEP_HISTORY_INFINITE => '∞') as $v => $t) {
 						echo '<option value="' . $v . (FreshRSS_Context::$user_conf->keep_history_default == $v ? '" selected="selected' : '') . '">' . $t . ' </option>';
 					}
 				?></select> (<?php echo _t('gen.short.by_default'); ?>)
@@ -34,7 +34,7 @@
 					                3600 => '1h', 5400 => '1.5h', 7200 => '2h', 10800 => '3h', 14400 => '4h', 18800 => '5h', 21600 => '6h', 25200 => '7h', 28800 => '8h',
 					                36000 => '10h', 43200 => '12h', 64800 => '18h',
 					                86400 => '1d', 129600 => '1.5d', 172800 => '2d', 259200 => '3d', 345600 => '4d', 432000 => '5d', 518400 => '6d',
-					                604800 => '1wk', -1 => '∞') as $v => $t) {
+					                604800 => '1wk') as $v => $t) {
 						echo '<option value="' . $v . (FreshRSS_Context::$user_conf->ttl_default == $v ? '" selected="selected' : '') . '">' . $t . '</option>';
 						if (FreshRSS_Context::$user_conf->ttl_default == $v) {
 							$found = true;

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -101,7 +101,7 @@
 			<label class="group-name" for="keep_history"><?php echo _t('sub.feed.keep_history'); ?></label>
 			<div class="group-controls">
 				<select class="number" name="keep_history" id="keep_history" required="required"><?php
-					foreach (array('' => '', -2 => _t('gen.short.by_default'), 0 => '0', 10 => '10', 50 => '50', 100 => '100', 500 => '500', 1000 => '1 000', 5000 => '5 000', 10000 => '10 000', -1 => '∞') as $v => $t) {
+					foreach (array('' => '', FreshRSS_Feed::KEEP_HISTORY_DEFAULT => _t('gen.short.by_default'), 0 => '0', 10 => '10', 50 => '50', 100 => '100', 500 => '500', 1000 => '1 000', 5000 => '5 000', 10000 => '10 000', FreshRSS_Feed::KEEP_HISTORY_INFINITE => '∞') as $v => $t) {
 						echo '<option value="' . $v . ($this->feed->keepHistory() === $v ? '" selected="selected' : '') . '">' . $t . '</option>';
 					}
 				?></select>


### PR DESCRIPTION
I think the use of a magic value repeated many times in the code is prone to have some errors made by people not knowing its meaning. Using a constant is a bit more safe. Judging by some comments in the code, I am not the only one.