### PR TITLE
FreshRSS 1.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ install:
 
 script:
   - phpenv rehash
-  - git ls-files -z "*.php" | xargs -0 -n1 -P4 php -l
+  - find . -not -path "./lib/JSON.php" -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
+  - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
   - |
     if [[ $VALIDATE_STANDARD == yes ]]; then
       COMPOSER_BIN=$(composer global config --absolute bin-dir)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 
 script:
   - phpenv rehash
+  - git ls-files -z "*.php" | xargs -0 -n1 -P4 php -l
   - |
     if [[ $VALIDATE_STANDARD == yes ]]; then
       COMPOSER_BIN=$(composer global config --absolute bin-dir)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ﻿# FreshRSS changelog
 
-## 2019-0X-XX FreshRSS 1.14.2-dev
+## 2019-04-XX FreshRSS 1.14.2-dev
 
+* Bug fixing (regressions introduced in 1.14.X)
+	* Fix PHP 5.5- compatibility [#2359](https://github.com/FreshRSS/FreshRSS/issues/2359)
+* Bug fixing (misc.)
+	* Fix minor code syntax warning in API [#2362](https://github.com/FreshRSS/FreshRSS/pull/2362)
+* Misc.
+	* Add Travis check for PHP syntax [#2361](https://github.com/FreshRSS/FreshRSS/pull/2361)
 
 
 ## 2019-04-07 FreshRSS 1.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# FreshRSS changelog
 
+## 2019-0X-XX FreshRSS 1.14.2-dev
+
+
+
 ## 2019-04-07 FreshRSS 1.14.1
 
 * Bug fixing (regressions introduced in 1.14.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# FreshRSS changelog
 
-## 2019-04-XX FreshRSS 1.14.2-dev
+## 2019-04-08 FreshRSS 1.14.2
 
 * Bug fixing (regressions introduced in 1.14.X)
 	* Fix PHP 5.5- compatibility [#2359](https://github.com/FreshRSS/FreshRSS/issues/2359)

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -166,7 +166,8 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 	 * tab and up.
 	 */
 	public function shortcutAction() {
-		$this->view->list_keys = SHORTCUT_KEYS;
+		global $SHORTCUT_KEYS;
+		$this->view->list_keys = $SHORTCUT_KEYS;
 
 		if (Minz_Request::isPost()) {
 			FreshRSS_Context::$user_conf->shortcuts = validateShortcutList(Minz_Request::param('shortcuts'));

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -92,7 +92,7 @@ return array(
 		'auto_remove_article' => 'Rescondre los articles aprèp lectura',
 		'confirm_enabled' => 'Mostrar una confirmacion per las accions del tipe « o marcar tot coma legit »',
 		'display_articles_unfolded' => 'Mostrar los articles desplegats per defaut',
-		'display_categories_unfolded' => 'Mostrar las categorias desplegats per defaut',
+		'display_categories_unfolded' => 'Mostrar las categorias desplegadas per defaut',
 		'hide_read_feeds' => 'Rescondre las categorias & fluxes sens articles pas legits (fonciona pas amb la configuracion « Mostrar totes los articles »)',
 		'img_with_lazyload' => 'Utilizar lo mòde “cargament tardiu” pels imatges',
 		'jump_next' => 'sautar al vesin venent pas legit (flux o categoria)',

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.14.2-dev');
+define('FRESHRSS_VERSION', '1.14.2');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.14.1');
+define('FRESHRSS_VERSION', '1.14.2-dev');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -549,7 +549,7 @@ function _i($icon, $url_only = false) {
 }
 
 
-const SHORTCUT_KEYS = array(
+$SHORTCUT_KEYS = array(	//No const for < PHP 5.6 compatibility
 			'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
 			'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
 			'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
@@ -559,6 +559,7 @@ const SHORTCUT_KEYS = array(
 		);
 
 function validateShortcutList($shortcuts) {
+	global $SHORTCUT_KEYS;
 	$legacy = array(
 			'down' => 'ArrowDown', 'left' => 'ArrowLeft', 'page_down' => 'PageDown', 'page_up' => 'PageUp',
 			'right' => 'ArrowRight', 'up' => 'ArrowUp',
@@ -567,17 +568,17 @@ function validateShortcutList($shortcuts) {
 	$shortcuts_ok = array();
 
 	foreach ($shortcuts as $key => $value) {
-		if (in_array($value, SHORTCUT_KEYS)) {
+		if (in_array($value, $SHORTCUT_KEYS)) {
 			$shortcuts_ok[$key] = $value;
 		} elseif (isset($legacy[$value])) {
 			$shortcuts_ok[$key] = $legacy[$value];
 		} else {	//Case-insensitive search
 			if ($upper === null) {
-				$upper = array_map('strtoupper', SHORTCUT_KEYS);
+				$upper = array_map('strtoupper', $SHORTCUT_KEYS);
 			}
 			$i = array_search(strtoupper($value), $upper);
 			if ($i !== false) {
-				$shortcuts_ok[$key] = SHORTCUT_KEYS[$i];
+				$shortcuts_ok[$key] = $SHORTCUT_KEYS[$i];
 			}
 		}
 	}

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -377,7 +377,7 @@ function subscriptionEdit($streamNames, $titles, $action, $add = '', $remove = '
 						$http_auth = '';
 						try {
 							$feed = FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, $c_name, $http_auth);
-							continue;
+							continue 2;
 						} catch (Exception $e) {
 							Minz_Log::error('subscriptionEdit error subscribe: ' . $e->getMessage(), API_LOG);
 						}


### PR DESCRIPTION
Quick [minor release](https://github.com/FreshRSS/FreshRSS/milestones/1.14.2) to fix compatibility with PHP 5.5-.

Full [changelog](https://github.com/FreshRSS/FreshRSS/blob/dev/CHANGELOG.md):

* Bug fixing (regressions introduced in 1.14.X)
	* Fix PHP 5.5- compatibility [#2359](https://github.com/FreshRSS/FreshRSS/issues/2359)
* Bug fixing (misc.)
	* Fix minor code syntax warning in API [#2362](https://github.com/FreshRSS/FreshRSS/pull/2362)
* Misc.
	* Add Travis check for PHP syntax [#2361](https://github.com/FreshRSS/FreshRSS/pull/2361)