### PR TITLE
Fix PostgreSQL and SQLite DB size estimation

### DIFF
--- a/app/Models/DatabaseDAOSQLite.php
+++ b/app/Models/DatabaseDAOSQLite.php
@@ -54,7 +54,15 @@ class FreshRSS_DatabaseDAOSQLite extends FreshRSS_DatabaseDAO {
 	}
 
 	public function size($all = false) {
-		return @filesize(join_path(DATA_PATH, 'users', $this->current_user, 'db.sqlite'));
+		$sum = 0;
+		if ($all) {
+			foreach (glob(DATA_PATH . '/users/*/db.sqlite') as $filename) {
+				$sum += @filesize($filename);
+			}
+		} else {
+			$sum = @filesize(DATA_PATH . '/users/' . $this->current_user . '/db.sqlite');
+		}
+		return $sum;
 	}
 
 	public function optimize() {

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -951,6 +951,9 @@ SQL;
 			$sql .= ' WHERE f.priority > ' . intval($minPriority);
 		}
 		$stm = $this->pdo->query($sql);
+		if ($stm == false) {
+			return false;
+		}
 		$res = $stm->fetchAll(PDO::FETCH_COLUMN, 0);
 		return isset($res[0]) ? $res[0] : 0;
 	}


### PR DESCRIPTION
Only MySQL was working so far, as PostgreSQL was always returning the total DB size for all users, while SQLite was always returning the DB size for the current user.