### PR TITLE
Changelog + Revert mistakes from 2202 and 2204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 * Bug fixing
 	* Fix missing HTTP `X-Forwarded-Prefix` in cookie path behind a reverse-proxy [#2201](https://github.com/FreshRSS/FreshRSS/pull/2201)
+* Deployment
+	* Docker improvements [#2202](https://github.com/FreshRSS/FreshRSS/pull/2202)
+		* Performance: Hard-include Apache .htaccess to avoid having to scan for changes in those files
+		* Performance: Disable unused Apache security check of symlinks
+		* Performance: Disable unused Apache modules
+		* Add option to mount custom `.htaccess` for HTTP authentication
+		* Docker logs gets PHP syslog messages (e.g. from cron job and when fetching external content)
+	* Send a copy of PHP syslog messages to STDERR [#2208](https://github.com/FreshRSS/FreshRSS/pull/2208)
+	* Run Docker cron job with Apache user instead of root [#2208](https://github.com/FreshRSS/FreshRSS/pull/2208)
+	* Accept HTTP header `X-WebAuth-User` for delegated HTTP Authentication [#2204](https://github.com/FreshRSS/FreshRSS/pull/2204)
+* API
+	* Automatic test of API configuration [#2207](https://github.com/FreshRSS/FreshRSS/pull/2207)
+	* Use Apache SetEnvIf module if available and fall-back to RewriteRule [#2202](https://github.com/FreshRSS/FreshRSS/pull/2202)
+* Security
+	* Fixes when HTTP user does not exist in FreshRSS [#2204](https://github.com/FreshRSS/FreshRSS/pull/2204)
 
 
 ## 2018-12-22 FreshRSS 1.13.0

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 RUN apk add --no-cache \
 	apache2 php7-apache2 \
-	php7 php7-curl php7-intl php7-mbstring php7-xml php7-zip \
+	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
 	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-session php7-simplexml php7-xmlreader php7-zlib \
 	php7-pdo_sqlite php7-pdo_mysql php7-pdo_pgsql
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -205,35 +205,20 @@ sudo docker run -d --restart unless-stopped --log-opt max-size=10m \
 
 ## More deployment options
 
-### Use HTTP-based login (advanced users)
-
-FreshRSS allows logins using either a Web form (easiest) or based on HTTP authentication.
-If you want HTTP authentication, [Træfik can do it](https://docs.traefik.io/configuration/entrypoints/#authentication) (otherwise, see section below for giving this task to Apache inside the FreshRSS Docker image):
-
-```
-sudo docker run ...
-  --label traefik.frontend.auth.basic.users='admin:$2y$05$BJ3eexf8gkyfHR1L38nVMeQ2RbQ5PF6KW4/PlttXeR6IOGZKH4sbC,alice:$2y$05$0vv8eexRq4qujzyBCYh6a.bo/KUvuXCmjJ54RqEHBApaHdQrpzFJC' \
-  --label traefik.frontend.auth.removeheader=true \
-  --label traefik.frontend.auth.headerField=X-WebAuth-User \
-  --name freshrss freshrss/freshrss
-```
-
-N.B.: You can create password hashes for instance with: `htpasswd -nB alice`
-
 ### Custom Apache configuration (advanced users)
 
 Changes in Apache `.htaccess` files are applied when restarting the container.
-In particular, if you want FreshRSS to use HTTP-based login (instead of the easier Web form login, and instead of letting Træfik do it), you can mount your own `./FreshRSS/p/i/.htaccess`:
+In particular, if you want FreshRSS to use HTTP-based login (instead of the easier Web form login), you can mount your own `./FreshRSS/p/i/.htaccess`:
 
 ```
 sudo docker run ...
-  -v ./your/.htaccess:/var/www/FreshRSS/p/i/.htaccess \
-  -v ./your/.htpasswd:/var/www/FreshRSS/data/.htpasswd \
+  -v /your/.htaccess:/var/www/FreshRSS/p/i/.htaccess \
+  -v /your/.htpasswd:/var/www/FreshRSS/data/.htpasswd \
   ...
   --name freshrss freshrss/freshrss
 ```
 
-Example of `./your/.htaccess` referring to `./your/.htpasswd`:
+Example of `/your/.htaccess` referring to `/your/.htpasswd`:
 ```
 AuthUserFile /var/www/FreshRSS/data/.htpasswd
 AuthName "FreshRSS"


### PR DESCRIPTION
* GMP is needed because Alpine on e.g. ARM runs 32-bit https://github.com/FreshRSS/FreshRSS/pull/2202
* Remove documentation for Træfik HTTP authentication as it is not compatible with API
https://github.com/FreshRSS/FreshRSS/pull/2204

https://github.com/FreshRSS/FreshRSS/pull/2208
https://github.com/FreshRSS/FreshRSS/pull/2207