### PR TITLE
Greener Travis?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 php:
   - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
   - 7.3
 
 install:
@@ -51,4 +48,4 @@ matrix:
         - git ls-files --exclude='*Dockerfile*' --ignored | xargs --max-lines=1 "$HADOLINT"
   allow_failures:
     - env: CHECK_TRANSLATION=yes VALIDATE_STANDARD=no
-    - dist: precise
+


### PR DESCRIPTION
With PHP 7.4 just around the corner, I suggest to test only the minimum
and maximum PHP versions we support in Travis, to save resources
(greener).
For the translation check, with can test with max version -1 (or min version + 1, or median :-P) to run on
yet another PHP version.
It makes also the Travis tests faster to complete.