### PR TITLE
[CI] Fix PHP 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -35,6 +33,11 @@ matrix:
     # PHP 5.3 only runs on Ubuntu 12.04 (precise), not 14.04 (trusty)
     - php: "5.3"
       dist: precise
+    # PHP 5.4 & 5.5 only run on Travis in 14.04 (trusty), not 16.04 (xenial)
+    - php: "5.4"
+      dist: trusty
+    - php: "5.5"
+      dist: trusty
     - php: "7.2"
       env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no
     - language: node_js


### PR DESCRIPTION
The PHP 5.4 and 5.5 archives recently started failing, also see https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723

Setting them to use the Trusty images restores their functionality.