### PR TITLE
Use getenv instead of $_SERVER for environment variables

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -33,7 +33,7 @@ safe_define('FRESHRSS_USERAGENT', 'FreshRSS/' . FRESHRSS_VERSION . ' (' . PHP_OS
 safe_define('PHP_COMPRESSION', false);
 
 // For cases when syslog is not available
-safe_define('COPY_SYSLOG_TO_STDERR', isset($_SERVER['COPY_SYSLOG_TO_STDERR']) ? filter_var($_SERVER['COPY_SYSLOG_TO_STDERR'], FILTER_VALIDATE_BOOLEAN) : false);
+safe_define('COPY_SYSLOG_TO_STDERR', filter_var(getenv('COPY_SYSLOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
 
 // Maximum log file size in Bytes, before it will be divided by two
 safe_define('MAX_LOG_SIZE', 1048576);


### PR DESCRIPTION
getenv() is the proper way, and $_SERVER was not working on some
configurations.
Improvement of https://github.com/FreshRSS/FreshRSS/pull/2213