### PR TITLE
HTTP_X_FORWARDED_PREFIX for cookie path

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -7,7 +7,8 @@ header("Content-Security-Policy: default-src 'self'");
 require(LIB_PATH . '/lib_install.php');
 
 session_name('FreshRSS');
-session_set_cookie_params(0, dirname(empty($_SERVER['REQUEST_URI']) ? '/' : dirname($_SERVER['REQUEST_URI'])), null, false, true);
+$forwardedPrefix = empty($_SERVER['HTTP_X_FORWARDED_PREFIX']) ? '' : rtrim($_SERVER['HTTP_X_FORWARDED_PREFIX'], '/ ');
+session_set_cookie_params(0, $forwardedPrefix . dirname(empty($_SERVER['REQUEST_URI']) ? '/' : dirname($_SERVER['REQUEST_URI'])), null, false, true);
 session_start();
 
 if (isset($_GET['step'])) {

--- a/lib/Minz/Session.php
+++ b/lib/Minz/Session.php
@@ -61,7 +61,11 @@ class Minz_Session {
 
 	public static function getCookieDir() {
 		// Get the script_name (e.g. /p/i/index.php) and keep only the path.
-		$cookie_dir = empty($_SERVER['REQUEST_URI']) ? '/' : $_SERVER['REQUEST_URI'];
+		$cookie_dir = '';
+		if (!empty($_SERVER['HTTP_X_FORWARDED_PREFIX'])) {
+			$cookie_dir .= rtrim($_SERVER['HTTP_X_FORWARDED_PREFIX'], '/ ');
+		}
+		$cookie_dir .= empty($_SERVER['REQUEST_URI']) ? '/' : $_SERVER['REQUEST_URI'];
 		if (substr($cookie_dir, -1) !== '/') {
 			$cookie_dir = dirname($cookie_dir) . '/';
 		}


### PR DESCRIPTION
Forgotten. Follow-up of https://github.com/FreshRSS/FreshRSS/pull/2191
The symptoms are otherwise the impossibility to login using Web form behind a reverse-proxy when using path-based routing, with a message in logs: `nonce=` (empty)