### PR TITLE
Workaround for Firefox favicon glitch

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1465,6 +1465,7 @@ function init_afterDOM() {
 		init_posts();
 		init_nav_entries();
 		init_notifs_html5();
+		setTimeout(faviconNbUnread, 1000);
 		setInterval(refreshUnreads, 120000);
 	}
 


### PR DESCRIPTION
Observed in Firefox 69: the favicon is sometimes refreshed with an old
favicon that does not have the number of unread items on it. Seems to
depend on load speed.