### PR TITLE
Remove some preload / prefetch

### DIFF
--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -90,7 +90,7 @@ class FreshRSS extends Minz_FrontController {
 				}
 				$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
 				$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
-				header('Link: <' . Minz_Url::display($url, '', 'root') . '>;rel=preload', false);	//HTTP2
+				//header('Link: <' . Minz_Url::display($url, '', 'root') . '>;rel=preload', false);	//HTTP2
 				Minz_View::prependStyle(Minz_Url::display($url));
 			}
 		}

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -90,7 +90,6 @@ class FreshRSS extends Minz_FrontController {
 				}
 				$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
 				$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
-				//header('Link: <' . Minz_Url::display($url, '', 'root') . '>;rel=preload', false);	//HTTP2
 				Minz_View::prependStyle(Minz_Url::display($url));
 			}
 		}

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -32,14 +32,7 @@
 		<?php echo self::headTitle(); ?>
 <?php
 	$url_base = Minz_Request::currentRequest();
-	if (FreshRSS_Context::$next_id !== '') {
-		$url_next = $url_base;
-		$url_next['params']['next'] = FreshRSS_Context::$next_id;
-		$url_next['params']['ajax'] = 1;
-?>
-		<link id="prefetch" rel="next prefetch" href="<?php echo Minz_Url::display($url_next); ?>" />
-<?php
-	} if (isset($this->rss_title)) {
+	if (isset($this->rss_title)) {
 		$url_rss = $url_base;
 		$url_rss['a'] = 'rss';
 		if (FreshRSS_Context::$user_conf->since_hours_posts_per_rss) {

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -11,10 +11,6 @@
 		<?php echo self::headScript(); ?>
 		<link rel="shortcut icon" id="favicon" type="image/x-icon" sizes="16x16 64x64" href="<?php echo Minz_Url::display('/favicon.ico'); ?>" />
 		<link rel="icon msapplication-TileImage apple-touch-icon" type="image/png" sizes="256x256" href="<?php echo Minz_Url::display('/themes/icons/favicon-256.png'); ?>" />
-		<link rel="prefetch" href="<?php echo FreshRSS_Themes::icon('starred', true); ?>" />
-		<link rel="prefetch" href="<?php echo FreshRSS_Themes::icon('non-starred', true); ?>" />
-		<link rel="prefetch" href="<?php echo FreshRSS_Themes::icon('read', true); ?>" />
-		<link rel="prefetch" href="<?php echo FreshRSS_Themes::icon('unread', true); ?>" />
 		<link rel="apple-touch-icon" href="<?php echo Minz_Url::display('/themes/icons/apple-touch-icon.png'); ?>" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black" />

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1172,7 +1172,16 @@ function init_load_more(box) {
 	box_load_more = box;
 	document.body.dispatchEvent(freshrssLoadMoreEvent);
 
-	$("#load_more").click(function () {
+	var $next_link = $("#load_more");
+	if (!$next_link.length) {
+		// no more article to load
+		url_load_more = "";
+		return;
+	}
+
+	url_load_more = $next_link.attr("href");
+
+	$next_link.click(function () {
 		load_more_posts();
 		return false;
 	});

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1170,25 +1170,9 @@ freshrssLoadMoreEvent.initEvent('freshrss:load-more', true, true);
 
 function init_load_more(box) {
 	box_load_more = box;
-
 	document.body.dispatchEvent(freshrssLoadMoreEvent);
 
-	var $next_link = $("#load_more");
-	if (!$next_link.length) {
-		// no more article to load
-		url_load_more = "";
-		return;
-	}
-
-	url_load_more = $next_link.attr("href");
-	var $prefetch = $('#prefetch');
-	if ($prefetch.attr('href') !== url_load_more) {
-		$prefetch.attr('rel', 'next');	//Remove prefetch
-		$.ajax({url: url_load_more, ifModified: true });	//TODO: Try to find a less agressive solution
-		$prefetch.attr('href', url_load_more);
-	}
-
-	$next_link.click(function () {
+	$("#load_more").click(function () {
 		load_more_posts();
 		return false;
 	});


### PR DESCRIPTION
This approach was only efficient in the specific case when no change was made while reading the first page (no mark-as-read, favourites, tags), and useless in the other situations.
Removed to reduce server load.