### PR TITLE
fix update user for empty username

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -76,10 +76,14 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 
 			$apiPasswordPlain = Minz_Request::param('apiPasswordPlain', '', true);
 
+			$ok = false;
+
 			$username = Minz_Request::param('username');
-			$ok = self::updateUser($username, $passwordPlain, $apiPasswordPlain, array(
+			if (!empty($username)) {
+				$ok = self::updateUser($username, $passwordPlain, $apiPasswordPlain, array(
 					'token' => Minz_Request::param('token', null),
 				));
+			}
 
 			if ($ok) {
 				Minz_Request::good(_t('feedback.user.updated', $username),

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -45,6 +45,10 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 	}
 
 	public static function updateUser($user, $passwordPlain, $apiPasswordPlain, $userConfigUpdated = array()) {
+		if (empty($user)) {
+			return false;
+		}
+
 		$userConfig = get_user_configuration($user);
 		if ($passwordPlain != '') {
 			$passwordHash = self::hashPassword($passwordPlain);
@@ -76,14 +80,10 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 
 			$apiPasswordPlain = Minz_Request::param('apiPasswordPlain', '', true);
 
-			$ok = false;
-
 			$username = Minz_Request::param('username');
-			if (!empty($username)) {
-				$ok = self::updateUser($username, $passwordPlain, $apiPasswordPlain, array(
-					'token' => Minz_Request::param('token', null),
-				));
-			}
+			$ok = self::updateUser($username, $passwordPlain, $apiPasswordPlain, array(
+				'token' => Minz_Request::param('token', null),
+			));
 
 			if ($ok) {
 				Minz_Request::good(_t('feedback.user.updated', $username),

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -45,11 +45,11 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 	}
 
 	public static function updateUser($user, $passwordPlain, $apiPasswordPlain, $userConfigUpdated = array()) {
-		if (empty($user)) {
+		$userConfig = get_user_configuration($user);
+		if ($userConfig === null) {
 			return false;
 		}
 
-		$userConfig = get_user_configuration($user);
 		if ($passwordPlain != '') {
 			$passwordHash = self::hashPassword($passwordPlain);
 			$userConfig->passwordHash = $passwordHash;


### PR DESCRIPTION
Minor fix for the page `/i/?c=user&a=manage` where you could previously hit the Update button and get a 500 error:
```
PHP message: PHP Fatal error:  Uncaught Error: Call to a member function save() on null in /xxx/app/Controllers/userController.php:67
```

I added a minor validation to prevent that.