### PR TITLE
Add an option validation on cli commands

### DIFF
--- a/cli/_cli.php
+++ b/cli/_cli.php
@@ -3,6 +3,9 @@ if (php_sapi_name() !== 'cli') {
 	die('FreshRSS error: This PHP script may only be invoked from command line!');
 }
 
+const REGEX_INPUT_OPTIONS = '/^--/';
+const REGEX_PARAM_OPTIONS = '/:*$/';
+
 require(__DIR__ . '/../constants.php');
 require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader
 require(LIB_PATH . '/lib_install.php');
@@ -63,4 +66,26 @@ function performRequirementCheck($databaseType) {
 		}
 		fail($message);
 	}
+}
+
+function getLongOptions($options, $regex) {
+	$longOptions = array_filter($options, function($a) use ($regex) {
+		return preg_match($regex, $a);
+	});
+	return array_map(function($a) use ($regex) {
+		return preg_replace($regex, '', $a);
+	}, $longOptions);
+}
+
+function validateOptions($input, $params) {
+	$sanitizeInput = getLongOptions($input, REGEX_INPUT_OPTIONS);
+	$sanitizeParams = getLongOptions($params, REGEX_PARAM_OPTIONS);
+	$unknownOptions = array_diff($sanitizeInput, $sanitizeParams);
+
+	if (0 === count($unknownOptions)) {
+		return true;
+	}
+
+	fwrite(STDERR, sprintf("FreshRSS error: unknown options: %s\n", implode (', ', $unknownOptions)));
+	return false;
 }

--- a/cli/_update-or-create-user.php
+++ b/cli/_update-or-create-user.php
@@ -22,7 +22,7 @@ if (!$isUpdate) {
 
 $options = getopt('', $params);
 
-if (empty($options['user'])) {
+if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename($_SERVER['SCRIPT_FILENAME']) .
 		" --user username ( --password 'password' --api_password 'api_password'" .
 		" --language en --email user@example.net --token 'longRandomString'" .

--- a/cli/actualize-user.php
+++ b/cli/actualize-user.php
@@ -2,11 +2,13 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-$options = getopt('', array(
-		'user:',
-	));
+$params = array(
+	'user:',
+);
 
-if (empty($options['user'])) {
+$options = getopt('', $params);
+
+if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename(__FILE__) . " --user username");
 }
 

--- a/cli/db-optimize.php
+++ b/cli/db-optimize.php
@@ -2,11 +2,13 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-$options = getopt('', array(
-		'user:',
-	));
+$params = array(
+	'user:',
+);
 
-if (empty($options['user'])) {
+$options = getopt('', $params);
+
+if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename(__FILE__) . " --user username");
 }
 

--- a/cli/delete-user.php
+++ b/cli/delete-user.php
@@ -2,11 +2,13 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-$options = getopt('', array(
-		'user:',
-	));
+$params = array(
+	'user:',
+);
 
-if (empty($options['user'])) {
+$options = getopt('', $params);
+
+if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename(__FILE__) . " --user username");
 }
 $username = $options['user'];

--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -31,10 +31,10 @@ $dBparams = array(
 
 $options = getopt('', array_merge($params, $dBparams));
 
-if (empty($options['default_user'])) {
+if (!validateOptions($argv, array_merge($params, $dBparams)) || empty($options['default_user'])) {
 	fail('Usage: ' . basename(__FILE__) . " --default_user admin ( --auth_type form" .
-		" --environment production --base_url https://rss.example.net" .
-		" --language en --title FreshRSS --allow_anonymous --api_enabled" .
+		" --environment production --base_url https://rss.example.net --allow_robots" .
+		" --language en --title FreshRSS --allow_anonymous --allow_anonymous_refresh --api_enabled" .
 		" --db-type mysql --db-host localhost:3306 --db-user freshrss --db-password dbPassword123" .
 		" --db-base freshrss --db-prefix freshrss_ --disable_update )");
 }

--- a/cli/export-opml-for-user.php
+++ b/cli/export-opml-for-user.php
@@ -2,11 +2,13 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-$options = getopt('', array(
-		'user:',
-	));
+$params = array(
+	'user:',
+);
 
-if (empty($options['user'])) {
+$options = getopt('', $params);
+
+if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename(__FILE__) . " --user username > /path/to/file.opml.xml");
 }
 

--- a/cli/export-zip-for-user.php
+++ b/cli/export-zip-for-user.php
@@ -2,12 +2,14 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-$options = getopt('', array(
-		'user:',
-		'max-feed-entries:',
-	));
+$params = array(
+	'user:',
+	'max-feed-entries:',
+);
 
-if (empty($options['user'])) {
+$options = getopt('', $params);
+
+if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename(__FILE__) . " --user username ( --max-feed-entries 100 ) > /path/to/file.zip");
 }
 

--- a/cli/import-for-user.php
+++ b/cli/import-for-user.php
@@ -2,12 +2,14 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-$options = getopt('', array(
-		'user:',
-		'filename:',
-	));
+$params = array(
+	'user:',
+	'filename:',
+);
 
-if (empty($options['user']) || empty($options['filename'])) {
+$options = getopt('', $params);
+
+if (!validateOptions($argv, $params) || empty($options['user']) || empty($options['filename'])) {
 	fail('Usage: ' . basename(__FILE__) . " --user username --filename /path/to/file.ext");
 }
 

--- a/cli/reconfigure.php
+++ b/cli/reconfigure.php
@@ -27,6 +27,14 @@ $dBparams = array(
 
 $options = getopt('', array_merge($params, $dBparams));
 
+if (!validateOptions($argv, array_merge($params, $dBparams))) {
+	fail('Usage: ' . basename(__FILE__) . " --default_user admin ( --auth_type form" .
+		" --environment production --base_url https://rss.example.net --allow_robots" .
+		" --language en --title FreshRSS --allow_anonymous --allow_anonymous_refresh --api_enabled" .
+		" --db-type mysql --db-host localhost:3306 --db-user freshrss --db-password dbPassword123" .
+		" --db-base freshrss --db-prefix freshrss_ --disable_update )");
+}
+
 fwrite(STDERR, 'Reconfiguring FreshRSS…' . "\n");
 
 $config = Minz_Configuration::get('system');


### PR DESCRIPTION
If an option used on cli is not recognized, the command
aborts and displays an error message.
If the typed option is similar to one of the recognized
options, a hint is displayed.

At the moment, there is a limitation on long options.
Short options are not validated at the moment.

See #2046