### PR TITLE
Removes hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
-  - hhvm
 
 install:
   # newest version without https://github.com/squizlabs/PHP_CodeSniffer/pull/1404

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 	* Fix encoding problem in Fever API [#2241](https://github.com/FreshRSS/FreshRSS/issues/2241)
 * UI
 	* New themes *Ansum* and *Mapco* [#2245](https://github.com/FreshRSS/FreshRSS/pull/2245)
+	* Rewrite jQuery and keyboard shortcut code as native JavaScript ES6 (except for graphs on the statistics pages) [#2234](https://github.com/FreshRSS/FreshRSS/pull/2234)
 	* Batch scroll-as-read for better client-side and server-side performance [#2199](https://github.com/FreshRSS/FreshRSS/pull/2199)
-	* Rewrite some jQuery code as native JavaScript [#2234](https://github.com/FreshRSS/FreshRSS/pull/2234)
 * Deployment
 	* Docker image updated to Alpine 3.9 with PHP 7.2.14 and Apache 2.4.38 [#2238](https://github.com/FreshRSS/FreshRSS/pull/2238)
 * I18n


### PR DESCRIPTION
Because HHVM removes PHP support
https://www.phoronix.com/scan.php?page=news_item&px=HHVM-4.0-Released