### PR TITLE
Escape cron step values with backslash

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -100,7 +100,7 @@ There is no less than 3 options. Pick a single one.
 Easiest, built-in solution, also used in the examples above
 (but your Docker instance will have a second process in the background, without monitoring).
 Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `'13,43'` (recommended) or `'*/20'`.
+containing a valid cron minute definition such as `'13,43'` (recommended) or `'*\/20'`.
 Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
 
 ```sh

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -100,7 +100,7 @@ There is no less than 3 options. Pick a single one.
 Easiest, built-in solution, also used in the examples above
 (but your Docker instance will have a second process in the background, without monitoring).
 Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `'13,43'` (recommended) or `'*\/20'`.
+containing a valid cron minute definition such as `'13,43'` (recommended) or `'*/20'`.
 Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
 
 ```sh

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -6,7 +6,7 @@ chown -R :www-data .
 chmod -R g+r . && chmod -R g+w ./data/
 
 if [ -n "$CRON_MIN" ]; then
-	sed -r -i "/FreshRSS/s/^[^ ]+ /$CRON_MIN /" /var/spool/cron/crontabs/root
+	sed -r -i "\#FreshRSS#s#^[^ ]+ #$CRON_MIN #" /var/spool/cron/crontabs/root
 fi
 
 exec "$@"


### PR DESCRIPTION
As I had this error myself I propose the following change:
Escape cron step values with backslash in $CRON_MIN.

Otherwise you will get the error ```sed: bad option in substitution expression```.

