### PR TITLE
use GET method for mastodon

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -120,11 +120,10 @@ return array(
 		'method' => 'GET',
 	),
 	'mastodon' => array(
-		'url' => '~URL~/api/v1/statuses',
-		'transform' => array(),
+		'url' => '~URL~/share?title=~TITLE~&url=~LINK~',
+		'transform' => array('rawurlencode'),
 		'form' => 'advanced',
-		'method' => 'POST',
-		'field' => 'status',
+		'method' => 'GET',
 	),
 	'pocket' => array(
 		'url' => 'https://getpocket.com/save?url=~LINK~&amp;title=~TITLE~',


### PR DESCRIPTION
Update #1904

According to tootsuite/mastodon#6278 , mastodon has supported sharing with GET method since version 2.2.0.

It seems that the POST method doesn't work properly and most of the top 20 instance are running 2.2.0+ version, therefore I replaced the old configuration.