### PR TITLE
[CI] Force php -l failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
   - phpenv rehash
-  - git ls-files -z "*.php" | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
+  - find . -not -path "./lib/JSON.php" -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
   - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
   - |
     if [[ $VALIDATE_STANDARD == yes ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ install:
 
 script:
   - phpenv rehash
-  - git ls-files -z "*.php" | xargs -0 -n1 -P4 php -l
+  - git ls-files -z "*.php" | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
+  - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
   - |
     if [[ $VALIDATE_STANDARD == yes ]]; then
       COMPOSER_BIN=$(composer global config --absolute bin-dir)


### PR DESCRIPTION
By redirecting stderr to a file and checking if the filesize is greater than 0 bytes, we can also force failure for warnings.

See discussion in <https://github.com/FreshRSS/FreshRSS/pull/2362#issuecomment-480623161>.