### PR TITLE
[CI] Add PHP 7.3 to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: php
 php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 install:
   # newest version without https://github.com/squizlabs/PHP_CodeSniffer/pull/1404
-  - composer global require squizlabs/php_codesniffer "<=3.0.0RC4"
+  - composer global require squizlabs/php_codesniffer
 
 script:
   - phpenv rehash

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset name="FreshRSS Ruleset">
 	<description>Created with the PHP Coding Standard Generator. https://edorian.github.com/php-coding-standard-generator/</description>
 	<!-- to circumvent https://github.com/squizlabs/PHP_CodeSniffer/pull/1404 -->
-	<!--<arg name="tab-width" value="10"/>-->
+	<arg name="tab-width" value="40"/>
 	<exclude-pattern>./static</exclude-pattern>
 	<exclude-pattern>./vendor</exclude-pattern>
 	<exclude-pattern>./lib/SimplePie/</exclude-pattern>
@@ -33,8 +33,9 @@
 		<exclude-pattern>./app/SQL/install.sql.mysql.php</exclude-pattern>
 		<exclude-pattern>./app/SQL/install.sql.pgsql.php</exclude-pattern>
 		<properties>
-			<property name="lineLimit" value="80"/>
-			<property name="absoluteLineLimit" value="180"/>
+			<property name="lineLimit" value="100"/>
+			<!-- needs to be large to accomodate extra large tab width to circumvent https://github.com/squizlabs/PHP_CodeSniffer/pull/1404 -->
+			<property name="absoluteLineLimit" value="500"/>
 		</properties>
 	</rule>
 	<!-- When calling a function: -->


### PR DESCRIPTION
This also requires an update of phpcs, since the old version won't run on PHP 7.3.

By setting setting the tab-width to 40 it works around the behavior introduced in https://github.com/squizlabs/PHP_CodeSniffer/pull/1404 which erroneously interprets positioning spaces as indentation. ("If the line started with tabs, but had spaces after that, no error was thrown at all.")

That makes any line length checks ineffective, but I think line length checks aren't very useful anyway. They're basically just a (very!) rough indication that you might want to consider some refactoring.