### PR TITLE
[CI] Run hadolint

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,7 @@
+ignored:
+  # ignore apt version pinning
+  - DL3008
+  # ignore pip version pinning
+  - DL3013
+  # ignore apk version pinning
+  - DL3018

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - phpenv rehash
   - find . -not -path "./lib/JSON.php" -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
   - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
-  - bash tests/shellchecks.sh
   - |
     if [[ $VALIDATE_STANDARD == yes ]]; then
       COMPOSER_BIN=$(composer global config --absolute bin-dir)
@@ -50,6 +49,7 @@ matrix:
         - curl -sLo "$HADOLINT" $(curl -s https://api.github.com/repos/hadolint/hadolint/releases/latest?access_token="$GITHUB_TOKEN" | jq -r '.assets | .[] | select(.name=="hadolint-Linux-x86_64") | .browser_download_url') && chmod 700 ${HADOLINT}
       script:
         - node_modules/jshint/bin/jshint .
+        - bash tests/shellchecks.sh
         - git ls-files --exclude='*Dockerfile*' --ignored | xargs --max-lines=1 "$HADOLINT"
   allow_failures:
     - env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,14 @@ matrix:
         - "node"
       php:
         # none
+      env:
+        - HADOLINT="$HOME/hadolint"
       install:
         - npm install jshint
+        - curl -sLo "$HADOLINT" $(curl -s https://api.github.com/repos/hadolint/hadolint/releases/latest?access_token="$GITHUB_TOKEN" | jq -r '.assets | .[] | select(.name=="hadolint-Linux-x86_64") | .browser_download_url') && chmod 700 ${HADOLINT}
       script:
         - node_modules/jshint/bin/jshint .
+        - git ls-files --exclude='*Dockerfile*' --ignored | xargs --max-lines=1 "$HADOLINT"
   allow_failures:
     - env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no
     - dist: precise

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -52,6 +52,7 @@ ENV CRON_MIN ''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+# hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -48,6 +48,7 @@ ENV CRON_MIN ''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+# hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
 	exec httpd -D FOREGROUND
 

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -64,6 +64,7 @@ ENV CRON_MIN ''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+# hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND


### PR DESCRIPTION
As requested [here](https://github.com/FreshRSS/FreshRSS/pull/2455#issuecomment-513809772)

I don't like that it needs ``jq`` but I am to lazy to write that json select with bash. It is also probably more robust and easier to understand this way.

This would also require to add a GItHub Token under ``$GITHUB_TOKEN`` in Travis. If we leave this out the CI periodically fails cause GitHub API gets rate limited quite easily.
The URL would then change to:
``https://api.github.com/repos/hadolint/hadolint/releases/latest?access_token="$GITHUB_TOKEN"``

I am a bit unsure where to put it or if it should be blocking for the other CI jobs. Let me know if I should move it to another section.