### PR TITLE
Changes in Swage theme for Mark As Read on Scroll

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -778,7 +778,6 @@ display: none;
 text-align: center;
 text-decoration: none;
 background: #e3e3e3;
-padding: 20px !IMPORTANT;
 }
 #bigMarkAsRead:hover {
 background: #22303d;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -873,7 +873,6 @@ form {
 	text-align: center;
 	text-decoration: none;
 	background: darken( $color_light, 10%);
-	padding: 20px !IMPORTANT;
 	&:hover {
 		background: $color_aside;
 		color: $color_light;


### PR DESCRIPTION
Remove theme sizing to make scroll as read work per #1980, as requested in https://github.com/FreshRSS/FreshRSS/pull/2088#issuecomment-434309422

I just want to say that I really don't like this solution; it doesn't seem intuitive to me if scroll to mark as read is enabled, and looks downright broken if you don't, which is why I'd overridden the height in the first place. I'll be adding looking into another way to do this to my personal to-do list.