### PR TITLE
PostgreSQL 9.5+

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -46,7 +46,7 @@ FreshRSS n’est fourni avec aucune garantie.
 * PHP 5.6+ (PHP 7+ recommandé pour de meilleures performances)
 	* Requis : [cURL](https://www.php.net/curl), [DOM](https://www.php.net/dom), [JSON](https://www.php.net/json), [XML](https://www.php.net/xml), [session](https://www.php.net/session), [ctype](https://www.php.net/ctype), et [PDO_MySQL](https://www.php.net/pdo-mysql) ou [PDO_SQLite](https://www.php.net/pdo-sqlite) ou [PDO_PGSQL](https://www.php.net/pdo-pgsql)
 	* Recommandés : [GMP](https://www.php.net/gmp) (pour accès API sur plateformes < 64 bits), [IDN](https://www.php.net/intl.idn) (pour les noms de domaines internationalisés), [mbstring](https://www.php.net/mbstring) (pour le texte Unicode), [iconv](https://www.php.net/iconv) (pour conversion d’encodages), [ZIP](https://www.php.net/zip) (pour import/export), [zlib](https://www.php.net/zlib) (pour les flux compressés)
-* MySQL 5.5.3+ (recommandé) ou équivalent MariaDB, ou SQLite 3.7.4+, ou PostgreSQL 9.2+
+* MySQL 5.5.3+ ou équivalent MariaDB, ou SQLite 3.7.4+, ou PostgreSQL 9.5+
 
 
 # Téléchargement

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ FreshRSS comes with absolutely no warranty.
 * PHP 5.6+ (PHP 7+ recommended for higher performance)
 	* Required extensions: [cURL](https://www.php.net/curl), [DOM](https://www.php.net/dom), [JSON](https://www.php.net/json), [XML](https://www.php.net/xml), [session](https://www.php.net/session), [ctype](https://www.php.net/ctype), and [PDO_MySQL](https://www.php.net/pdo-mysql) or [PDO_SQLite](https://www.php.net/pdo-sqlite) or [PDO_PGSQL](https://www.php.net/pdo-pgsql)
 	* Recommended extensions: [GMP](https://www.php.net/gmp) (for API access on 32-bit platforms), [IDN](https://www.php.net/intl.idn) (for Internationalized Domain Names), [mbstring](https://www.php.net/mbstring) (for Unicode strings), [iconv](https://www.php.net/iconv) (for charset conversion), [ZIP](https://www.php.net/zip) (for import/export), [zlib](https://www.php.net/zlib) (for compressed feeds)
-* MySQL 5.5.3+ (recommended) or MariaDB equivalent, or SQLite 3.7.4+, or PostgreSQL 9.2+
+* MySQL 5.5.3+ or MariaDB equivalent, or SQLite 3.7.4+, or PostgreSQL 9.5+
 
 
 # Releases

--- a/app/SQL/install.sql.pgsql.php
+++ b/app/SQL/install.sql.pgsql.php
@@ -28,9 +28,9 @@ CREATE TABLE IF NOT EXISTS `_feed` (
 	"cache_nbUnreads" INT DEFAULT 0,
 	FOREIGN KEY ("category") REFERENCES `_category` ("id") ON DELETE SET NULL ON UPDATE CASCADE
 );
-CREATE INDEX `_name_index` ON `_feed` ("name");
-CREATE INDEX `_priority_index` ON `_feed` ("priority");
-CREATE INDEX `_keep_history_index` ON `_feed` ("keep_history");
+CREATE INDEX IF NOT EXISTS `_name_index` ON `_feed` ("name");
+CREATE INDEX IF NOT EXISTS `_priority_index` ON `_feed` ("priority");
+CREATE INDEX IF NOT EXISTS `_keep_history_index` ON `_feed` ("keep_history");
 
 CREATE TABLE IF NOT EXISTS `_entry` (
 	"id" BIGINT NOT NULL PRIMARY KEY,
@@ -49,9 +49,9 @@ CREATE TABLE IF NOT EXISTS `_entry` (
 	FOREIGN KEY ("id_feed") REFERENCES `_feed` ("id") ON DELETE CASCADE ON UPDATE CASCADE,
 	UNIQUE ("id_feed","guid")
 );
-CREATE INDEX `_is_favorite_index` ON `_entry` ("is_favorite");
-CREATE INDEX `_is_read_index` ON `_entry` ("is_read");
-CREATE INDEX `_entry_lastSeen_index` ON `_entry` ("lastSeen");
+CREATE INDEX IF NOT EXISTS `_is_favorite_index` ON `_entry` ("is_favorite");
+CREATE INDEX IF NOT EXISTS `_is_read_index` ON `_entry` ("is_read");
+CREATE INDEX IF NOT EXISTS `_entry_lastSeen_index` ON `_entry` ("lastSeen");
 
 INSERT INTO `_category` (id, name)
 	SELECT 1, 'Uncategorized'
@@ -77,10 +77,10 @@ CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	FOREIGN KEY ("id_feed") REFERENCES `_feed` ("id") ON DELETE CASCADE ON UPDATE CASCADE,
 	UNIQUE ("id_feed","guid")
 );
-CREATE INDEX `_entrytmp_date_index` ON `_entrytmp` ("date");
+CREATE INDEX IF NOT EXISTS `_entrytmp_date_index` ON `_entrytmp` ("date");
 
 -- v1.7
-CREATE INDEX `_entry_feed_read_index` ON `_entry` ("id_feed","is_read");
+CREATE INDEX IF NOT EXISTS `_entry_feed_read_index` ON `_entry` ("id_feed","is_read");
 SQL;
 
 const SQL_CREATE_TABLE_TAGS = <<<'SQL'
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS `_entrytag` (
 	FOREIGN KEY ("id_tag") REFERENCES `_tag` ("id") ON DELETE CASCADE ON UPDATE CASCADE,
 	FOREIGN KEY ("id_entry") REFERENCES `_entry` ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
-CREATE INDEX `_entrytag_id_entry_index` ON `_entrytag` ("id_entry");
+CREATE INDEX IF NOT EXISTS `_entrytag_id_entry_index` ON `_entrytag` ("id_entry");
 SQL;
 
 const SQL_INSERT_FEED = <<<'SQL'

--- a/docs/en/admins/02_Installation.md
+++ b/docs/en/admins/02_Installation.md
@@ -9,7 +9,7 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 | Web server  | **Apache 2**     | Nginx                         |
 | PHP         | **PHP 7+**       | PHP 5.6+                      |
 | PHP modules | Required: libxml, cURL, JSON, PDO_MySQL, PCRE and ctype. <br>Required (32-bit only): GMP <br> Recommanded: Zlib, mbstring, iconv, ZipArchive <br> *For the whole modules list see [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/master/Docker/Dockerfile-Alpine#L7-L9)* | |
-| Database    | **MySQL 5.5.3+** | SQLite 3.7.4+                 |
+| Database    | **MySQL 5.5.3+** | SQLite 3.7.4+, PostgreSQL 9.5+  |
 | Browser     | **Firefox**      | Chrome, Opera, Safari, or IE11+ |
 
 

--- a/docs/fr/users/01_Installation.md
+++ b/docs/fr/users/01_Installation.md
@@ -9,7 +9,7 @@ Il est toutefois de votre responsabilité de vérifier que votre hébergement pe
  | Serveur web      | **Apache 2**                                                                                                   | Nginx                          |
  | PHP              | **PHP 7+**                                                                                                     | PHP 5.6+                       |
  | Modules PHP      | Requis : libxml, cURL, JSON, PDO_MySQL, PCRE et ctype<br>Requis (32 bits seulement) : GMP<br>Recommandé : Zlib, mbstring et iconv, ZipArchive<br>*Pour une liste complète des modules nécessaires voir le [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/master/Docker/Dockerfile-Alpine#L7-L9)* |                                |
- | Base de données  | **MySQL 5.5.3+**                                                                                               | SQLite 3.7.4+                  |
+ | Base de données  | **MySQL 5.5.3+**                                                                                               | SQLite 3.7.4+, PostgreSQL 9.5+   |
  | Navigateur       | **Firefox**                                                                                                    | Chrome, Opera, Safari, or IE 11+ |
 
 # Choisir la bonne version de FreshRSS


### PR DESCRIPTION
Needed for `CREATE  INDEX IF NOT EXISTS` syntax.
Supported as back as Ubuntu 16.04 LTS.
Similar version checks than for the PHP version bump
https://github.com/FreshRSS/FreshRSS/pull/2495
https://www.postgresql.org/docs/9.5/sql-createindex.html
https://www.postgresql.org/docs/9.5/release-9-5.html