### PR TITLE
Better rand()

### DIFF
--- a/p/f.php
+++ b/p/f.php
@@ -28,7 +28,7 @@ $txt_mtime = @filemtime($txt);
 
 header('Content-Type: image/x-icon');
 
-if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (rand(15, 20) * 86400))) {
+if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (mt_rand(15, 20) * 86400))) {
 	if ($txt_mtime == false) {
 		show_default_favicon(1800);
 		exit();
@@ -49,6 +49,6 @@ if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (ra
 
 header('Content-Disposition: inline; filename="' . $id . '.ico"');
 
-if (!httpConditional($ico_mtime, rand(14, 21) * 86400, 2)) {
+if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
 	readfile($ico);
 }


### PR DESCRIPTION
http://php.net/manual/en/function.mt-rand.php

from php Doc

"Many random number generators of older libcs have dubious or unknown characteristics and are slow. The mt_rand() function is a drop-in replacement for the older rand(). It uses a random number generator with known characteristics using the » Mersenne Twister, which will produce random numbers four times faster than what the average libc rand() provides. "