### PR TITLE
Hide the admin checkbox if user is not admin

### DIFF
--- a/app/views/user/profile.phtml
+++ b/app/views/user/profile.phtml
@@ -15,12 +15,19 @@
 			<label class="group-name" for="current_user"><?php echo _t('conf.user.current'); ?></label>
 			<div class="group-controls">
 				<input id="current_user" type="text" disabled="disabled" value="<?php echo Minz_Session::param('currentUser', '_'); ?>" />
-				<label class="checkbox" for="is_admin">
-					<input type="checkbox" id="is_admin" disabled="disabled" <?php echo FreshRSS_Auth::hasAccess('admin') ? 'checked="checked" ' : ''; ?>/>
-					<?php echo _t('conf.user.is_admin'); ?>
-				</label>
 			</div>
 		</div>
+
+		<?php if (FreshRSS_Auth::hasAccess('admin')) { ?>
+			<div class="form-group">
+				<div class="group-controls">
+					<label class="checkbox" for="is_admin">
+						<input type="checkbox" id="is_admin" disabled checked />
+						<?php echo _t('conf.user.is_admin'); ?>
+					</label>
+				</div>
+			</div>
+		<?php } ?>
 
 		<div class="form-group">
 			<label class="group-name" for="email"><?php echo _t('conf.profile.email'); ?></label>


### PR DESCRIPTION
It is a bit disturbing to see a disabled "is admin" checkbox when we are a simple user!