### PR TITLE
Fix HTTP Auth when internal redirects occur

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -364,7 +364,15 @@ function get_user_configuration($username) {
 
 
 function httpAuthUser() {
-	return isset($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'] : '';
+	if (isset($_SERVER['REMOTE_USER'])) {
+		return $_SERVER['REMOTE_USER'];
+	}
+
+	if (isset($_SERVER['REDIRECT_REMOTE_USER'])) {
+		return $_SERVER['REDIRECT_REMOTE_USER'];
+	}
+
+	return '';
 }
 
 function cryptAvailable() {


### PR DESCRIPTION
When Apache performs an internal redirect, it stores the username in the
REDIRECT_REMOTE_USER variable instead of REMOTE_USER, breaking HTTP
authentication. For more information, see this Stack Overflow
discussion:
<https://stackoverflow.com/questions/3050444/when-setting-environment-variables-in-apache-rewriterule-directives-what-causes>

This PR first tries REMOTE_USER, as before. If it is not set, it checks whether REDIRECT_REMOTE_USER is set.