### PR TITLE
Increase import size

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -6,6 +6,8 @@ chown -R :www-data .
 chmod -R g+r . && chmod -R g+w ./data/
 
 find /etc/php*/ -name php.ini -exec sed -r -i "\\#^;?date.timezone#s#^.*#date.timezone = $TZ#" {} \;
+find /etc/php*/ -name php.ini -exec sed -r -i "\\#^;?post_max_size#s#^.*#post_max_size = 32M#" {} \;
+find /etc/php*/ -name php.ini -exec sed -r -i "\\#^;?upload_max_filesize#s#^.*#upload_max_filesize = 32M#" {} \;
 
 if [ -n "$CRON_MIN" ]; then
 	(

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -29,7 +29,24 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 		Minz_View::prependTitle(_t('sub.import_export.title') . ' · ');
 	}
 
+	private static function megabytes($size_str) {
+		switch (substr($size_str, -1)) {
+			case 'M': case 'm': return (int)$size_str;
+			case 'K': case 'k': return (int)$size_str / 1024;
+			case 'G': case 'g': return (int)$size_str * 1024;
+		}
+		return $size_str;
+	}
+
+	private static function minimumMemory($mb) {
+		$ini = self::megabytes(ini_get('memory_limit'));
+		if ($ini < $mb) {
+			ini_set('memory_limit', '256M');
+		}
+	}
+
 	public function importFile($name, $path, $username = null) {
+		self::minimumMemory(256);
 		require_once(LIB_PATH . '/lib_opml.php');
 
 		$this->catDAO = new FreshRSS_CategoryDAO($username);

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -39,9 +39,10 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 	}
 
 	private static function minimumMemory($mb) {
+		$mb = (int)$mb;
 		$ini = self::megabytes(ini_get('memory_limit'));
 		if ($ini < $mb) {
-			ini_set('memory_limit', '256M');
+			ini_set('memory_limit', $mb . 'M');
 		}
 	}
 


### PR DESCRIPTION
This is merely a temporary workaround to allow at least some medium size
imports
https://framateam.org/freshrss/pl/7wbt4tcyetrfmris9xdcbq7uuw
The import module should be rewritten to process files one by one and as
data streams instead of loading multiple copies of the whole dataset in
memory as is the case now :-(
https://github.com/FreshRSS/FreshRSS/issues/1890
Note that the new SQLite export/import is distinct from this case.