### PR TITLE
strict comparaision for null

### DIFF
--- a/app/views/helpers/export/articles.phtml
+++ b/app/views/helpers/export/articles.phtml
@@ -23,7 +23,7 @@ foreach ($this->entriesRaw as $entryRaw) {
 	$entry = FreshRSS_EntryDAO::daoToEntry($entryRaw);
 	if (!isset($this->feed)) {
 		$feed = FreshRSS_CategoryDAO::findFeed($this->categories, $entry->feed());
-		if ($feed == null) {
+		if ($feed === null) {
 			$feed = $entry->feed(true);
 		}
 	} else {


### PR DESCRIPTION
With booleans and null, only strict comparison (with === operator) should be used to lower bug risks and to improve performances.