### PR TITLE
Detection of non-unique GUIDs

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -398,6 +398,17 @@ class FreshRSS_Feed extends Minz_Model {
 			unset($item);
 		}
 
+		$hasBadGuids = $this->attributes('hasBadGuids');
+		if ($hasBadGuids != !$hasUniqueGuids) {
+			$hasBadGuids = !$hasUniqueGuids;
+			if ($hasBadGuids) {
+				Minz_Log::warning('Feed has invalid GUIDs: ' . $this->url);
+			} else {
+				Minz_Log::warning('Feed has valid GUIDs again: ' . $this->url);
+			}
+			$feedDAO = FreshRSS_Factory::createFeedDao();
+			$feedDAO->updateFeedAttribute($this, 'hasBadGuids', $hasBadGuids);
+		}
 		if (!$hasUniqueGuids) {
 			foreach ($entries as $entry) {
 				$entry->_guid('');


### PR DESCRIPTION
Some feeds are using GUIDs, but fail to make them unique.
Example: https://www.kbh-sprogcenter.dk/en/category/danish-break/feed/
This patch detects non-unique GUIDs, and disable GUIDs in that specific
case.