### PR TITLE
Suppress XML error during conversion attempt

### DIFF
--- a/lib/SimplePie/SimplePie/Parser.php
+++ b/lib/SimplePie/SimplePie/Parser.php
@@ -141,7 +141,7 @@ class SimplePie_Parser
 				$dom = new DOMDocument();
 				$dom->recover = true;
 				$dom->strictErrorChecking = false;
-				@$dom->loadXML($data);
+				@$dom->loadXML($data, LIBXML_NOERROR | LIBXML_NOWARNING);
 				$this->encoding = $encoding = $dom->encoding = 'UTF-8';
 				$data2 = $dom->saveXML();
 				if (function_exists('mb_convert_encoding'))


### PR DESCRIPTION
Using LIBXML_NOERROR. It looks like the `@` sign does not suppress all warnings. In a FreshRSS-specific
SimplePie section.

Example with a very bad feed:

```
Warning: DOMDocument::loadXML(): Namespace prefix media on content is
not defined in Entity, line: 42 in
/.../FreshRSS/lib/SimplePie/SimplePie/Parser.php on line 144
``` 