### PR TITLE
Replace curl healthcheck with pure php, apply haodlint suggestions

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:19.04
 
 ENV TZ UTC
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update && \
-	apt install --no-install-recommends -y \
-	ca-certificates cron curl \
+RUN apt-get update && \
+	apt-get install --no-install-recommends -y \
+	ca-certificates cron \
 	apache2 libapache2-mod-php \
 	php-curl php-gmp php-intl php-mbstring php-xml php-zip \
 	php-sqlite3 php-mysql php-pgsql && \
@@ -56,4 +57,4 @@ CMD ([ -z "$CRON_MIN" ] || cron) && \
 	exec apache2 -D FOREGROUND
 
 HEALTHCHECK --start-period=20s --interval=37s --timeout=5s --retries=3 \
-	CMD curl -fsS 'http://localhost/i/' | grep -q 'jsonVars' || exit 1
+	CMD (php -r "readfile('http://localhost/i/');" | grep -q 'jsonVars') || exit 1

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -1,9 +1,8 @@
 FROM alpine:3.10
 
 ENV TZ UTC
-
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
-	curl \
 	apache2 php7-apache2 \
 	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
 	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-session php7-simplexml php7-xmlreader php7-zlib \
@@ -53,4 +52,4 @@ CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
 	exec httpd -D FOREGROUND
 
 HEALTHCHECK --start-period=20s --interval=37s --timeout=5s --retries=3 \
-	CMD curl -fsS 'http://localhost/i/' | grep -q 'jsonVars' || exit 1
+	CMD (php -r "readfile('http://localhost/i/');" | grep -q 'jsonVars') || exit 1

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -7,11 +7,12 @@ FROM arm32v7/ubuntu:19.04
 COPY ./Docker/qemu-arm-* /usr/bin/
 
 ENV TZ UTC
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update && \
-	apt install --no-install-recommends -y \
-	ca-certificates cron curl \
+RUN apt-get update && \
+	apt-get install --no-install-recommends -y \
+	ca-certificates cron \
 	apache2 libapache2-mod-php \
 	php-curl php-gmp php-intl php-mbstring php-xml php-zip \
 	php-sqlite3 php-mysql php-pgsql && \
@@ -68,4 +69,4 @@ CMD ([ -z "$CRON_MIN" ] || cron) && \
 	exec apache2 -D FOREGROUND
 
 HEALTHCHECK --start-period=20s --interval=37s --timeout=5s --retries=3 \
-	CMD curl -fsS 'http://localhost/i/' | grep -q 'jsonVars' || exit 1
+	CMD (php -r "readfile('http://localhost/i/');" | grep -q 'jsonVars') || exit 1


### PR DESCRIPTION
Closes #2453

Adding ``-o pipefail`` to the shell ensures that errors will fail pipechains and forward errors correctly.
Apt is an end user tool and scripts are recommended to use ``apt-get``. See https://github.com/hadolint/hadolint/wiki/DL3027