### PR TITLE
Better rand()

### DIFF
--- a/app/Controllers/javascriptController.php
+++ b/app/Controllers/javascriptController.php
@@ -47,8 +47,8 @@ class FreshRSS_javascript_Controller extends Minz_ActionController {
 		$this->view->salt1 = sprintf('$2a$%02d$', FreshRSS_user_Controller::BCRYPT_COST);
 		$alphabet = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 		for ($i = 22; $i > 0; $i--) {
-			$this->view->salt1 .= $alphabet[rand(0, 63)];
+			$this->view->salt1 .= $alphabet[mt_rand(0, 63)];
 		}
-		$this->view->nonce = sha1(rand());
+		$this->view->nonce = sha1(mt_rand());
 	}
 }


### PR DESCRIPTION
http://php.net/manual/en/function.mt-rand.php

from php Doc

"Many random number generators of older libcs have dubious or unknown characteristics and are slow. The mt_rand() function is a drop-in replacement for the older rand(). It uses a random number generator with known characteristics using the » Mersenne Twister, which will produce random numbers four times faster than what the average libc rand() provides. "