### PR TITLE
Fix for #2115

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -139,6 +139,13 @@ td.numeric {
 	text-align: center;
 }
 
+/*=== COMPONENTS */
+/*===============*/
+
+[aria-hidden="true"] {
+	display: none !important;
+}
+
 /*=== Forms */
 .form-group::after {
 	content: "";
@@ -973,11 +980,4 @@ pre.enclosure-description {
 		content: " [" attr(href) "] ";
 		font-style: italic;
 	}
-}
-
-/*=== COMPONENTS */
-/*===============*/
-
-[aria-hidden="true"] {
-	display: none;
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -139,13 +139,6 @@ td.numeric {
 	text-align: center;
 }
 
-/*=== COMPONENTS */
-/*===============*/
-
-[aria-hidden="true"] {
-	display: none;
-}
-
 /*=== Forms */
 .form-group::after {
 	content: "";
@@ -980,4 +973,11 @@ pre.enclosure-description {
 		content: " [" attr(href) "] ";
 		font-style: italic;
 	}
+}
+
+/*=== COMPONENTS */
+/*===============*/
+
+[aria-hidden="true"] {
+	display: none;
 }


### PR DESCRIPTION
`aria-hidden="true"` can be overridden by more specific css display rules. In the case of #2115, it was `.dropdown-menu .input { display: block }`.

Moving this css rule down the document doesn't help because it's not being overriden by rules of the same type, but rules with finer specificity. 

As much as I don't like using `!important`, it's the best course of action here, because otherwise we'd have to write new css for any element that might ever be in an `aria-hidden` element, to unset it's display property.