### PR TITLE
fix: Fix "validate email"-related issues

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -123,6 +123,7 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 		}
 
 		$email_not_verified = FreshRSS_Context::$user_conf->email_validation_token !== '';
+		$this->view->disable_aside = false;
 		if ($email_not_verified) {
 			$this->view->_layout('simple');
 			$this->view->disable_aside = true;

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -153,7 +153,9 @@ class FreshRSS extends Minz_FrontController {
 			Minz_Request::is('user', 'validateEmail') ||
 			Minz_Request::is('user', 'sendValidationEmail') ||
 			Minz_Request::is('user', 'profile') ||
-			Minz_Request::is('auth', 'logout')
+			Minz_Request::is('user', 'delete') ||
+			Minz_Request::is('auth', 'logout') ||
+			Minz_Request::is('javascript', 'nonce')
 		);
 		if ($email_not_verified && !$action_is_allowed) {
 			Minz_Request::forward(array(

--- a/app/layout/simple.phtml
+++ b/app/layout/simple.phtml
@@ -5,6 +5,9 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="initial-scale=1.0" />
 		<?php echo self::headStyle(); ?>
+		<script id="jsonVars" type="application/json">
+<?php $this->renderHelper('javascript_vars'); ?>
+		</script>
 		<?php echo self::headScript(); ?>
 		<link rel="shortcut icon" id="favicon" type="image/x-icon" sizes="16x16 64x64" href="<?php echo Minz_Url::display('/favicon.ico'); ?>" />
 		<link rel="icon msapplication-TileImage apple-touch-icon" type="image/png" sizes="256x256" href="<?php echo Minz_Url::display('/themes/icons/favicon-256.png'); ?>" />


### PR DESCRIPTION
I missed some issues during #2481 development:

- `$disable_aside` was not correctly initialized (missed it since my environment was in "production")
- users were offered to delete their account but endpoints weren't allowed if email wasn't validated (missed that since I was testing with an admin account)