### PR TITLE
Add support for images to the ext.php endpoint

### DIFF
--- a/p/ext.php
+++ b/p/ext.php
@@ -59,6 +59,23 @@ case 'js':
 	header('Content-Type: application/javascript; charset=UTF-8');
 	header('Content-Disposition: inline; filename="' . $file_name . '"');
 	break;
+case 'png':
+	header('Content-Type: image/png');
+	header('Content-Disposition: inline; filename="' . $file_name . '"');
+	break;
+case 'jpeg':
+case 'jpg':
+	header('Content-Type: image/jpeg');
+	header('Content-Disposition: inline; filename="' . $file_name . '"');
+	break;
+case 'gif':
+	header('Content-Type: image/gif');
+	header('Content-Disposition: inline; filename="' . $file_name . '"');
+	break;
+case 'svg':
+	header('Content-Type: image/svg+xml');
+	header('Content-Disposition: inline; filename="' . $file_name . '"');
+	break;
 default:
 	header('HTTP/1.1 400 Bad Request');
 	die();


### PR DESCRIPTION
The `ext.php` endpoint is used to serve files from extension folders. Until now, it only served JavaScript and CSS files. This PR adds support for png, jpeg, gif and svg files.

The `Content-Disposition` header is duplicated across all the `case`s but I'm not sure I want to factor them in this PR (I like its simplicity :)). Let me know if you prefer a "factored" version.