### PR TITLE
count() parameter must be an array

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -203,7 +203,7 @@ class FreshRSS_index_Controller extends Minz_ActionController {
 		$entryDAO = FreshRSS_Factory::createEntryDao();
 
 		$get = FreshRSS_Context::currentGet(true);
-		if (count($get) > 1) {
+		if (is_array($get) && count($get) > 1) {
 			$type = $get[0];
 			$id = $get[1];
 		} else {


### PR DESCRIPTION
 Since Php 7.2 i have this warning :

`Warning: count(): Parameter must be an array or an object that implements Countable in /app/Controllers/indexController.php on line 206`

currentGet(true) return "a" on the index page.