### PR TITLE
Feed parsing: use author email when there's no author name

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -355,7 +355,7 @@ class FreshRSS_Feed extends Minz_Model {
 				$this->id(),
 				$item->get_id(false, false),
 				$title === null ? '' : $title,
-				$author === null ? '' : html_only_entity_decode(strip_tags($author->name)),
+				$author === null ? '' : html_only_entity_decode(strip_tags($author->name == null ? $author->email : $author->name)),
 				$content === null ? '' : $content,
 				$link === null ? '' : $link,
 				$date ? $date : time()


### PR DESCRIPTION
This is especially useful because when author is given as
`<author>Author Name</author>` ( as in this example
https://cyber.harvard.edu/rss/rss.html#ltauthorgtSubelementOfLtitemgt ),
SimplePie will expose *Author Name* as `email`.
