### PR TITLE
Use realpath of EXTENSIONS_PATH

### DIFF
--- a/p/ext.php
+++ b/p/ext.php
@@ -19,13 +19,14 @@ require(__DIR__ . '/../constants.php');
  */
 function is_valid_path($path) {
 	// It must be under the extension path.
-	$in_ext_path = (substr($path, 0, strlen(EXTENSIONS_PATH)) === EXTENSIONS_PATH);
+	$real_ext_path = realpath(EXTENSIONS_PATH);
+	$in_ext_path = (substr($path, 0, strlen($real_ext_path)) === $real_ext_path);
 	if (!$in_ext_path) {
 		return false;
 	}
 
 	// File to serve must be under a `ext_dir/static/` directory.
-	$path_relative_to_ext = substr($path, strlen(EXTENSIONS_PATH) + 1);
+	$path_relative_to_ext = substr($path, strlen($real_ext_path) + 1);
 	$path_splitted = explode('/', $path_relative_to_ext);
 	if (count($path_splitted) < 3 || $path_splitted[1] !== 'static') {
 		return false;


### PR DESCRIPTION
This handles the case where the extensions directory might be a symlink.

On the FreshRSS Cloudron app (https://git.cloudron.io/cloudron/freshrss-app/issues/2), the extensions directory is a symlink to a writable location (so that users can install freshrss extensions, rest of the code is read-only).