### PR TITLE
Alpine 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2019-0X-XX FreshRSS 1.13.2-dev
 
+* Deployment
+	* Docker image updated to Alpine 3.9 with PHP 7.2.14 and Apache 2.4.38 [#2238](https://github.com/FreshRSS/FreshRSS/pull/2238)
+
 
 ## 2019-01-26 FreshRSS 1.13.1
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ENV TZ UTC
 


### PR DESCRIPTION
PHP 7.2.14, Apache 2.4.38
https://alpinelinux.org/posts/Alpine-3.9.0-released.html