### PR TITLE
FreshRSS 1.10.2 (only a Docker fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ﻿# FreshRSS changelog
 
-## 2018-0X-XX FreshRSS 1.10.2-dev
+## 2018-03-09 FreshRSS 1.10.2 (Docker only)
 
 * Bug fixing
 	* Fix Docker image for OPML import [#1819](https://github.com/FreshRSS/FreshRSS/pull/1819)
+	* Fix Docker image for CSS selectors [#1821](https://github.com/FreshRSS/FreshRSS/issues/1821)
+	* Fix Docker other missing PHP extensions [#1822](https://github.com/FreshRSS/FreshRSS/pull/1822)
 
 
 ## 2018-03-04 FreshRSS 1.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# FreshRSS changelog
 
+## 2018-0X-XX FreshRSS 1.10.2-dev
+
+
 ## 2018-03-04 FreshRSS 1.10.1
 
 * Deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2018-0X-XX FreshRSS 1.10.2-dev
 
+* Bug fixing
+	* Fix Docker image for OPML import [#1819](https://github.com/FreshRSS/FreshRSS/pull/1819)
+
 
 ## 2018-03-04 FreshRSS 1.10.1
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.7
 RUN apk add --no-cache \
 	apache2 php7-apache2 \
 	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
-	php7-ctype php7-dom php7-fileinfo php7-json php7-session php7-simplexml \
+	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-session php7-simplexml php7-xmlreader php7-zlib \
 	php7-pdo_sqlite \
 	php7-pdo_mysql \
 	php7-pdo_pgsql

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.7
 RUN apk add --no-cache \
 	apache2 php7-apache2 \
 	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
-	php7-ctype php7-dom php7-fileinfo php7-json php7-session \
+	php7-ctype php7-dom php7-fileinfo php7-json php7-session php7-simplexml \
 	php7-pdo_sqlite \
 	php7-pdo_mysql \
 	php7-pdo_pgsql

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.10.2-dev');
+define('FRESHRSS_VERSION', '1.10.2');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.10.1');
+define('FRESHRSS_VERSION', '1.10.2-dev');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 


### PR DESCRIPTION
Quick fix for 1.10.x, only for Docker. No need to make a new FreshRSS update.