### PR TITLE
Promote FreshRSS-Notify in user documentation

### DIFF
--- a/docs/en/users/06_Mobile_access.md
+++ b/docs/en/users/06_Mobile_access.md
@@ -55,6 +55,8 @@ See the [page about the Fever compatible API](06_Fever_API.md) for another possi
 		* [FeedReader 2.0+](https://jangernert.github.io/FeedReader/) (Open source)
 	* MacOS
 		* [Vienna RSS](http://www.vienna-rss.com/) (Open source)
+	* Firefox
+		* [FreshRSS-Notify](https://addons.mozilla.org/fr/firefox/addon/freshrss-notify-webextension/) (Open source)
 
 
 # Google Reader compatible API

--- a/docs/en/users/06_Mobile_access.md
+++ b/docs/en/users/06_Mobile_access.md
@@ -56,7 +56,7 @@ See the [page about the Fever compatible API](06_Fever_API.md) for another possi
 	* MacOS
 		* [Vienna RSS](http://www.vienna-rss.com/) (Open source)
 	* Firefox
-		* [FreshRSS-Notify](https://addons.mozilla.org/fr/firefox/addon/freshrss-notify-webextension/) (Open source)
+		* [FreshRSS-Notify](https://addons.mozilla.org/firefox/addon/freshrss-notify-webextension/) (Open source)
 
 
 # Google Reader compatible API

--- a/docs/fr/users/06_Mobile_access.md
+++ b/docs/fr/users/06_Mobile_access.md
@@ -69,6 +69,8 @@ Tout client supportant une API de type Google Reader. Sélection :
 	* [FeedReader 2.0+](https://jangernert.github.io/FeedReader/) (Libre)
 * MacOS
 	* [Vienna RSS](http://www.vienna-rss.com/) (Libre)
+* Firefox
+	* [FreshRSS-Notify](https://addons.mozilla.org/fr/firefox/addon/freshrss-notify-webextension/) (Libre)
 
 # API compatible Google Reader
 


### PR DESCRIPTION
Bonjour,

Suite à un rapide échange avec @Alkarex [sur le fédiverse](https://framapiaf.org/@Purexo/102433697337820562) on m'a proposé d'ajouter mon extension FreshRSS-Notify (une extension permettant de notifier la présence de nouveaux articles non-lus avec un aperçu de ceux-ci) à la documentation de FreshRSS.
La page `06_Mobile_access` de la documentation dans la section **Clients compatibles** m'a semblé être la plus approprié.

PS : Désolé pour le double commit, je n'avais pas de client git sous la main, il doit être possible de squash les commits en un seul avant de merge avec l'interface web de PR de github.