### PR TITLE
Add New Article banner to reader mode

### DIFF
--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -12,8 +12,11 @@ if (!empty($this->entries)) {
 	$content_width = FreshRSS_Context::$user_conf->content_width;
 ?>
 
-<div id="stream" class="reader"><?php
-	foreach ($this->entries as $item) {
+<div id="stream" class="reader">
+	<div id="new-article">
+		<a href="<?php echo Minz_Url::display(Minz_Request::currentRequest()); ?>"><?php echo _t('gen.js.new_article'); /* TODO: move string in JS*/ ?></a>
+	</div>
+	<?php foreach ($this->entries as $item) {
 		$item = Minz_ExtensionManager::callHook('entry_before_display', $item);
 		if (is_null($item)) {
 			continue;


### PR DESCRIPTION
Fixes #1407

Display the new available articles banner while in reader mode. With the sidebar now present on reader mode, all that was needed to fix this is adding the div in reader mode. Sorry I didn't have this done before 1.13.0 went to testing!

