### PR TITLE
Apache performance

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -15,7 +15,11 @@ WORKDIR ${FRESHRSS_ROOT}
 COPY . ${FRESHRSS_ROOT}
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
-RUN sed -r -i "/^[ ]*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/httpd.conf && \
+RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
+		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
+	sed -r -i "/^[ ]*LoadModule .*mod_(access_compat|alias|auth[n]?_[^.]+|authz_groupfile|authz_host|authz_user|autoindex|negotiation|status|version).so$/s/^/#/" \ 
+		/etc/apache2/httpd.conf && \
+	sed -r -i "/^[ ]*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/httpd.conf && \
 	echo "17,37 * * * * php ${FRESHRSS_ROOT}/app/actualize_script.php 2>&1 | tee /tmp/FreshRSS.log" >> \
 		/var/spool/cron/crontabs/root
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,11 +2,9 @@ FROM alpine:3.8
 
 RUN apk add --no-cache \
 	apache2 php7-apache2 \
-	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
+	php7 php7-curl php7-intl php7-mbstring php7-xml php7-zip \
 	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-session php7-simplexml php7-xmlreader php7-zlib \
-	php7-pdo_sqlite \
-	php7-pdo_mysql \
-	php7-pdo_pgsql
+	php7-pdo_sqlite php7-pdo_mysql php7-pdo_pgsql
 
 ENV FRESHRSS_ROOT /var/www/FreshRSS
 RUN mkdir -p ${FRESHRSS_ROOT} /run/apache2/
@@ -17,11 +15,14 @@ COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
-	sed -r -i "/^[ ]*LoadModule .*mod_(access_compat|alias|auth[n]?_[^.]+|authz_groupfile|authz_host|authz_user|autoindex|negotiation|status|version).so$/s/^/#/" \ 
+	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|negotiation|status).so$/s/^/#/" \ 
 		/etc/apache2/httpd.conf && \
-	sed -r -i "/^[ ]*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/httpd.conf && \
+	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|headers|mime|setenvif).so$/s/^\s*#//" \ 
+		/etc/apache2/httpd.conf && \
+	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
+		/etc/apache2/httpd.conf && \
 	echo "17,37 * * * * php ${FRESHRSS_ROOT}/app/actualize_script.php 2>&1 | tee /tmp/FreshRSS.log" >> \
-		/var/spool/cron/crontabs/root
+		/var/spool/cron/crontabs/www-data
 
 ENV CRON_MIN ''
 ENTRYPOINT ["./Docker/entrypoint.sh"]

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -1,17 +1,17 @@
-<IfModule !deflate_module>
+<IfModule !mod_deflate.c>
 	LoadModule deflate_module modules/mod_deflate.so
 </IfModule>
-<IfModule !expires_module>
+<IfModule !mod_expires.c>
 	LoadModule expires_module modules/mod_expires.so
 </IfModule>
-<IfModule !headers_module>
+<IfModule !mod_headers.c>
 	LoadModule headers_module modules/mod_headers.so
 </IfModule>
-<IfModule !mime_module>
+<IfModule !mod_mime.c>
 	LoadModule mime_module modules/mod_mime.so
 </IfModule>
-<IfModule !rewrite_module>
-	LoadModule rewrite_module modules/mod_rewrite.so
+<IfModule !mod_setenvif.c>
+	LoadModule setenvif_module modules/mod_setenvif.so
 </IfModule>
 
 ServerName freshrss.localhost
@@ -21,7 +21,17 @@ CustomLog /dev/stdout combined
 ErrorLog /dev/stderr
 AllowEncodedSlashes On
 
+<Directory />
+	AllowOverride None
+	Options FollowSymLinks
+	Require all denied
+</Directory>
+
 <Directory /var/www/FreshRSS/p>
-	AllowOverride AuthConfig FileInfo Indexes Limit
+	Include /var/www/FreshRSS/p/.htaccess
 	Require all granted
+</Directory>
+
+<Directory /var/www/FreshRSS/p/api>
+	Include /var/www/FreshRSS/p/api/.htaccess
 </Directory>

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -1,19 +1,3 @@
-<IfModule !mod_deflate.c>
-	LoadModule deflate_module modules/mod_deflate.so
-</IfModule>
-<IfModule !mod_expires.c>
-	LoadModule expires_module modules/mod_expires.so
-</IfModule>
-<IfModule !mod_headers.c>
-	LoadModule headers_module modules/mod_headers.so
-</IfModule>
-<IfModule !mod_mime.c>
-	LoadModule mime_module modules/mod_mime.so
-</IfModule>
-<IfModule !mod_setenvif.c>
-	LoadModule setenvif_module modules/mod_setenvif.so
-</IfModule>
-
 ServerName freshrss.localhost
 Listen 0.0.0.0:80
 DocumentRoot /var/www/FreshRSS/p/
@@ -28,10 +12,16 @@ AllowEncodedSlashes On
 </Directory>
 
 <Directory /var/www/FreshRSS/p>
+	AllowOverride None
 	Include /var/www/FreshRSS/p/.htaccess
+	Options FollowSymLinks
 	Require all granted
 </Directory>
 
 <Directory /var/www/FreshRSS/p/api>
 	Include /var/www/FreshRSS/p/api/.htaccess
+</Directory>
+
+<Directory /var/www/FreshRSS/p/i>
+	IncludeOptional /var/www/FreshRSS/p/i/.htaccess
 </Directory>

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -6,7 +6,7 @@ chown -R :www-data .
 chmod -R g+r . && chmod -R g+w ./data/
 
 if [ -n "$CRON_MIN" ]; then
-	sed -r -i "\#FreshRSS#s#^[^ ]+ #$CRON_MIN #" /var/spool/cron/crontabs/root
+	sed -r -i "\#FreshRSS#s#^[^ ]+ #$CRON_MIN #" /var/spool/cron/crontabs/www-data
 fi
 
 exec "$@"

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,4 @@
+.htpasswd
 config.php
 config.php.bak.php
 force-https.txt

--- a/docs/en/users/06_Mobile_access.md
+++ b/docs/en/users/06_Mobile_access.md
@@ -29,7 +29,7 @@ See the [page about the Fever compatible API](06_Fever_API.md) for another possi
 	* If you get *Service Unavailable!*, then check from step 1 again.
 	* With __Apache__:
 		* If you get *FAIL getallheaders!*, the combination of your PHP version and your Web server does not provide access to [`getallheaders`](http://php.net/getallheaders)
-			* Update to PHP 5.4+, or use PHP as module instead of CGI. Otherwise turn on Apache `mod_rewrite`:
+			* Update to PHP 5.4+, or use PHP as module instead of CGI. Otherwise turn on Apache `mod_setenvif` (often enabled by default), or `mod_rewrite` with the following procedure:
 				* Allow [`FileInfo` in `.htaccess`](http://httpd.apache.org/docs/trunk/mod/core.html#allowoverride): see the [server setup](../admins/02_Installation.md) again.
 				* Enable [`mod_rewrite`](http://httpd.apache.org/docs/trunk/mod/mod_rewrite.html):
 					* With Debian / Ubuntu: `sudo a2enmod rewrite`

--- a/docs/fr/users/06_Mobile_access.md
+++ b/docs/fr/users/06_Mobile_access.md
@@ -29,7 +29,7 @@ Voir la [page sur l’API compatible Fever](06_Fever_API.md) pour une autre poss
 	* Si vous obtenez *Service Unavailable!*, retourner à l’étape 6.
 	* Avec __Apache__:
 		* Si vous obtenez *FAIL getallheaders!*, alors la combinaison de votre version de PHP et de votre serveur Web ne permet pas l’accès à [`getallheaders`](http://php.net/getallheaders)
-			* Utilisez au moins PHP 5.4+, ou utilisez PHP en tant que module plutôt que CGI. Sinon, activer Apache `mod_rewrite` :
+			* Utilisez au moins PHP 5.4+, ou utilisez PHP en tant que module plutôt que CGI. Sinon, activer Apache `mod_setenvif` (souvent activé par défault), ou `mod_rewrite` avec la procédure suivate :
 				* Autoriser [`FileInfo` dans `.htaccess`](http://httpd.apache.org/docs/trunk/mod/core.html#allowoverride) : revoir [l’installation du serveur](01_Installation.md).
 				* Activer [`mod_rewrite`](http://httpd.apache.org/docs/trunk/mod/mod_rewrite.html) :
 					* Sur Debian / Ubuntu : `sudo a2enmod rewrite`

--- a/docs/fr/users/06_Mobile_access.md
+++ b/docs/fr/users/06_Mobile_access.md
@@ -29,7 +29,7 @@ Voir la [page sur l’API compatible Fever](06_Fever_API.md) pour une autre poss
 	* Si vous obtenez *Service Unavailable!*, retourner à l’étape 6.
 	* Avec __Apache__:
 		* Si vous obtenez *FAIL getallheaders!*, alors la combinaison de votre version de PHP et de votre serveur Web ne permet pas l’accès à [`getallheaders`](http://php.net/getallheaders)
-			* Utilisez au moins PHP 5.4+, ou utilisez PHP en tant que module plutôt que CGI. Sinon, activer Apache `mod_setenvif` (souvent activé par défault), ou `mod_rewrite` avec la procédure suivate :
+			* Utilisez au moins PHP 5.4+, ou utilisez PHP en tant que module plutôt que CGI. Sinon, activer Apache `mod_setenvif` (souvent activé par défault), ou `mod_rewrite` avec la procédure suivante :
 				* Autoriser [`FileInfo` dans `.htaccess`](http://httpd.apache.org/docs/trunk/mod/core.html#allowoverride) : revoir [l’installation du serveur](01_Installation.md).
 				* Activer [`mod_rewrite`](http://httpd.apache.org/docs/trunk/mod/mod_rewrite.html) :
 					* Sur Debian / Ubuntu : `sudo a2enmod rewrite`
@@ -72,7 +72,7 @@ Tout client supportant une API de type Google Reader. Sélection :
 
 # API compatible Google Reader
 
-Exemples de requêtes simples:
+Exemples de requêtes simples :
 
 ```sh
 # Authentification utilisant le mot de passe API (Email et Passwd peuvent être passés en GET, ou POST - mieux)

--- a/p/api/.htaccess
+++ b/p/api/.htaccess
@@ -1,4 +1,9 @@
-<IfModule mod_rewrite.c>
-	RewriteEngine on
-	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+<IfModule mod_setenvif.c>
+	SetEnvIf "^Authorization$" "(.*)" HTTP_AUTHORIZATION=$1
+</IfModule>
+<IfModule !mod_setenvif.c>
+	<IfModule mod_rewrite.c>
+		RewriteEngine on
+		RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+	</IfModule>
 </IfModule>

--- a/p/i/.gitignore
+++ b/p/i/.gitignore
@@ -1,1 +1,1 @@
-.htaccess
+.ht*


### PR DESCRIPTION
API: Use Apache SetEnvIf if available and fallback to RewriteRule.
Docker: Run cron job with correct www-data user instead of root
Docker: Hard-include Apache .htaccess to avoid having to scan for changes in those files.
Docker: Disable Apache security check of symlinks, which we do not use anyway.
Docker: Disable unused Apache and PHP modules.