### PR TITLE
Fix filter action display

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -240,7 +240,7 @@
 			<div class="group-controls">
 				<textarea name="filteractions_read" id="filteractions_read"><?php
 					foreach ($this->feed->filtersAction('read') as $filterRead) {
-						echo htmlspecialchars($filterRead->getRawInput(), ENT_NOQUOTES, 'UTF-8'), "\n\n";
+						echo htmlspecialchars($filterRead->getRawInput(), ENT_NOQUOTES, 'UTF-8'), PHP_EOL;
 					}
 				?></textarea>
 				<?php echo _i('help'); ?> <?php echo _t('sub.feed.filteractions.help'); ?>


### PR DESCRIPTION
Before, there was extra white lines between search terms when displaying
the data. It was not an issue for the storage since they were discarded
during the save process. But it was confusing.
Now, extra white lines are stripped.