### PR TITLE
Fix HTTP_HOST port

### DIFF
--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -106,7 +106,8 @@ class Minz_Request {
 		$https = self::isHttps();
 
 		if (!empty($_SERVER['HTTP_HOST'])) {
-			$host = $_SERVER['HTTP_HOST'];
+			//Might contain a port number, and mind IPv6 addresses
+			$host = parse_url('http://' . $_SERVER['HTTP_HOST'], PHP_URL_HOST);
 		} elseif (!empty($_SERVER['SERVER_NAME'])) {
 			$host = $_SERVER['SERVER_NAME'];
 		} else {


### PR DESCRIPTION
HTTP_HOST sometimes contains a port number.
This made FreshRSS to generate a public URL with two times the port,
like https://freshrss.example:8080:8080/
Needed for https://github.com/FreshRSS/FreshRSS/pull/1813