### PR TITLE
better rand()

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -413,7 +413,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				$entryDAO->updateLastSeen($feed->id(), $oldGuids, $mtime);
 			}
 
-			if ($feed_history >= 0 && rand(0, 30) === 1) {
+			if ($feed_history >= 0 && mt_rand(0, 30) === 1) {
 				// TODO: move this function in web cron when available (see entry::purge)
 				// Remove old entries once in 30.
 				if (!$entryDAO->inTransaction()) {


### PR DESCRIPTION
http://php.net/manual/en/function.mt-rand.php

from php Doc

"Many random number generators of older libcs have dubious or unknown characteristics and are slow. The mt_rand() function is a drop-in replacement for the older rand(). It uses a random number generator with known characteristics using the » Mersenne Twister, which will produce random numbers four times faster than what the average libc rand() provides. "