### PR TITLE
Batch scroll as read + reducing jQuery

### DIFF
--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -97,14 +97,15 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 				}
 			}
 		} else {
-			$entryDAO->markRead($id, $is_read);
-
+			$ids = is_array($id) ? $id : array($id);
+			$entryDAO->markRead($ids, $is_read);
 			$tagDAO = FreshRSS_Factory::createTagDao();
-			foreach ($tagDAO->getTagsForEntry($id) as $tag) {
-				if (!empty($tag['checked'])) {
-					$this->view->tags[] = $tag['id'];
-				}
+			$tagsForEntries = $tagDAO->getTagsForEntries($ids);
+			$tags = array();
+			foreach ($tagsForEntries as $line) {
+				$tags['t_' . $line['id_tag']][] = $line['id_entry'];
 			}
+			$this->view->tags = $tags;
 		}
 
 		if (!$this->ajax) {

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -383,7 +383,7 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 	 */
 	public function markRead($ids, $is_read = true) {
 		FreshRSS_UserDAO::touch();
-		if (is_array($ids)) {	//Many IDs at once (used by API)
+		if (is_array($ids)) {	//Many IDs at once
 			if (count($ids) < 6) {	//Speed heuristics
 				$affected = 0;
 				foreach ($ids as $id) {

--- a/app/Models/TagDAO.php
+++ b/app/Models/TagDAO.php
@@ -256,40 +256,54 @@ class FreshRSS_TagDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		}
 	}
 
-	//For API
-	public function getEntryIdsTagNames($entries) {
-		$sql = 'SELECT et.id_entry, t.name '
+	public function getTagsForEntries($entries) {
+		$sql = 'SELECT et.id_entry, et.id_tag, t.name '
 			 . 'FROM `' . $this->prefix . 'tag` t '
 			 . 'INNER JOIN `' . $this->prefix . 'entrytag` et ON et.id_tag = t.id';
 
 		$values = array();
 		if (is_array($entries) && count($entries) > 0) {
 			$sql .= ' AND et.id_entry IN (' . str_repeat('?,', count($entries) - 1). '?)';
-			foreach ($entries as $entry) {
-				$values[] = is_array($entry) ? $entry['id'] : $entry->id();
+			if (is_array($entries[0])) {
+				foreach ($entries as $entry) {
+					$values[] = $entry['id'];
+				}
+			} elseif (is_object($entries[0])) {
+				foreach ($entries as $entry) {
+					$values[] = $entry->id();
+				}
+			} else {
+				foreach ($entries as $entry) {
+					$values[] = $entry;
+				}
 			}
 		}
 		$stm = $this->bd->prepare($sql);
 
 		if ($stm && $stm->execute($values)) {
-			$result = array();
-			foreach ($stm->fetchAll(PDO::FETCH_ASSOC) as $line) {
-				$entryId = 'e_' . $line['id_entry'];
-				$tagName = $line['name'];
-				if (empty($result[$entryId])) {
-					$result[$entryId] = array();
-				}
-				$result[$entryId][] = $tagName;
-			}
-			return $result;
+			return $stm->fetchAll(PDO::FETCH_ASSOC);
 		} else {
 			$info = $stm == null ? array(0 => '', 1 => '', 2 => 'syntax error') : $stm->errorInfo();
 			if ($this->autoUpdateDb($info)) {
-				return $this->getTagNamesEntryIds($id_entry);
+				return $this->getTagsForEntries($entries);
 			}
-			Minz_Log::error('SQL error getTagNamesEntryIds: ' . $info[2]);
+			Minz_Log::error('SQL error getTagsForEntries: ' . $info[2]);
 			return false;
 		}
+	}
+
+	//For API
+	public function getEntryIdsTagNames($entries) {
+		$result = array();
+		foreach ($this->getTagsForEntries($entries) as $line) {
+			$entryId = 'e_' . $line['id_entry'];
+			$tagName = $line['name'];
+			if (empty($result[$entryId])) {
+				$result[$entryId] = array();
+			}
+			$result[$entryId][] = $tagName;
+		}
+		return $result;
 	}
 
 	public static function daoToTag($listDAO) {

--- a/app/views/entry/read.phtml
+++ b/app/views/entry/read.phtml
@@ -1,17 +1,7 @@
 <?php
 header('Content-Type: application/json; charset=UTF-8');
 
-$url = array(
-	'c' => Minz_Request::controllerName(),
-	'a' => Minz_Request::actionName(),
-	'params' => Minz_Request::fetchGET(),
-);
-
-$url['params']['is_read'] = Minz_Request::param('is_read', true) ? '0' : '1';
-
 FreshRSS::loadStylesAndScripts();
 echo json_encode(array(
-		'url' => str_ireplace('&amp;', '&', Minz_Url::display($url)),
-		'icon' => _i($url['params']['is_read'] === '1' ? 'unread' : 'read'),
 		'tags' => $this->tags,
 	));

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -56,6 +56,7 @@ echo htmlspecialchars(json_encode(array(
 		'category_empty' => _t('gen.js.category_empty'),
 	),
 	'icons' => array(
-		'close' => _i('close'),
+		'read' => rawurlencode(_i('read')),
+		'unread' => rawurlencode(_i('unread')),
 	),
 ), JSON_UNESCAPED_UNICODE), ENT_NOQUOTES, 'UTF-8');

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -42,7 +42,7 @@ echo htmlspecialchars(json_encode(array(
 		'reading_view' => @$s['reading_view'],
 		'rss_view' => @$s['rss_view'],
 	),
-	'url' => array(
+	'urls' => array(
 		'index' => _url('index', 'index'),
 		'login' => Minz_Url::display(array('c' => 'auth', 'a' => 'login'), 'php'),
 		'logout' => Minz_Url::display(array('c' => 'auth', 'a' => 'logout'), 'php'),

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -165,17 +165,13 @@ var pending_entries = {},
 	mark_read_queue = [];
 
 function send_mark_read_queue(queue, asRead) {
-	let url = '.?c=entry&a=read' + (asRead ? '' : '&is_read=0');
-	for (let i = queue.length - 1; i >= 0; i--) {
-		url += '&id[]=' + queue[i];
-	}
-
 	$.ajax({
 		type: 'POST',
-		url: url,
+		url: '.?c=entry&a=read' + (asRead ? '' : '&is_read=0'),
 		data: {
 			ajax: true,
 			_csrf: context.csrf,
+			'id[]': queue,
 		},
 	}).done(function (data) {
 		for (let i = queue.length - 1; i >= 0; i--) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -500,7 +500,7 @@ function user_filter(key) {
 			return;
 		}
 		// Display the filter div
-		window.location.hash = filter.attr('id');
+		location.hash = filter.attr('id');
 		// Force scrolling to the filter div
 		const scroll = needsScroll($('.header'));
 		if (scroll !== 0) {
@@ -528,7 +528,7 @@ function auto_share(key) {
 			return;
 		}
 		// Display the share div
-		window.location.hash = $share.attr('id');
+		location.hash = $share.attr('id');
 		// Force scrolling to the share div
 		const scroll = needsScroll($share.closest('.bottom'));
 		if (scroll !== 0) {
@@ -566,12 +566,12 @@ function init_posts() {
 		let lastScroll = 0,	//Throttle
 			timerId = 0;
 		$box_to_follow.scroll(function () {
-			window.clearTimeout(timerId);
+			clearTimeout(timerId);
 			if (lastScroll + 500 < Date.now()) {
 				lastScroll = Date.now();
 				scrollAsRead($box_to_follow);
 			} else {
-				timerId = window.setTimeout(function() {
+				timerId = setTimeout(function () {
 						scrollAsRead($box_to_follow);
 					}, 500);
 			}
@@ -600,7 +600,7 @@ function init_column_categories() {
 	}
 
 	$('#aside_feed').on('click', '.tree-folder>.tree-folder-title>a.dropdown-toggle', function () {
-		$(this).children().each(function() {
+		$(this).children().each(function () {
 			if (this.alt === '▽') {
 				this.src = this.src.replace('/icons/down.', '/icons/up.');
 				this.alt = '△';
@@ -643,11 +643,11 @@ function init_column_categories() {
 }
 
 function init_shortcuts() {
-	if (!(window.shortcut && window.shortcuts)) {
+	if (!(window.shortcut)) {
 		if (window.console) {
 			console.log('FreshRSS waiting for shortcut.js…');
 		}
-		window.setTimeout(init_shortcuts, 200);
+		setTimeout(init_shortcuts, 200);
 		return;
 	}
 	// Manipulation shortcuts
@@ -795,7 +795,7 @@ function init_shortcuts() {
 	});
 
 	shortcut.add(shortcuts.close_dropdown, function () {
-		window.location.hash = null;
+		location.hash = null;
 	}, {
 		'disable_in_input': true
 	});
@@ -1017,7 +1017,7 @@ function updateFeed(feeds, feeds_count) {
 						noCommit: 0,
 					},
 				}).always(function (data) {
-					window.location.reload();
+					location.reload();
 				});
 		} else {
 			updateFeed(feeds, feeds_count);
@@ -1092,15 +1092,15 @@ function openNotification(msg, status) {
 	$notification.find('.msg').html(msg);
 	$notification.fadeIn(300);
 
-	notification_interval = window.setTimeout(closeNotification, 4000);
+	notification_interval = setTimeout(closeNotification, 4000);
 }
 
 function closeNotification() {
-	$notification.fadeOut(600, function() {
+	$notification.fadeOut(600, function () {
 		$notification.removeClass();
 		$notification.addClass('closed');
 
-		window.clearInterval(notification_interval);
+		clearInterval(notification_interval);
 		notification_working = false;
 	});
 }
@@ -1115,7 +1115,7 @@ function init_notifications() {
 
 	if ($notification.find('.msg').html().length > 0) {
 		notification_working = true;
-		notification_interval = window.setTimeout(closeNotification, 4000);
+		notification_interval = setTimeout(closeNotification, 4000);
 	}
 }
 // </notification>
@@ -1144,14 +1144,14 @@ function notifs_html5_show(nb) {
 		tag: 'freshRssNewArticles',
 	});
 
-	notification.onclick = function() {
-		window.location.reload();
+	notification.onclick = function () {
+		location.reload();
 		window.focus();
 		notification.close();
 	};
 
 	if (context.html5_notif_timeout !== 0) {
-		setTimeout(function() {
+		setTimeout(function () {
 			notification.close();
 		}, context.html5_notif_timeout * 1000);
 	}
@@ -1171,7 +1171,7 @@ function refreshUnreads() {
 		const isAll = document.querySelector('.category.all.active');
 		let new_articles = false;
 
-		$.each(data.feeds, function(feed_id, nbUnreads) {
+		$.each(data.feeds, function (feed_id, nbUnreads) {
 			feed_id = 'f_' + feed_id;
 			const elem = document.getElementById(feed_id),
 				feed_unreads = elem ? str2int(elem.getAttribute('data-unread')) : 0;
@@ -1185,7 +1185,7 @@ function refreshUnreads() {
 
 		let nbUnreadTags = 0;
 
-		$.each(data.tags, function(tag_id, nbUnreads) {
+		$.each(data.tags, function (tag_id, nbUnreads) {
 			nbUnreadTags += nbUnreads;
 			$('#t_' + tag_id).attr('data-unread', nbUnreads)
 				.children('.item-title').attr('data-unread', numberFormat(nbUnreads));
@@ -1298,11 +1298,11 @@ function init_crypto_form() {
 		if (window.console) {
 			console.log('FreshRSS waiting for bcrypt.js…');
 		}
-		window.setTimeout(init_crypto_form, 100);
+		setTimeout(init_crypto_form, 100);
 		return;
 	}
 
-	$crypto_form.on('submit', function() {
+	$crypto_form.on('submit', function () {
 		const $submit_button = $(this).find('button[type="submit"]');
 		$submit_button.attr('disabled', '');
 
@@ -1329,7 +1329,7 @@ function init_crypto_form() {
 					openNotification('Crypto exception! ' + e, 'bad');
 				}
 			}
-		}).fail(function() {
+		}).fail(function () {
 			openNotification('Communication error!', 'bad');
 		});
 
@@ -1402,7 +1402,7 @@ function init_share_observers() {
 }
 
 function init_stats_observers() {
-	$('.select-change').on('change', function(e) {
+	$('.select-change').on('change', function (e) {
 		redirect($(this).find(':selected').data('url'));
 	});
 }
@@ -1488,7 +1488,7 @@ function init_slider_observers() {
 		return;
 	}
 
-	$('.post').on('click', '.open-slider', function() {
+	$('.post').on('click', '.open-slider', function () {
 		if (ajax_loading) {
 			return false;
 		}
@@ -1509,7 +1509,7 @@ function init_slider_observers() {
 		return false;
 	});
 
-	$closer.on('click', function() {
+	$closer.on('click', function () {
 		$closer.removeClass('active');
 		$slider.removeClass('active');
 		return false;
@@ -1550,7 +1550,7 @@ function init_normal() {
 		if (window.console) {
 			console.log('FreshRSS waiting for content…');
 		}
-		window.setTimeout(init_normal, 100);
+		setTimeout(init_normal, 100);
 		return;
 	}
 	init_column_categories();
@@ -1565,7 +1565,7 @@ function init_beforeDOM() {
 		if (window.console) {
 			console.log('FreshRSS waiting for jQuery…');
 		}
-		window.setTimeout(init_beforeDOM, 100);
+		setTimeout(init_beforeDOM, 100);
 		return;
 	}
 	if (['normal', 'reader', 'global'].indexOf(context.current_view) >= 0) {
@@ -1578,7 +1578,7 @@ function init_afterDOM() {
 		if (window.console) {
 			console.log('FreshRSS waiting again for jQuery…');
 		}
-		window.setTimeout(init_afterDOM, 100);
+		setTimeout(init_afterDOM, 100);
 		return;
 	}
 	init_notifications();
@@ -1592,7 +1592,7 @@ function init_afterDOM() {
 		init_print_action();
 		init_post_action();
 		init_notifs_html5();
-		window.setInterval(refreshUnreads, 120000);
+		setInterval(refreshUnreads, 120000);
 	} else {
 		init_subscription();
 		init_crypto_form();

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -49,9 +49,10 @@ function redirect(url, new_tab) {
 
 function needsScroll(elem) {
 	const winBottom = document.documentElement.scrollTop + document.documentElement.clientHeight,
-		elemBottom = elem.offsetTop + elem.offsetHeight;
-	return (elem.offsetTop < document.documentElement.scrollTop || elemBottom > winBottom) ?
-		elem.offsetTop - (document.documentElement.clientHeight / 2) : 0;
+		elemTop = elem.offsetParent.offsetTop + elem.offsetTop,
+		elemBottom = elemTop + elem.offsetHeight;
+	return (elemTop < document.documentElement.scrollTop || elemBottom > winBottom) ?
+		elemTop - (document.documentElement.clientHeight / 2) : 0;
 }
 
 function str2int(str) {
@@ -178,7 +179,8 @@ function send_mark_read_queue(queue, asRead) {
 				div.querySelectorAll('a.read > .icon').forEach(function (img) { img.outerHTML = myIcons.read; });
 				inc--;
 			} else {
-				div.classList.add('not_read', 'keep_unread');
+				div.classList.add('not_read');
+				div.classList.add('keep_unread');	//Split for IE11
 				div.querySelectorAll('a.read').forEach(function (a) { a.setAttribute('href', a.getAttribute('href').replace('&is_read=1', '')); });
 				div.querySelectorAll('a.read > .icon').forEach(function (img) { img.outerHTML = myIcons.unread; });
 				inc++;


### PR DESCRIPTION
The overall goal is to improve performance, in particular on mobile and server-side.

In particular, this patch improves scroll performance when using the auto mark-as-read feature:
Mark-as-read requests are queued and sent max once per second. https://github.com/FreshRSS/FreshRSS/pull/2199/commits/cd9a9a93099b80fb3f8c2ba09266aa31955cbdd6

The scroll event listener is also rewritten to be much lighter https://github.com/FreshRSS/FreshRSS/pull/2199/commits/caa893e14b46bc9b52f251ca93eada0c57634302

As the same time, in distinct commits, I have started some refactoring https://github.com/FreshRSS/FreshRSS/pull/2199/commits/eefeb2341915d677e446cd733fc58b45efb7f5d9 :
* to start using ES6 syntax (limited to an IE11-subset)
* to ensure that jQuery variable names start with a `$` (to distinguish them),
* and to avoid jQuery in easy cases (we might be able to soon avoid jQuery fully).