### PR TITLE
[i18n] Update missing string for Occitan

### DIFF
--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -26,7 +26,7 @@ return array(
 			'password' => 'Senhal HTTP',
 			'username' => 'Identificant HTTP',
 		),
-		'clear_cache' => 'Always clear cache',	//TODO - Translation
+		'clear_cache' => 'Totjorn escafar lo cache',	//TODO - Translation
 		'css_help' => 'Permet de recuperar los fluxes troncats (atencion, demanda mai de temps !)',
 		'css_path' => 'Selector CSS dels articles sul site d’origina',
 		'description' => 'Descripcion',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -26,7 +26,7 @@ return array(
 			'password' => 'Senhal HTTP',
 			'username' => 'Identificant HTTP',
 		),
-		'clear_cache' => 'Totjorn escafar lo cache',	//TODO - Translation
+		'clear_cache' => 'Totjorn escafar lo cache',
 		'css_help' => 'Permet de recuperar los fluxes troncats (atencion, demanda mai de temps !)',
 		'css_path' => 'Selector CSS dels articles sul site d’origina',
 		'description' => 'Descripcion',


### PR DESCRIPTION
According to I18n standardization #2138 this string was missing.
Took the most used translation for "to clear" from Firefox, escafar.
And «cache» like in French and English.
Tell me know if other strings are missing