### PR TITLE
Add php-gmp for API in Ubuntu 32-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 	* Make CGI Authorization configuration for API more compatible [#2446](https://github.com/FreshRSS/FreshRSS/issues/2446)
 	* Fix refresh icon in Swage theme [#2375](https://github.com/FreshRSS/FreshRSS/issues/2375)
 	* Fix message banner in Swage theme [#2379](https://github.com/FreshRSS/FreshRSS/issues/2379)
+	* Docker: Add `php-gmp` for API support in Ubuntu 32-bit [#2450](https://github.com/FreshRSS/FreshRSS/pull/2450)
 * UI
 	* New configuration page for each category [#2369](https://github.com/FreshRSS/FreshRSS/issues/2369)
 	* Update shortcut configuration page [#2405](https://github.com/FreshRSS/FreshRSS/issues/2405)

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && \
 	apt install --no-install-recommends -y \
 	ca-certificates cron curl \
 	apache2 libapache2-mod-php \
-	php-curl php-intl php-mbstring php-xml php-zip \
+	php-curl php-gmp php-intl php-mbstring php-xml php-zip \
 	php-sqlite3 php-mysql php-pgsql && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -55,5 +55,5 @@ CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND
 
-HEALTHCHECK --start-period=8s --interval=67s --timeout=5s --retries=3 \
+HEALTHCHECK --start-period=20s --interval=37s --timeout=5s --retries=3 \
 	CMD curl -fsS 'http://localhost/i/' | grep -q 'jsonVars' || exit 1

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -52,5 +52,5 @@ EXPOSE 80
 CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
 	exec httpd -D FOREGROUND
 
-HEALTHCHECK --start-period=8s --interval=67s --timeout=5s --retries=3 \
+HEALTHCHECK --start-period=20s --interval=37s --timeout=5s --retries=3 \
 	CMD curl -fsS 'http://localhost/i/' | grep -q 'jsonVars' || exit 1

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -13,7 +13,7 @@ RUN apt update && \
 	apt install --no-install-recommends -y \
 	ca-certificates cron curl \
 	apache2 libapache2-mod-php \
-	php-curl php-intl php-mbstring php-xml php-zip \
+	php-curl php-gmp php-intl php-mbstring php-xml php-zip \
 	php-sqlite3 php-mysql php-pgsql && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -67,5 +67,5 @@ CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND
 
-HEALTHCHECK --start-period=8s --interval=67s --timeout=5s --retries=3 \
+HEALTHCHECK --start-period=20s --interval=37s --timeout=5s --retries=3 \
 	CMD curl -fsS 'http://localhost/i/' | grep -q 'jsonVars' || exit 1


### PR DESCRIPTION
And adjust slightly the HEALTHCHECK parameters for faster start in
Træfik