### PR TITLE
Allow email as username

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -38,7 +38,7 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 	 * The username is also used as folder name, file name, and part of SQL table name.
 	 * '_' is a reserved internal username.
 	 */
-	const USERNAME_PATTERN = '([0-9a-zA-Z_][0-9a-zA-Z_.@+-]{1,38}|[0-9a-zA-Z])';
+	const USERNAME_PATTERN = '([0-9a-zA-Z_][0-9a-zA-Z_.@-]{1,38}|[0-9a-zA-Z])';
 
 	public static function checkUsername($username) {
 		return preg_match('/^' . self::USERNAME_PATTERN . '$/', $username) === 1;

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -38,7 +38,7 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 	 * The username is also used as folder name, file name, and part of SQL table name.
 	 * '_' is a reserved internal username.
 	 */
-	const USERNAME_PATTERN = '[0-9a-zA-Z_][0-9a-zA-Z_.@]{1,38}$|^[0-9a-zA-Z]';
+	const USERNAME_PATTERN = '([0-9a-zA-Z_][0-9a-zA-Z_.@+-]{1,38}|[0-9a-zA-Z])';
 
 	public static function checkUsername($username) {
 		return preg_match('/^' . self::USERNAME_PATTERN . '$/', $username) === 1;

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -38,7 +38,7 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 	 * The username is also used as folder name, file name, and part of SQL table name.
 	 * '_' is a reserved internal username.
 	 */
-	const USERNAME_PATTERN = '[0-9a-zA-Z_][0-9a-zA-Z_.]{1,38}|[0-9a-zA-Z]';
+	const USERNAME_PATTERN = '[0-9a-zA-Z_][0-9a-zA-Z_.@]{1,38}$|^[0-9a-zA-Z]';
 
 	public static function checkUsername($username) {
 		return preg_match('/^' . self::USERNAME_PATTERN . '$/', $username) === 1;


### PR DESCRIPTION
Before, it was possible to register email as username on cli but not in the
interface. This was caused by a bug in the pattern which was not working as
expected. If your input was "user@example.com", the PHP verification was
catching only "user" and was acting like the whole thing was catched. But
on the interface, the catching was unsuccesful.
Now, the catching should be working properly.

I needed to add "$|^" in the pattern because without, I was catching either
the beginning of a string either the last char. This was introduced as a
workaround for IE/Edge pattern matching on April 27, 2017. See #1511 for
more information.

I tested it only on FF. Tests on other browsers wanted.

See #2391