### PR TITLE
Patch for #2460: Run on Apache 2.4+ without mod_access_compat

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,3 +1,11 @@
-Order	Allow,Deny
-Deny	from all
-Satisfy	all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order	Allow,Deny
+	Deny	from all
+	Satisfy	all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>

--- a/cli/.htaccess
+++ b/cli/.htaccess
@@ -1,3 +1,11 @@
-Order	Allow,Deny
-Deny	from all
-Satisfy	all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order	Allow,Deny
+	Deny	from all
+	Satisfy	all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>

--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,3 +1,11 @@
-Order	Allow,Deny
-Deny	from all
-Satisfy	all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order	Allow,Deny
+	Deny	from all
+	Satisfy	all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>

--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,3 +1,11 @@
-Order	Allow,Deny
-Deny	from all
-Satisfy	all
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order	Allow,Deny
+	Deny	from all
+	Satisfy	all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>


### PR DESCRIPTION
Update corresponding .htaccess files:

Test for mod_authz_core and use directives according.