### PR TITLE
Improve long dropdown menu lists

### DIFF
--- a/app/views/helpers/index/normal/entry_bottom.phtml
+++ b/app/views/helpers/index/normal/entry_bottom.phtml
@@ -42,7 +42,7 @@
 			<a class="dropdown-toggle" href="#dropdown-labels-<?php echo $this->entry->id();?>"><?php
 				echo _t('index.menu.tags');
 			?></a>
-			<ul class="dropdown-menu">
+			<ul class="dropdown-menu dropdown-menu-scrollable">
 				<li class="dropdown-close"><a href="#close">❌</a></li>
 				<!-- Ajax -->
 			</ul>

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -230,6 +230,11 @@ a.btn {
 	background: #fff;
 	border: 1px solid #aaa;
 }
+.dropdown-menu-scrollable {
+	max-height: 75vh;
+	overflow-x: hidden;
+	overflow-y: auto;
+}
 .dropdown-header {
 	display: block;
 }


### PR DESCRIPTION
### Issue:
Dropdown menus with lots of entries were a bit difficult to use …
I was only able to see either the bottom of the labels-list or the article and not both …
And I was unable to close the labels menu on my Phone after adding more than 12 labels.

### Changes:
I set the max height to ~~60%~~ **75%** of Vieport-height and enabled vertical scrolling … ~~in the theme I use …~~
**for a new dropdown class now used for dropdowns of the "My labels" feature**

### To Further Improve:
- ~~Maybe similar changes to other themes are needed.~~
- On my (windows) phone i still can't add all labels because i cant scroll the menu … but at least i can close it again without reload …
Works ok on my Android …

**Edit:** Changed PR based on responses below