### PR TITLE
SimplePie fix for Atom feeds using namespace for type

### DIFF
--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -1928,9 +1928,18 @@ class SimplePie_Misc
 
 	public static function atom_10_content_construct_type($attribs)
 	{
+		$type = '';
 		if (isset($attribs['']['type']))
 		{
-			$type = strtolower(trim($attribs['']['type']));
+			$type = trim($attribs['']['type']);
+		}
+		elseif (isset($attribs[SIMPLEPIE_NAMESPACE_ATOM_10]['type']))
+		{//FreshRSS
+			$type = trim($attribs[SIMPLEPIE_NAMESPACE_ATOM_10]['type']);
+		}
+		if ($type != '')
+		{
+			$type = strtolower($type);
 			switch ($type)
 			{
 				case 'text':


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/1892
https://what-if.xkcd.com/feed.atom

```xml
<content xmlns:ns="http://www.w3.org/2005/Atom" ns:type="html">&lt;...</content>
```