### PR TITLE
Fix for broken read icon in Firefox

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -52,7 +52,7 @@ People are sorted by name so please keep this order.
 * [Nicolas Elie](https://github.com/nicolaselie): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=nicolaselie)
 * [Nicolas Frandeboeuf](https://github.com/nicofrand): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=nicofrand), [Web](https://nicofrand.ey)
 * [Nicolas Lœuillet](https://github.com/nicosomb): [contributions](https://github.com/FreshRSS/documentation/commits?author=nicosomb), [Web](http://www.loeuillet.org/)
-* [Offerel](https://github.com/Offerel): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=Offerel)
+* [Offerel](https://github.com/Offerel): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Offerel)
 * [Olivier Dossmann](https://github.com/blankoworld): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=blankoworld), [Web](https://olivier.dossmann.net)
 * [Patrick Crandol](https://github.com/pattems): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:pattems)
 * [Paulius Šukys](https://github.com/psukys): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:psukys), [Web](http://sukys.eu)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -52,6 +52,7 @@ People are sorted by name so please keep this order.
 * [Nicolas Elie](https://github.com/nicolaselie): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=nicolaselie)
 * [Nicolas Frandeboeuf](https://github.com/nicofrand): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=nicofrand), [Web](https://nicofrand.ey)
 * [Nicolas Lœuillet](https://github.com/nicosomb): [contributions](https://github.com/FreshRSS/documentation/commits?author=nicosomb), [Web](http://www.loeuillet.org/)
+* [Offerel](https://github.com/Offerel): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=Offerel)
 * [Olivier Dossmann](https://github.com/blankoworld): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=blankoworld), [Web](https://olivier.dossmann.net)
 * [Patrick Crandol](https://github.com/pattems): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:pattems)
 * [Paulius Šukys](https://github.com/psukys): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:psukys), [Web](http://sukys.eu)

--- a/p/themes/Swage/icons/read.svg
+++ b/p/themes/Swage/icons/read.svg
@@ -1,5 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg enable-background="new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
-<style type="text/css">.st0{fill:#DDDDDD;}</style>
-<path class="st0" d="M15.9,6c0-0.6-0.3-1.1-0.7-1.4L8,0.4L0.8,4.6C0.3,4.9,0,5.4,0,6v8c0,0.9,0.7,1.6,1.6,1.6h12.8,c0.9,0,1.6-0.7,1.6-1.6L15.9,6z M8,10L1.4,5.9L8,2l6.6,3.9L8,10z"/>
-</svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><style type="text/css">  .st0{fill:#DDDDDD;}</style><path class="st0" d="M15.9 6c0-0.6-0.3-1.1-0.7-1.4L8 0.4 0.8 4.6C0.3 4.9 0 5.4 0 6v8c0 0.9 0.7 1.6 1.6 1.6h12.8c0.9 0 1.6-0.7 1.6-1.6L15.9 6zM8 10L1.4 5.9 8 2l6.6 3.9L8 10z"/></svg>

--- a/p/themes/Swage/icons/view-reader.svg
+++ b/p/themes/Swage/icons/view-reader.svg
@@ -1,6 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg enable-background="new 0 0 16 16" version="1.1" viewBox="0 0 16 16" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
-<style type="text/css">.st0{fill:#FFFFFF;}</style>
-<path class="st0" d="M8.7,7.3h5.1v1.4H8.7V7.3z M8.7,5h5.1v1.4H8.7V5z M8.7,9.6h5.1V11H8.7V9.6z M14.5,0H1.5C0.7,0,0,0.8,0,1.8v11.9,c0,1,0.7,1.8,1.5,1.8h13.1c0.8,0,1.5-0.8,1.5-1.8V1.8C16,0.8,15.3,0,14.5,0z M14.5,13.8H8V1.8h6.5V13.8z"/>
-</svg>
-
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><style type="text/css">  .st0{fill:#FFFFFF;}</style><path class="st0" d="M8.7 7.3h5.1v1.4H8.7V7.3zM8.7 5h5.1v1.4H8.7V5zM8.7 9.6h5.1V11H8.7V9.6zM14.5 0H1.5C0.7 0 0 0.8 0 1.8v11.9c0 1 0.7 1.8 1.5 1.8h13.1c0.8 0 1.5-0.8 1.5-1.8V1.8C16 0.8 15.3 0 14.5 0zM14.5 13.8H8V1.8h6.5V13.8z"/></svg>


### PR DESCRIPTION
It seems that the read icons shape has also some error. I fixed them like same way as with the reader view icon. Now the icon looks identical in Chrome and other browsers.