### PR TITLE
Fix public IP detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 	* Fix database size in the Web UI for users about to be deleted [#2047](https://github.com/FreshRSS/FreshRSS/pull/2047)
 	* Fix actualize bug after install [#2044](https://github.com/FreshRSS/FreshRSS/pull/2044)
 	* Fix manual / Web actualize for which the final commit coud be done too early [#2081](https://github.com/FreshRSS/FreshRSS/pull/2081)
+	* Fix regression from version 1.11.2, which might have wrongly believed that the server address was private [#2084](https://github.com/FreshRSS/FreshRSS/pull/2084)
+		* Please check in `data/config.php` that you have `'pubsubhubbub_enabled' => true,` if your server has a public address
 * Extensions
 	* Update built-in extension to again fix Tumblr feeds from European Union due to GDPR [#2053](https://github.com/FreshRSS/FreshRSS/pull/2053)
 * I18n

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -125,9 +125,8 @@ function server_is_public($address) {
 	));
 
 	if ($is_public) {
-		$ip = gethostbyname($host);
-		$is_public &= !preg_match('/^(10|127|172[.]16|192[.]168)[.]/', $ip);
-		$is_public &= !preg_match('/^(\[)?(::1$|fc00::|fe80::)/i', $ip);
+		$is_public &= !preg_match('/^(10|127|172[.]16|192[.]168)[.]/', $host);
+		$is_public &= !preg_match('/^(\[)?(::1$|fc00::|fe80::)/i', $host);
 	}
 
 	return (bool)$is_public;


### PR DESCRIPTION
gethostbyname() may not return the expected public IP in a container
deployment or behind a proxy.
https://github.com/FreshRSS/FreshRSS/pull/2010/files#r228714764
Might have set to false `pubsubhubbub_enabled` some installations made
from stratch from version 1.11.2.