### PR TITLE
WIP: allow ignoring SSL certificate for some feed

### DIFF
--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -56,6 +56,7 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 	 *   - CSS path to article on website
 	 *   - display in main stream (default: 0)
 	 *   - HTTP authentication
+         *   - Tolerate invalid SSL certificate (default: false)
 	 *   - number of article to retain (default: -2)
 	 *   - refresh frequency (default: 0)
 	 * Default values are empty strings unless specified.
@@ -104,6 +105,7 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 				'pathEntries' => Minz_Request::param('path_entries', ''),
 				'priority' => intval(Minz_Request::param('priority', FreshRSS_Feed::PRIORITY_MAIN_STREAM)),
 				'httpAuth' => $httpAuth,
+				'tolerateInvalidSSLCertificate' => Minz_Request::param('tolerate_invalid_ssl_certificate', 0),
 				'keep_history' => intval(Minz_Request::param('keep_history', FreshRSS_Feed::KEEP_HISTORY_DEFAULT)),
 				'ttl' => $ttl * ($mute ? -1 : 1),
 			);

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -23,6 +23,7 @@ class FreshRSS_Feed extends Minz_Model {
 	private $priority = self::PRIORITY_MAIN_STREAM;
 	private $pathEntries = '';
 	private $httpAuth = '';
+        private $tolerateInvalidSSLCertificate = false;
 	private $error = false;
 	private $keep_history = self::KEEP_HISTORY_DEFAULT;
 	private $ttl = self::TTL_DEFAULT;
@@ -105,6 +106,9 @@ class FreshRSS_Feed extends Minz_Model {
 			);
 		}
 	}
+        public function tolerateInvalidSSLCertificate() {
+                return $this->tolerateInvalidSSLCertificate;
+        }
 	public function inError() {
 		return $this->error;
 	}
@@ -219,6 +223,9 @@ class FreshRSS_Feed extends Minz_Model {
 	public function _httpAuth($value) {
 		$this->httpAuth = $value;
 	}
+        public function _tolerateInvalidSSLCertificate($value) {
+                $this->tolerateInvalidSSLCertificate = (bool)$value;
+        }
 	public function _error($value) {
 		$this->error = (bool)$value;
 	}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -260,7 +260,17 @@ class FreshRSS_Feed extends Minz_Model {
 				if ($this->httpAuth != '') {
 					$url = preg_replace('#((.+)://)(.+)#', '${1}' . $this->httpAuth . '@${3}', $url);
 				}
-				$feed = customSimplePie();
+                                
+                                $feed = customSimplePie();
+                                if ($this->tolerateInvalidSSLCertificate()) {
+                                        // TODO: merge with default curl options
+                                        $curl_options = array(
+                                            CURLOPT_SSL_VERIFYHOST => 0,
+                                            CURLOPT_SSL_VERIFYPEER => false,
+                                        );
+                                        $feed->set_curl_options($curl_options);
+                                }
+
 				if (substr($url, -11) === '#force_feed') {
 					$feed->force_feed(true);
 					$url = substr($url, 0, -11);

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -107,6 +107,12 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		if ($stm && $stm->execute($values)) {
 			return $stm->rowCount();
 		} else {
+                        // XXX on the fly migration :(
+			$sql2 = 'ALTER TABLE `' . $this->prefix . 'feed` ADD COLUMN `tolerateInvalidSSLCertificate` INT NOT NULL DEFAULT 0'; // v1.1.0 ? XXX
+			$stm = $this->bd->prepare($sql2);
+			$stm->execute();
+                        // XXX this will fail the first time and user will have to retry
+
 			$info = $stm == null ? array(2 => 'syntax error') : $stm->errorInfo();
 			Minz_Log::error('SQL error updateFeed: ' . $info[2]);
 			return false;

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -13,12 +13,13 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 					`lastUpdate`,
 					priority,
 					`httpAuth`,
+					`tolerateInvalidSSLCertificate`,
 					error,
 					keep_history,
 					ttl
 				)
 				VALUES
-				(?, ?, ?, ?, ?, ?, 10, ?, 0, ?, ?)';
+				(?, ?, ?, ?, ?, ?, 10, ?, ?, 0, ?, ?)';
 		$stm = $this->bd->prepare($sql);
 
 		$valuesTmp['url'] = safe_ascii($valuesTmp['url']);
@@ -32,6 +33,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 			substr($valuesTmp['description'], 0, 1023),
 			$valuesTmp['lastUpdate'],
 			base64_encode($valuesTmp['httpAuth']),
+                        $valuesTmp['tolerateInvalidSSLCertificate'],
 			FreshRSS_Feed::KEEP_HISTORY_DEFAULT,
 			FreshRSS_Feed::TTL_DEFAULT,
 		);
@@ -60,7 +62,8 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 				'website' => $feed->website(),
 				'description' => $feed->description(),
 				'lastUpdate' => 0,
-				'httpAuth' => $feed->httpAuth()
+				'httpAuth' => $feed->httpAuth(),
+				'tolerateInvalidSSLCertificate' => $feed->tolerateInvalidSSLCertificate()
 			);
 
 			$id = $this->addFeed($values);
@@ -406,6 +409,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 			$myFeed->_priority(isset($dao['priority']) ? $dao['priority'] : 10);
 			$myFeed->_pathEntries(isset($dao['pathEntries']) ? $dao['pathEntries'] : '');
 			$myFeed->_httpAuth(isset($dao['httpAuth']) ? base64_decode($dao['httpAuth']) : '');
+			$myFeed->_tolerateInvalidSSLCertificate(isset($dao['tolerateInvalidSSLCertificate']) ? $dao['tolerateInvalidSSLCertificate'] : false);
 			$myFeed->_error(isset($dao['error']) ? $dao['error'] : 0);
 			$myFeed->_keepHistory(isset($dao['keep_history']) ? $dao['keep_history'] : FreshRSS_Feed::KEEP_HISTORY_DEFAULT);
 			$myFeed->_ttl(isset($dao['ttl']) ? $dao['ttl'] : FreshRSS_Feed::TTL_DEFAULT);

--- a/app/SQL/install.sql.mysql.php
+++ b/app/SQL/install.sql.mysql.php
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS `%1$sfeed` (
 	`priority` tinyint(2) NOT NULL DEFAULT 10,
 	`pathEntries` varchar(511) DEFAULT NULL,
 	`httpAuth` varchar(511) DEFAULT NULL,
+	`tolerateInvalidSSLCertificate` boolean DEFAULT 0,
 	`error` boolean DEFAULT 0,
 	`keep_history` MEDIUMINT NOT NULL DEFAULT -2,	-- v0.7
 	`ttl` INT NOT NULL DEFAULT 0,	-- v0.7.3

--- a/app/SQL/install.sql.pgsql.php
+++ b/app/SQL/install.sql.pgsql.php
@@ -19,6 +19,7 @@ $SQL_CREATE_TABLES = array(
 	"priority" SMALLINT NOT NULL DEFAULT 10,
 	"pathEntries" VARCHAR(511) DEFAULT NULL,
 	"httpAuth" VARCHAR(511) DEFAULT NULL,
+	"tolerateInvalidSSLCertificate" smallint DEFAULT 0,
 	"error" smallint DEFAULT 0,
 	"keep_history" INT NOT NULL DEFAULT -2,
 	"ttl" INT NOT NULL DEFAULT 0,

--- a/app/SQL/install.sql.sqlite.php
+++ b/app/SQL/install.sql.sqlite.php
@@ -18,6 +18,7 @@ $SQL_CREATE_TABLES = array(
 	`priority` tinyint(2) NOT NULL DEFAULT 10,
 	`pathEntries` varchar(511) DEFAULT NULL,
 	`httpAuth` varchar(511) DEFAULT NULL,
+	`tolerateInvalidSSLCertificate` boolean DEFAULT 0,
 	`error` boolean DEFAULT 0,
 	`keep_history` MEDIUMINT NOT NULL DEFAULT -2,
 	`ttl` INT NOT NULL DEFAULT 0,

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -29,6 +29,8 @@ return array(
 		),
 		'css_help' => 'Retrieves truncated RSS feeds (caution, requires more time!)',
 		'css_path' => 'Articles CSS path on original website',
+		'tolerate_invalid_ssl_certificate' => 'Tolerate invalid SSL certificate',
+		'tolerate_invalid_ssl_certificate_help' => 'Ignore SSL errors when connecting to this feed.',
 		'description' => 'Description',
 		'empty' => 'This feed is empty. Please verify that it is still maintained.',
 		'error' => 'This feed has encountered a problem. Please verify that it is always reachable then update it.',

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -177,6 +177,13 @@
 				<?php echo _i('help'); ?> <?php echo _t('sub.feed.css_help'); ?>
 			</div>
 		</div>
+		<div class="form-group">
+			<label class="group-name" for="tolerate_invalid_ssl_certificate"><?php echo _t('sub.feed.tolerate_invalid_ssl_certificate'); ?></label>
+			<div class="group-controls">
+				<input type="checkbox" name="tolerate_invalid_ssl_certificate" id="tolerate_invalid_ssl_certificate" value="1"<?php echo $this->feed->tolerateInvalidSSLCertificate() ? ' checked="checked"' : ''; ?> />
+				<?php echo _i('help'); ?> <?php echo _t('sub.feed.tolerate_invalid_ssl_certificate_help'); ?>
+			</div>
+		</div>
 
 		<div class="form-group form-actions">
 			<div class="group-controls">


### PR DESCRIPTION
Implementing suggestion from https://github.com/FreshRSS/FreshRSS/issues/1723#issuecomment-369171458

This is very early work, I still have to polish several things, but I'm already interesting on feedback on:
 * wether this is a good idea at all
 * this introduce a new column. Do you guys already have anything to manage schema migrations ? I did b092527 because I saw the addition of `feed.ttl` have been managed like this, but I know this does not support all cases.