### PR TITLE
[BlueLagoon] Fix header's height

### DIFF
--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -137,8 +137,6 @@ button.as-link[disabled] {
 .stick .btn:first-child,.stick input:first-child {
 	border-radius: 6px 0 0 6px;
 }
-.stick .btn-important:first-child {
-}
 .stick .btn:last-child, .stick input:last-child {
 	border-radius: 0 6px 6px 0;
 }
@@ -570,7 +568,6 @@ a.btn {
 /*===============*/
 /*=== Header */
 .header {
-	height: 55px;
 	background: linear-gradient(0deg, #EDE7DE 0%, #FFF 100%) #EDE7DE;
 	background: -webkit-linear-gradient(bottom, #EDE7DE 0%, #FFF 100%);
 	border-bottom: solid 1px #BDB7AE;
@@ -582,14 +579,14 @@ a.btn {
 	text-align: center;
 }
 .header > .item.title .logo {
-	height: 60px;
-	width: 60px;
+	height: 40px;
+	width: 40px;
 }
 .header > .item.title{
 	width: 250px;
 }
 .header > .item.title h1 {
-	margin: 0.5em 0;
+	margin: 10px 0;
 }
 .header > .item.title h1 a {
 	text-decoration: none;
@@ -607,7 +604,8 @@ a.btn {
 /*=== Body */
 #global {
 	background:#F9F7F4;
-	height: calc(100% - 60px);
+	/* Header : 60px + 1px border bottom */
+	height: calc(100% - 61px);
 }
 .aside {
 	box-shadow: 0 2px 2px #171717 inset;

--- a/p/themes/BlueLagoon/icons/icon.svg
+++ b/p/themes/BlueLagoon/icons/icon.svg
@@ -1,5 +1,5 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 59.4 59.7">
 <defs>
 <linearGradient id="linearGradient3796">
 <stop stop-color="#0090ff" offset="0"/>


### PR DESCRIPTION
Hi,

I'll try to sum up the current issue: the `#global` height is calculated with `calc(100% - 60px)`. 60px is supposed to be the header's height. However, even though there is a `height: 55px` set on `.header` it would not restrict the height because of `display: table`. And the height actually equals the logo's height (60px) + (0.5em * 2) of margin on the `<h1>`, which makes it around 80.5px on my screen.

This MR:

* Removes the useless `height: 55px` on `.header`
* Reduces the logo size to 40px
* Fixes the margins on `<h1>` to 10px (x 2 : top and bottom)
* Sets the `#global` height to `calc(100% - 61px)` because there also is a 1px border bottom on the header

![screenshot_2018-12-04 vos flux rss freshrss](https://user-images.githubusercontent.com/3419050/49426384-b6e3a380-f7a0-11e8-9765-6d7af64513c5.png)

