### PR TITLE
Fix Dropdown being obscured by other elements

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -256,7 +256,7 @@ a.btn {
 }
 .dropdown-target:target ~ .dropdown-menu {
 	display: block;
-	z-index: 10;
+	z-index: 1000;
 }
 .dropdown-close {
 	display: inline;


### PR DESCRIPTION
I noticed that in every theme but Swage (and I can't quite figure out what my own theme's doing differently that makes this a non-issue), the properties tile of the theme select slider floats over the menu on a small screen, like so:

![image](https://user-images.githubusercontent.com/2626332/47627902-1ba84000-db09-11e8-9222-b8644046e2f9.png)

massively increasing the dropdown-menu's z-index will ensure that it should stay on top of everything; if this solution's non-ideal for some reason, .nav label's z-index could be reduced from 11 to 9, and properties' z-index could be reduced to 8.