### PR TITLE
Small docs update (see #1999) and i18n fix (see #1309)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,6 +13,7 @@ People are sorted by name so please keep this order.
 * [Amaury Carrade](https://github.com/AmauryCarrade): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=AmauryCarrade), [Web](https://amaury.carrade.eu/)
 * [Anton Smirnov](https://github.com/sandfoxme): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:sandfoxme), [Web](http://sandfox.me/)
 * [ASMfreaK](https://github.com/ASMfreaK): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=ASMfreaK)
+* [chemical1979](https://github.com/chemical1979): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=chemical1979)
 * [Craig Andrews](https://github.com/candrews): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:candrews), [Web](http://candrews.integralblue.com/)
 * [Crupuk](https://github.com/Crupuk): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Crupuk)
 * [Damstre](https://github.com/Damstre): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Damstre)

--- a/README.fr.md
+++ b/README.fr.md
@@ -187,6 +187,7 @@ Tout client supportant une API de type Fever ; Sélection :
 * iOS
 	* [Fiery Feeds](https://itunes.apple.com/app/fiery-feeds-rss-reader/id1158763303) (Propriétaire)
 	* [Unread](https://itunes.apple.com/app/unread-rss-reader/id1252376153) (Propriétaire)
+	* [Reeder-3](https://itunes.apple.com/app/reeder-3/id697846300) (Propriétaire)
 * MacOS
 	* [Readkit](https://itunes.apple.com/app/readkit/id588726889) (Propriétaire)
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Supported clients are:
 	* [Unread](https://itunes.apple.com/app/unread-rss-reader/id1252376153) (Closed source)
 * MacOS
 	* [Readkit](https://itunes.apple.com/app/readkit/id588726889) (Closed source)
+	* [Reeder-3](https://itunes.apple.com/app/reeder-3/id697846300) (Closed source)
 
 
 # Included libraries

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Supported clients are:
 * iOS
 	* [Fiery Feeds](https://itunes.apple.com/app/fiery-feeds-rss-reader/id1158763303) (Closed source)
 	* [Unread](https://itunes.apple.com/app/unread-rss-reader/id1252376153) (Closed source)
+	* [Reeder-3](https://itunes.apple.com/app/reeder-3/id697846300) (Closed source)
 * MacOS
 	* [Readkit](https://itunes.apple.com/app/readkit/id588726889) (Closed source)
-	* [Reeder-3](https://itunes.apple.com/app/reeder-3/id697846300) (Closed source)
 
 
 # Included libraries

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -102,7 +102,7 @@ return array(
 		'read' => array(
 			'article_open_on_website' => 'wenn der Artikel auf der Original-Webseite geöffnet wird',
 			'article_viewed' => 'wenn der Artikel angesehen wird',
-			'scroll' => 'beim Blättern',
+			'scroll' => 'beim Scrollen bzw. Überspringen',
 			'upon_reception' => 'beim Empfang des Artikels',
 			'when' => 'Artikel als gelesen markieren…',
 		),

--- a/docs/en/users/06_Fever_API.md
+++ b/docs/en/users/06_Fever_API.md
@@ -23,6 +23,7 @@ Tested with:
 - iOS
   - [Fiery Feeds](https://itunes.apple.com/app/fiery-feeds-rss-reader/id1158763303)
   - [Unread](https://itunes.apple.com/app/unread-rss-reader/id1252376153)
+  - [Reeder-3](https://itunes.apple.com/app/reeder-3/id697846300)
 
 - MacOS
   - [Readkit](https://itunes.apple.com/app/readkit/id588726889)

--- a/docs/fr/users/06_Fever_API.md
+++ b/docs/fr/users/06_Fever_API.md
@@ -10,6 +10,7 @@ Testé avec:
 - iOS
   - [Fiery Feeds](https://itunes.apple.com/app/fiery-feeds-rss-reader/id1158763303)
   - [Unread](https://itunes.apple.com/app/unread-rss-reader/id1252376153)
+  - [Reeder-3](https://itunes.apple.com/app/reeder-3/id697846300)
 
 - MacOS
   - [Readkit](https://itunes.apple.com/app/readkit/id588726889)


### PR DESCRIPTION
Adding Reeder-3/iOS as an supported client via Fever API to the docs and a small translation fix for an option in the config (german)