### PR TITLE
FreshRSS 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Bug fixing
 	* Fix bug in case of bad i18n in extensions [#1797](https://github.com/FreshRSS/FreshRSS/issues/1797)
 	* Fix regression in fetching full articles content [#1917](https://github.com/FreshRSS/FreshRSS/issues/1917)
+	* Fix several bugs in the new Fever API [#1930](https://github.com/FreshRSS/FreshRSS/issues/1930)
 	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# FreshRSS changelog
 
-## 2018-06-1X FreshRSS 1.11.1-dev
+## 2018-06-16 FreshRSS 1.11.1
 
 * Features
 	* Better support of `media:` tags such as thumbnails and descriptions (e.g. for YouTube) [#944](https://github.com/FreshRSS/FreshRSS/issues/944)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2018-0X-XX FreshRSS 1.11.1-dev
 
+* Bug fixing
+	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)
+
 
 ## 2018-06-03 FreshRSS 1.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2018-0X-XX FreshRSS 1.11.1-dev
 
 * Bug fixing
+	* Fix regression in fetching full articles content [#1917](https://github.com/FreshRSS/FreshRSS/issues/1917)
 	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# FreshRSS changelog
 
+## 2018-0X-XX FreshRSS 1.11.1-dev
+
+
 ## 2018-06-03 FreshRSS 1.11.0
 
 * API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 	* Built-in extension to fix Tumblr feeds from European Union due to GDPR [#1894](https://github.com/FreshRSS/FreshRSS/issues/1894)
 * Bug fixing
 	* Fix bug in case of bad i18n in extensions [#1797](https://github.com/FreshRSS/FreshRSS/issues/1797)
+	* Fix extension callback for updated articles and PubSubHubbub [#1926](https://github.com/FreshRSS/FreshRSS/issues/1926)
 	* Fix regression in fetching full articles content [#1917](https://github.com/FreshRSS/FreshRSS/issues/1917)
 	* Fix several bugs in the new Fever API [#1930](https://github.com/FreshRSS/FreshRSS/issues/1930)
 	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ﻿# FreshRSS changelog
 
-## 2018-06-XX FreshRSS 1.11.1-dev
+## 2018-06-1X FreshRSS 1.11.1-dev
 
 * Features
 	* Better support of `media:` tags such as thumbnails and descriptions (e.g. for YouTube) [#944](https://github.com/FreshRSS/FreshRSS/issues/944)
+* Extensions
+	* New extension mechanism allowing changing HTTP headers and other SimplePie parameters [#1924](https://github.com/FreshRSS/FreshRSS/pull/1924)
+	* Built-in extension to fix Tumblr feeds from European Union due to GDPR [#1894](https://github.com/FreshRSS/FreshRSS/issues/1894)
 * Bug fixing
+	* Fix bug in case of bad i18n in extensions [#1797](https://github.com/FreshRSS/FreshRSS/issues/1797)
 	* Fix regression in fetching full articles content [#1917](https://github.com/FreshRSS/FreshRSS/issues/1917)
 	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ﻿# FreshRSS changelog
 
-## 2018-0X-XX FreshRSS 1.11.1-dev
+## 2018-06-XX FreshRSS 1.11.1-dev
 
+* Features
+	* Better support of `media:` tags such as thumbnails and descriptions (e.g. for YouTube) [#944](https://github.com/FreshRSS/FreshRSS/issues/944)
 * Bug fixing
 	* Fix regression in fetching full articles content [#1917](https://github.com/FreshRSS/FreshRSS/issues/1917)
 	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -140,7 +140,7 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 
 			if ($res === true) {
 				$ext_list = $conf->extensions_enabled;
-				array_push_unique($ext_list, $ext_name);
+				$ext_list[$ext_name] = true;
 				$conf->extensions_enabled = $ext_list;
 				$conf->save();
 
@@ -196,7 +196,11 @@ class FreshRSS_extension_Controller extends Minz_ActionController {
 
 			if ($res === true) {
 				$ext_list = $conf->extensions_enabled;
-				array_remove($ext_list, $ext_name);
+				$legacyKey = array_search($ext_name, $ext_list, true);
+				if ($legacyKey !== false) {	//Legacy format FreshRSS < 1.11.1
+					unset($ext_list[$legacyKey]);
+				}
+				$ext_list[$ext_name] = false;
 				$conf->extensions_enabled = $ext_list;
 				$conf->save();
 

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -351,13 +351,20 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 							//This entry already exists and is unchanged. TODO: Remove the test with the zero'ed hash in FreshRSS v1.3
 							$oldGuids[] = $entry->guid();
 						} else {	//This entry already exists but has been updated
-							//Minz_Log::debug('Entry with GUID `' . $entry->guid() . '` updated in feed ' . $feed->id() .
+							//Minz_Log::debug('Entry with GUID `' . $entry->guid() . '` updated in feed ' . $feed->url() .
 								//', old hash ' . $existingHash . ', new hash ' . $entry->hash());
 							$mark_updated_article_unread = $feed->attributes('mark_updated_article_unread') !== null ? (
 									$feed->attributes('mark_updated_article_unread')
 								) : FreshRSS_Context::$user_conf->mark_updated_article_unread;
 							$needFeedCacheRefresh = $mark_updated_article_unread;
 							$entry->_isRead(FreshRSS_Context::$user_conf->mark_updated_article_unread ? false : null);	//Change is_read according to policy.
+
+							$entry = Minz_ExtensionManager::callHook('entry_before_insert', $entry);
+							if ($entry === null) {
+								// An extension has returned a null value, there is nothing to insert.
+								continue;
+							}
+
 							if (!$entryDAO->inTransaction()) {
 								$entryDAO->beginTransaction();
 							}

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -904,8 +904,8 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 	}
 
 	public function countUnreadRead() {
-		$sql = 'SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id WHERE priority > 0'
-			. ' UNION SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id WHERE priority > 0 AND is_read=0';
+		$sql = 'SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id WHERE f.priority > 0'
+			. ' UNION SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id WHERE f.priority > 0 AND e.is_read=0';
 		$stm = $this->bd->prepare($sql);
 		$stm->execute();
 		$res = $stm->fetchAll(PDO::FETCH_COLUMN, 0);
@@ -914,9 +914,10 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		return array('all' => $all, 'unread' => $unread, 'read' => $all - $unread);
 	}
 	public function count($minPriority = null) {
-		$sql = 'SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id';
+		$sql = 'SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e';
 		if ($minPriority !== null) {
-			$sql = ' WHERE priority > ' . intval($minPriority);
+			$sql .= ' INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id';
+			$sql .= ' WHERE f.priority > ' . intval($minPriority);
 		}
 		$stm = $this->bd->prepare($sql);
 		$stm->execute();
@@ -924,9 +925,13 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		return $res[0];
 	}
 	public function countNotRead($minPriority = null) {
-		$sql = 'SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id WHERE is_read=0';
+		$sql = 'SELECT COUNT(e.id) AS count FROM `' . $this->prefix . 'entry` e';
 		if ($minPriority !== null) {
-			$sql = ' AND priority > ' . intval($minPriority);
+			$sql .= ' INNER JOIN `' . $this->prefix . 'feed` f ON e.id_feed=f.id';
+		}
+		$sql .= ' WHERE e.is_read=0';
+		if ($minPriority !== null) {
+			$sql .= ' AND f.priority > ' . intval($minPriority);
 		}
 		$stm = $this->bd->prepare($sql);
 		$stm->execute();

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -356,49 +356,53 @@ class FreshRSS_Feed extends Minz_Model {
 
 			$content = html_only_entity_decode($item->get_content());
 
-			$elinks = array();
-			foreach ($item->get_enclosures() as $enclosure) {
-				$elink = $enclosure->get_link();
-				if ($elink != '' && empty($elinks[$elink])) {
-					$content .= '<div class="enclosure">';
+			if ($item->get_enclosures() != null) {
+				$elinks = array();
+				foreach ($item->get_enclosures() as $enclosure) {
+					$elink = $enclosure->get_link();
+					if ($elink != '' && empty($elinks[$elink])) {
+						$content .= '<div class="enclosure">';
 
-					if ($enclosure->get_title() != '') {
-						$content .= '<p class="enclosure-title">' . $enclosure->get_title() . '</p>';
-					}
-
-					$enclosureContent = '';
-					$elinks[$elink] = true;
-					$mime = strtolower($enclosure->get_type());
-					$medium = strtolower($enclosure->get_medium());
-					if ($medium === 'image' || strpos($mime, 'image/') === 0) {
-						$enclosureContent .= '<p class="enclosure-content"><img src="' . $elink . '" alt="" /></p>';
-					} elseif ($medium === 'audio' || strpos($mime, 'audio/') === 0) {
-						$enclosureContent .= '<p class="enclosure-content"><audio preload="none" src="' . $elink
-							. '" controls="controls"></audio> <a download="" href="' . $elink . '">💾</a></p>';
-					} elseif ($medium === 'video' || strpos($mime, 'video/') === 0) {
-						$enclosureContent .= '<p class="enclosure-content"><video preload="none" src="' . $elink
-							. '" controls="controls"></video> <a download="" href="' . $elink . '">💾</a></p>';
-					} elseif ($medium != '' || strpos($mime, 'application/') === 0 || strpos($mime, 'text/') === 0) {
-						$enclosureContent .= '<p class="enclosure-content"><a download="" href="' . $elink . '">💾</a></p>';
-					} else {
-						unset($elinks[$elink]);
-					}
-
-					$thumbnailContent = '';
-					foreach ($enclosure->get_thumbnails() as $thumbnail) {
-						if (empty($elinks[$thumbnail])) {
-							$elinks[$thumbnail] = true;
-							$thumbnailContent .= '<p><img class="enclosure-thumbnail" src="' . $thumbnail . '" alt="" /></p>';
+						if ($enclosure->get_title() != '') {
+							$content .= '<p class="enclosure-title">' . $enclosure->get_title() . '</p>';
 						}
-					}
 
-					$content .= $thumbnailContent;
-					$content .= $enclosureContent;
+						$enclosureContent = '';
+						$elinks[$elink] = true;
+						$mime = strtolower($enclosure->get_type());
+						$medium = strtolower($enclosure->get_medium());
+						if ($medium === 'image' || strpos($mime, 'image/') === 0) {
+							$enclosureContent .= '<p class="enclosure-content"><img src="' . $elink . '" alt="" /></p>';
+						} elseif ($medium === 'audio' || strpos($mime, 'audio/') === 0) {
+							$enclosureContent .= '<p class="enclosure-content"><audio preload="none" src="' . $elink
+								. '" controls="controls"></audio> <a download="" href="' . $elink . '">💾</a></p>';
+						} elseif ($medium === 'video' || strpos($mime, 'video/') === 0) {
+							$enclosureContent .= '<p class="enclosure-content"><video preload="none" src="' . $elink
+								. '" controls="controls"></video> <a download="" href="' . $elink . '">💾</a></p>';
+						} elseif ($medium != '' || strpos($mime, 'application/') === 0 || strpos($mime, 'text/') === 0) {
+							$enclosureContent .= '<p class="enclosure-content"><a download="" href="' . $elink . '">💾</a></p>';
+						} else {
+							unset($elinks[$elink]);
+						}
 
-					if ($enclosure->get_description() != '') {
-						$content .= '<pre class="enclosure-description">' . $enclosure->get_description() . '</pre>';
+						$thumbnailContent = '';
+						if ($enclosure->get_thumbnails() != null) {
+							foreach ($enclosure->get_thumbnails() as $thumbnail) {
+								if (empty($elinks[$thumbnail])) {
+									$elinks[$thumbnail] = true;
+									$thumbnailContent .= '<p><img class="enclosure-thumbnail" src="' . $thumbnail . '" alt="" /></p>';
+								}
+							}
+						}
+
+						$content .= $thumbnailContent;
+						$content .= $enclosureContent;
+
+						if ($enclosure->get_description() != '') {
+							$content .= '<pre class="enclosure-description">' . $enclosure->get_description() . '</pre>';
+						}
+						$content .= "</div>\n";
 					}
-					$content .= "</div>\n";
 				}
 			}
 

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -359,21 +359,45 @@ class FreshRSS_Feed extends Minz_Model {
 			foreach ($item->get_enclosures() as $enclosure) {
 				$elink = $enclosure->get_link();
 				if ($elink != '' && empty($elinks[$elink])) {
-					$elinks[$elink] = '1';
+					$content .= '<div class="enclosure">';
+
+					if ($enclosure->get_title() != '') {
+						$content .= '<p class="enclosure-title">' . $enclosure->get_title() . '</p>';
+					}
+
+					$enclosureContent = '';
+					$elinks[$elink] = true;
 					$mime = strtolower($enclosure->get_type());
-					if (strpos($mime, 'image/') === 0) {
-						$content .= '<p class="enclosure"><img src="' . $elink . '" alt="" /></p>';
-					} elseif (strpos($mime, 'audio/') === 0) {
-						$content .= '<p class="enclosure"><audio preload="none" src="' . $elink
+					$medium = strtolower($enclosure->get_medium());
+					if ($medium === 'image' || strpos($mime, 'image/') === 0) {
+						$enclosureContent .= '<p class="enclosure-content"><img src="' . $elink . '" alt="" /></p>';
+					} elseif ($medium === 'audio' || strpos($mime, 'audio/') === 0) {
+						$enclosureContent .= '<p class="enclosure-content"><audio preload="none" src="' . $elink
 							. '" controls="controls"></audio> <a download="" href="' . $elink . '">💾</a></p>';
-					} elseif (strpos($mime, 'video/') === 0) {
-						$content .= '<p class="enclosure"><video preload="none" src="' . $elink
+					} elseif ($medium === 'video' || strpos($mime, 'video/') === 0) {
+						$enclosureContent .= '<p class="enclosure-content"><video preload="none" src="' . $elink
 							. '" controls="controls"></video> <a download="" href="' . $elink . '">💾</a></p>';
-					} elseif (strpos($mime, 'application/') === 0 || strpos($mime, 'text/') === 0) {
-						$content .= '<p class="enclosure"><a download="" href="' . $elink . '">💾</a></p>';
+					} elseif ($medium != '' || strpos($mime, 'application/') === 0 || strpos($mime, 'text/') === 0) {
+						$enclosureContent .= '<p class="enclosure-content"><a download="" href="' . $elink . '">💾</a></p>';
 					} else {
 						unset($elinks[$elink]);
 					}
+
+					$thumbnailContent = '';
+					foreach ($enclosure->get_thumbnails() as $thumbnail) {
+						if (empty($elinks[$thumbnail])) {
+							$elinks[$thumbnail] = true;
+							$thumbnailContent .= '<p><img class="enclosure-thumbnail" src="' . $thumbnail . '" alt="" /></p>';
+						}
+					}
+
+					$content .= $thumbnailContent;
+					$content .= $enclosureContent;
+
+					if ($enclosure->get_description() != '') {
+						$content .= '<pre class="enclosure-description">' . $enclosure->get_description() . '</pre>';
+					}
+					$content .= "</div>\n";
 				}
 			}
 

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -391,8 +391,11 @@ class FreshRSS_Feed extends Minz_Model {
 				$date ? $date : time()
 			);
 			$entry->_tags($tags);
-			// permet de récupérer le contenu des flux tronqués
-			$entry->loadCompleteContent($this->pathEntries());
+			$entry->_feed($this);
+			if ($this->pathEntries != '') {
+				// Optionally load full content for truncated feeds
+				$entry->loadCompleteContent();
+			}
 
 			$entries[] = $entry;
 			unset($item);

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -286,6 +286,7 @@ class FreshRSS_Feed extends Minz_Model {
 				if (!$loadDetails) {	//Only activates auto-discovery when adding a new feed
 					$feed->set_autodiscovery_level(SIMPLEPIE_LOCATOR_NONE);
 				}
+				Minz_ExtensionManager::callHook('simplepie_before_init', $feed, $this);
 				$mtime = $feed->init();
 
 				if ((!$mtime) || $feed->error()) {

--- a/app/shares.php
+++ b/app/shares.php
@@ -120,11 +120,10 @@ return array(
 		'method' => 'GET',
 	),
 	'mastodon' => array(
-		'url' => '~URL~/api/v1/statuses',
-		'transform' => array(),
+		'url' => '~URL~/share?title=~TITLE~&url=~LINK~',
+		'transform' => array('rawurlencode'),
 		'form' => 'advanced',
-		'method' => 'POST',
-		'field' => 'status',
+		'method' => 'GET',
 	),
 	'pocket' => array(
 		'url' => 'https://getpocket.com/save?url=~LINK~&amp;title=~TITLE~',

--- a/config.default.php
+++ b/config.default.php
@@ -145,7 +145,9 @@ return array(
 	),
 
 	# List of enabled FreshRSS extensions.
-	'extensions_enabled' => array(),
+	'extensions_enabled' => array(
+		'Tumblr-GDPR' => true,
+	),
 
 	# Disable self-update,
 	'disable_update' => false,

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.11.1-dev');
+define('FRESHRSS_VERSION', '1.11.1');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.11.0');
+define('FRESHRSS_VERSION', '1.11.1-dev');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -366,6 +366,7 @@ The following events are available:
 - `entry_before_insert` (`function($entry) -> Entry | null`) : will be executed when a feed is refreshed and new entries will be imported into the database. The new entry (instance of FreshRSS_Entry) will be passed as parameter. 
 - `feed_before_insert` (`function($feed) -> Feed | null`) : will be executed when a new feed is imported into the database. The new feed (instance of FreshRSS_Feed) will be passed as parameter. 
 - `post_update` (`function(none) -> none`) : **TODO** add documentation
+- `simplepie_before_init` (`function($simplePie, $feed) -> none`) : **TODO** add documentation
 
 ### Writing your own configure.phtml
 

--- a/docs/en/users/06_Fever_API.md
+++ b/docs/en/users/06_Fever_API.md
@@ -43,7 +43,7 @@ Following features are implemented:
 - setting starred marker for item(s)
 - setting read marker for feed
 - setting read marker for category
-- supports FreshRSS extensions, which use th `entry_before_display` hook
+- supports FreshRSS extensions, which use the `entry_before_display` hook
 
 Following features are not supported:
 - **Hot Links** aka **hot** as there is nothing in FreshRSS yet that is similar or could be used to simulate it

--- a/docs/fr/developers/03_Backend/05_Extensions.md
+++ b/docs/fr/developers/03_Backend/05_Extensions.md
@@ -329,6 +329,7 @@ TODO :
 - `entry_before_insert` (`function($entry) -> Entry | null`)
 - `feed_before_insert` (`function($feed) -> Feed | null`)
 - `post_update` (`function(none) -> none`)
+- `simplepie_before_init` (`function($simplePie, $feed) -> none`)
 
 ### Écrire le fichier configure.phtml
 

--- a/docs/fr/users/06_Mobile_access.md
+++ b/docs/fr/users/06_Mobile_access.md
@@ -41,6 +41,22 @@ Voir la [page sur l’API compatible Fever](06_Fever_API.md) pour une autre poss
 	* Mettre à jour et retourner à l’étape 3.
 
 
+# Tests sur mobile
+
+6. Vous pouvez maintenant tester sur une application mobile (News+, FeedMe, ou EasyRSS sur Android)
+	* en utilisant comme adresse https://rss.example.net/api/greader.php ou http://example.net/FreshRSS/p/api/greader.php selon la configuration de votre site Web.
+	* ⚠️ attention aux majuscules et aux espaces en tapant l’adresse avec le clavier du mobile ⚠️ 
+	* avec votre nom d’utilisateur et le mot de passe enregistré au point 2 (mot de passe API).
+
+
+# En cas de problèmes
+
+ * Vous pouvez voir les logs API dans `./FreshRSS/data/users/_/log_api.txt`
+ * Si vous avez une erreur 404 (fichier non trouvé) lors de l’étape de test, et que vous êtes sous Apache,
+ voir http://httpd.apache.org/docs/trunk/mod/core.html#allowencodedslashes pour utiliser News+ 
+(facultatif pour EasyRSS et FeedMe qui devraient fonctionner dès lors que vous obtenez un PASS au test *Check partial server configuration*).
+
+
 # Clients compatibles
 
 Tout client supportant une API de type Google Reader. Sélection :

--- a/extensions/Tumblr-GDPR/README.md
+++ b/extensions/Tumblr-GDPR/README.md
@@ -1,0 +1,4 @@
+# Tumblr-GDPR
+
+Needed for accessing [Tumblr](https://www.tumblr.com/) RSS feeds from the European Union:
+bypass the [GPDR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) check, implying consent.

--- a/extensions/Tumblr-GDPR/extension.php
+++ b/extensions/Tumblr-GDPR/extension.php
@@ -1,0 +1,13 @@
+<?php
+
+class TumblrGdprExtension extends Minz_Extension {
+	public function init() {
+		$this->registerHook('simplepie_before_init', array('TumblrGdprExtension', 'curlHook'));
+	}
+
+	public static function curlHook($simplePie, $feed) {
+		if (preg_match('#^https?://[a-zA-Z_0-9-]+.tumblr.com/#i', $feed->url())) {
+			$simplePie->set_useragent(FRESHRSS_USERAGENT . ' like Googlebot');
+		}
+	}
+}

--- a/extensions/Tumblr-GDPR/metadata.json
+++ b/extensions/Tumblr-GDPR/metadata.json
@@ -1,0 +1,8 @@
+{
+	"name": "Tumblr-GDPR",
+	"author": "Alkarex",
+	"description": "Bypass Tumblr’ GPDR check (implying consent) for the European Union",
+	"version": 1.0,
+	"entrypoint": "TumblrGdpr",
+	"type": "system"
+}

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -90,15 +90,15 @@ class Minz_Configuration {
 	private $configuration_setter = null;
 
 	public function removeExtension($ext_name) {
-		self::$extensions_enabled = array_diff(
-			self::$extensions_enabled,
-			array($ext_name)
-		);
+		unset(self::$extensions_enabled[$ext_name]);
+		$legacyKey = array_search($ext_name, self::$extensions_enabled, true);
+		if ($legacyKey !== false) {	//Legacy format FreshRSS < 1.11.1
+			unset(self::$extensions_enabled[$legacyKey]);
+		}
 	}
 	public function addExtension($ext_name) {
-		$found = array_search($ext_name, self::$extensions_enabled) !== false;
-		if (!$found) {
-			self::$extensions_enabled[] = $ext_name;
+		if (!isset(self::$extensions_enabled[$ext_name])) {
+			self::$extensions_enabled[$ext_name] = true;
 		}
 	}
 

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -194,6 +194,9 @@ class Minz_ExtensionManager {
 	 * @param string[] $ext_list the names of extensions we want to load.
 	 */
 	public static function enableByList($ext_list) {
+		if (!is_array($ext_list)) {
+			return;
+		}
 		foreach ($ext_list as $ext_name => $ext_status) {
 			if (is_int($ext_name)) {	//Legacy format int=>name
 				self::enable($ext_status);

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -35,6 +35,10 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'OneToOne',
 		),
+		'simplepie_before_init' => array(  // function($simplePie, $feed) -> none
+			'list' => array(),
+			'signature' => 'PassArguments',
+		),
 	);
 	private static $ext_to_hooks = array();
 
@@ -160,7 +164,8 @@ class Minz_ExtensionManager {
 		self::$ext_list[$name] = $ext;
 
 		if ($ext->getType() === 'system' &&
-				in_array($name, self::$ext_auto_enabled)) {
+				(!empty(self::$ext_auto_enabled[$name]) ||
+				in_array($name, self::$ext_auto_enabled, true))) {	//Legacy format < FreshRSS 1.11.1
 			self::enable($ext->getName());
 		}
 
@@ -189,8 +194,12 @@ class Minz_ExtensionManager {
 	 * @param string[] $ext_list the names of extensions we want to load.
 	 */
 	public static function enableByList($ext_list) {
-		foreach ($ext_list as $ext_name) {
-			self::enable($ext_name);
+		foreach ($ext_list as $ext_name => $ext_status) {
+			if (is_int($ext_name)) {	//Legacy format int=>name
+				self::enable($ext_status);
+			} elseif ($ext_status) {	//New format name=>Boolean
+				self::enable($ext_name);
+			}
 		}
 	}
 
@@ -255,10 +264,15 @@ class Minz_ExtensionManager {
 		}
 
 		$signature = self::$hook_list[$hook_name]['signature'];
-		$signature = 'self::call' . $signature;
 		$args = func_get_args();
-
-		return call_user_func_array($signature, $args);
+		if ($signature === 'PassArguments') {
+			array_shift($args);
+			foreach (self::$hook_list[$hook_name]['list'] as $function) {
+				call_user_func_array($function, $args);
+			}
+		} else {
+			return call_user_func_array('self::call' . $signature, $args);
+		}
 	}
 
 	/**

--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -64,12 +64,16 @@ class Minz_Translate {
 		$list_langs = array();
 
 		foreach (self::$path_list as $path) {
-			$path_langs = array_values(array_diff(
-				scandir($path),
-				array('..', '.')
-			));
-
-			$list_langs = array_merge($list_langs, $path_langs);
+			$scan = scandir($path);
+			if (is_array($scan)) {
+				$path_langs = array_values(array_diff(
+					$scan,
+					array('..', '.')
+				));
+				if (is_array($path_langs)) {
+					$list_langs = array_merge($list_langs, $path_langs);
+				}
+			}
 		}
 
 		return array_unique($list_langs);
@@ -80,12 +84,10 @@ class Minz_Translate {
 	 * @param $path a path containing i18n directories (e.g. ./en/, ./fr/).
 	 */
 	public static function registerPath($path) {
-		if (in_array($path, self::$path_list)) {
-			return;
+		if (!in_array($path, self::$path_list) && is_dir($path)) {
+			self::$path_list[] = $path;
+			self::loadLang($path);
 		}
-
-		self::$path_list[] = $path;
-		self::loadLang($path);
 	}
 
 	/**
@@ -94,7 +96,7 @@ class Minz_Translate {
 	 */
 	private static function loadLang($path) {
 		$lang_path = $path . '/' . self::$lang_name;
-		if (!file_exists($lang_path) || is_null(self::$lang_name)) {
+		if (!file_exists($lang_path) || self::$lang_name == '') {
 			// The lang path does not exist, nothing more to do.
 			return;
 		}

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -1322,7 +1322,12 @@ class SimplePie
 
 	function cleanMd5($rss)
 	{
-		return md5(preg_replace(array('#<(lastBuildDate|pubDate|updated|feedDate|dc:date|slash:comments)>[^<]+</\\1>#', '#<!--.+?-->#s'), '', $rss));
+		return md5(preg_replace(array(
+			'#<(lastBuildDate|pubDate|updated|feedDate|dc:date|slash:comments)>[^<]+</\\1>#',
+			'#<(media:starRating|media:statistics) [^/<>]+/>#',
+			'#<!--.+?-->#s',
+			), '', $rss));
+		
 	}
 
 	/**

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -480,7 +480,6 @@ function recursive_unlink($dir) {
 	return rmdir($dir);
 }
 
-
 /**
  * Remove queries where $get is appearing.
  * @param $get the get attribute which should be removed.
@@ -495,29 +494,6 @@ function remove_query_by_get($get, $queries) {
 		}
 	}
 	return $final_queries;
-}
-
-
-/**
- * Add a value in an array and take care it is unique.
- * @param $array the array in which we add the value.
- * @param $value the value to add.
- */
-function array_push_unique(&$array, $value) {
-	$found = array_search($value, $array) !== false;
-	if (!$found) {
-		$array[] = $value;
-	}
-}
-
-
-/**
- * Remove a value from an array.
- * @param $array the array from wich value is removed.
- * @param $value the value to remove.
- */
-function array_remove(&$array, $value) {
-	$array = array_diff($array, array($value));
 }
 
 //RFC 4648

--- a/p/api/pshb.php
+++ b/p/api/pshb.php
@@ -116,6 +116,8 @@ if ($self !== base64url_decode($canonical64)) {
 	$self = base64url_decode($canonical64);
 }
 
+Minz_ExtensionManager::init();
+
 $nb = 0;
 foreach ($users as $userFilename) {
 	$username = basename($userFilename, '.txt');
@@ -132,6 +134,10 @@ foreach ($users as $userFilename) {
 		                             join_path(FRESHRSS_PATH, 'config-user.default.php'));
 		new Minz_ModelPdo($username);	//TODO: FIXME: Quick-fix while waiting for a better FreshRSS() constructor/init
 		FreshRSS_Context::init();
+		if (FreshRSS_Context::$user_conf != null) {
+			Minz_ExtensionManager::enableByList(FreshRSS_Context::$user_conf->extensions_enabled);
+		}
+
 		list($updated_feeds, $feed, $nb_new_articles) = FreshRSS_feed_Controller::actualizeFeed(0, $self, false, $simplePie);
 		if ($updated_feeds > 0 || $feed != false) {
 			$nb++;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -832,9 +832,13 @@ input:checked + .slide-container .properties {
 	display: none;
 }
 
-.enclosure > [download] {
+.enclosure [download] {
 	font-size: xx-large;
 	margin-left: .8em;
+}
+
+pre.enclosure-description {
+	white-space: pre-line;
 }
 
 /*=== MOBILE */


### PR DESCRIPTION
[FreshRSS 1.11.1](https://github.com/FreshRSS/FreshRSS/milestones/1.11.1) is a quick fix for a regression introduced in [version 1.11.0](https://github.com/FreshRSS/FreshRSS/pull/1902) and affecting the fetching of full article contents. This version also contains a few more improvements.


[Changelog](https://github.com/FreshRSS/FreshRSS/blob/dev/CHANGELOG.md):

* Features
	* Better support of `media:` tags such as thumbnails and descriptions (e.g. for YouTube) [#944](https://github.com/FreshRSS/FreshRSS/issues/944)
* Extensions
	* New extension mechanism allowing changing HTTP headers and other SimplePie parameters [#1924](https://github.com/FreshRSS/FreshRSS/pull/1924)
	* Built-in extension to fix Tumblr feeds from European Union due to GDPR [#1894](https://github.com/FreshRSS/FreshRSS/issues/1894)
* Bug fixing
	* Fix bug in case of bad i18n in extensions [#1797](https://github.com/FreshRSS/FreshRSS/issues/1797)
	* Fix extension callback for updated articles and PubSubHubbub [#1926](https://github.com/FreshRSS/FreshRSS/issues/1926)
	* Fix regression in fetching full articles content [#1917](https://github.com/FreshRSS/FreshRSS/issues/1917)
	* Fix several bugs in the new Fever API [#1930](https://github.com/FreshRSS/FreshRSS/issues/1930)
	* Updated sharing to Mastodon [#1904](https://github.com/FreshRSS/FreshRSS/issues/1904)