### PR TITLE
Bugfix #1781

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -64,7 +64,7 @@ return array(
 	),
 	'movim' => array(
 		'url' => '~URL~/?share/~LINK~',
-		'transform' => array('rawurlencode', 'urlencode'),
+		'transform' => array('urlencode'),
 		'help' => 'https://github.com/edhelas/movim',
 		'form' => 'advanced',
 		'method' => 'GET',


### PR DESCRIPTION
Fixes #1781. 

Movim expects an encoded url in it's external share feature, not a raw encoded url.  I'm not sure when this change was made on Movim's end, but in any case, I've tested this as working.