### PR TITLE
 bottom padding to enable scroll to mark all as read 

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -630,7 +630,7 @@ br + br + br {
 #bigMarkAsRead {
 	display: block;
 	width: 100%;
-	padding: 1em 0;
+	padding: 1em 0 100% 0;
 	text-align: center;
 	font-size: 1.4em;
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -631,6 +631,7 @@ br + br + br {
 	display: block;
 	width: 100%;
 	padding: 1em 0 100% 0;
+	padding: 1em 0 100vh 0;
 	text-align: center;
 	font-size: 1.4em;
 }


### PR DESCRIPTION
100vh bottom padding to enable scrolling to mark as read and a 100% fallback for ancient browsers. 

It works on the desktop (Windows Firefox and Chrome) and mobile (Android Firefox and Chrome). Mobile needed the 100vh version, desktop was ok with just the 100% version. 

You can stop scrolling when you see the button if you want the original behaviour.