### PR TITLE
Docker: Apache overrides were not enough

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -15,8 +15,9 @@ WORKDIR ${FRESHRSS_ROOT}
 COPY . ${FRESHRSS_ROOT}
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
-RUN echo "17,37 * * * * php ${FRESHRSS_ROOT}/app/actualize_script.php 2>&1 | tee /tmp/FreshRSS.log" >> \
-	/var/spool/cron/crontabs/root
+RUN sed -r -i "/^[ ]*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/httpd.conf && \
+	echo "17,37 * * * * php ${FRESHRSS_ROOT}/app/actualize_script.php 2>&1 | tee /tmp/FreshRSS.log" >> \
+		/var/spool/cron/crontabs/root
 
 ENV CRON_MIN ''
 ENTRYPOINT ["./Docker/entrypoint.sh"]

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -17,8 +17,8 @@
 ServerName freshrss.localhost
 Listen 0.0.0.0:80
 DocumentRoot /var/www/FreshRSS/p/
+CustomLog /dev/stdout combined
 ErrorLog /dev/stderr
-TransferLog /dev/stdout
 AllowEncodedSlashes On
 
 <Directory /var/www/FreshRSS/p>


### PR DESCRIPTION
It looks like overrides of CustomLog, ErrorLog, Listen did not do the
job fully.
Updated to comment out those lines in httpd.conf.
Fixes the fact that **logs were kept in /var/log/apache2/** (instead of
being only given via STDOUT to Docker logs) and the "internal dummy
connection" bug over IPv6 (Docker is typically only IPv4).

Edit: this is because these Apache instructions are allowed to be repeated multiple times