### PR TITLE
Docker from Alpine 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2018-XX-XX FreshRSS 1.11.2-dev
 
+* Deployment
+	* Update Docker image to Alpine 3.8 with PHP 7.2 [#1956](https://github.com/FreshRSS/FreshRSS/pull/1956)
 * Bug fixing
 	* Fix bugs when searching with special characters (e.g. preventing marking as read) [#1944](https://github.com/FreshRSS/FreshRSS/issues/1944)
 * Mics.

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --no-cache \
 	apache2 php7-apache2 \


### PR DESCRIPTION
PHP 7.2 http://php.net/manual/migration72.incompatible.php
TODO: create_function() is deprecated (used by lib_phpQuery.php)