### PR TITLE
New environment variable COPY_LOG_TO_SYSLOG

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -43,10 +43,11 @@ RUN a2dismod -f alias autoindex negotiation status && \
 RUN sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.conf && \
 	sed -r -i "/^\s*Listen /s/^/#/" /etc/apache2/ports.conf && \
 	touch /var/www/FreshRSS/Docker/env.txt && \
-	echo "17,47 * * * * . /var/www/FreshRSS/Docker/env.txt; \
+	echo "7,37 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su www-data -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
 		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
 
+ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On
 ENV CRON_MIN ''
 ENV FRESHRSS_ENV ''

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -43,6 +43,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		su apache -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
 		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
 
+ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On
 ENV CRON_MIN ''
 ENV FRESHRSS_ENV ''

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -59,6 +59,7 @@ RUN update-ca-certificates -f
 # Useful with the `--squash` build option
 RUN rm /usr/bin/qemu-* /var/www/FreshRSS/Docker/qemu-*
 
+ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On
 ENV CRON_MIN ''
 ENV FRESHRSS_ENV ''

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -12,6 +12,7 @@ find /etc/php*/ -name php.ini -exec sed -r -i "\\#^;?upload_max_filesize#s#^.*#u
 if [ -n "$CRON_MIN" ]; then
 	(
 		echo "export TZ=$TZ"
+		echo "export COPY_LOG_TO_SYSLOG=$COPY_LOG_TO_SYSLOG"
 		echo "export COPY_SYSLOG_TO_STDERR=$COPY_SYSLOG_TO_STDERR"
 	) >/var/www/FreshRSS/Docker/env.txt
 	crontab -l | sed -r "\\#FreshRSS#s#^[^ ]+ #$CRON_MIN #" | crontab -

--- a/constants.php
+++ b/constants.php
@@ -32,6 +32,7 @@ safe_define('FRESHRSS_USERAGENT', 'FreshRSS/' . FRESHRSS_VERSION . ' (' . PHP_OS
 // PHP text output compression http://php.net/ob_gzhandler (better to do it at Web server level)
 safe_define('PHP_COMPRESSION', false);
 
+safe_define('COPY_LOG_TO_STDERR', filter_var(getenv('COPY_LOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
 // For cases when syslog is not available
 safe_define('COPY_SYSLOG_TO_STDERR', filter_var(getenv('COPY_SYSLOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
 

--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -15,10 +15,10 @@ class Minz_Log {
 	 * NOTICE erreurs mineures ou messages d'informations
 	 * DEBUG Informations affichées pour le déboggage
 	 */
-	const ERROR = 2;
-	const WARNING = 4;
-	const NOTICE = 8;
-	const DEBUG = 16;
+	const ERROR = LOG_ERR;
+	const WARNING = LOG_WARNING;
+	const NOTICE = LOG_NOTICE;
+	const DEBUG = LOG_DEBUG;
 
 	/**
 	 * Enregistre un message dans un fichier de log spécifique
@@ -70,6 +70,10 @@ class Minz_Log {
 			$log = '[' . date('r') . ']'
 			     . ' [' . $level_label . ']'
 			     . ' --- ' . $information . "\n";
+
+			if (defined('COPY_LOG_TO_SYSLOG') && COPY_LOG_TO_SYSLOG) {
+				syslog($level, '[' . $username . '] ' . $log);
+			}
 
 			self::ensureMaxLogSize($file_name);
 

--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -9,25 +9,13 @@
  */
 class Minz_Log {
 	/**
-	 * Les différents niveau de log
-	 * ERROR erreurs bloquantes de l'application
-	 * WARNING erreurs pouvant géner le bon fonctionnement, mais non bloquantes
-	 * NOTICE erreurs mineures ou messages d'informations
-	 * DEBUG Informations affichées pour le déboggage
-	 */
-	const ERROR = LOG_ERR;
-	const WARNING = LOG_WARNING;
-	const NOTICE = LOG_NOTICE;
-	const DEBUG = LOG_DEBUG;
-
-	/**
 	 * Enregistre un message dans un fichier de log spécifique
 	 * Message non loggué si
 	 * 	- environment = SILENT
-	 * 	- level = WARNING et environment = PRODUCTION
-	 * 	- level = NOTICE et environment = PRODUCTION
+	 * 	- level = LOG_WARNING et environment = PRODUCTION
+	 * 	- level = LOG_NOTICE et environment = PRODUCTION
 	 * @param $information message d'erreur / information à enregistrer
-	 * @param $level niveau d'erreur
+	 * @param $level niveau d'erreur https://php.net/function.syslog
 	 * @param $file_name fichier de log
 	 * @throws Minz_PermissionDeniedException
 	 */
@@ -41,7 +29,7 @@ class Minz_Log {
 
 		if (! ($env === 'silent'
 		       || ($env === 'production'
-		       && ($level >= Minz_Log::NOTICE)))) {
+		       && ($level >= LOG_NOTICE)))) {
 			if ($file_name === null) {
 				$username = Minz_Session::param('currentUser', '');
 				if ($username == '') {
@@ -51,16 +39,16 @@ class Minz_Log {
 			}
 
 			switch ($level) {
-			case Minz_Log::ERROR :
+			case LOG_ERR :
 				$level_label = 'error';
 				break;
-			case Minz_Log::WARNING :
+			case LOG_WARNING :
 				$level_label = 'warning';
 				break;
-			case Minz_Log::NOTICE :
+			case LOG_NOTICE :
 				$level_label = 'notice';
 				break;
-			case Minz_Log::DEBUG :
+			case LOG_DEBUG :
 				$level_label = 'debug';
 				break;
 			default :
@@ -124,8 +112,8 @@ class Minz_Log {
 		$msg_get = str_replace("\n", '', '$_GET content : ' . print_r($_GET, true));
 		$msg_post = str_replace("\n", '', '$_POST content : ' . print_r($_POST, true));
 
-		self::record($msg_get, Minz_Log::DEBUG, $file_name);
-		self::record($msg_post, Minz_Log::DEBUG, $file_name);
+		self::record($msg_get, LOG_DEBUG, $file_name);
+		self::record($msg_post, LOG_DEBUG, $file_name);
 	}
 
 	/**
@@ -133,15 +121,15 @@ class Minz_Log {
 	 * Parameters are the same of those of the record() method.
 	 */
 	public static function debug($msg, $file_name = null) {
-		self::record($msg, Minz_Log::DEBUG, $file_name);
+		self::record($msg, LOG_DEBUG, $file_name);
 	}
 	public static function notice($msg, $file_name = null) {
-		self::record($msg, Minz_Log::NOTICE, $file_name);
+		self::record($msg, LOG_NOTICE, $file_name);
 	}
 	public static function warning($msg, $file_name = null) {
-		self::record($msg, Minz_Log::WARNING, $file_name);
+		self::record($msg, LOG_WARNING, $file_name);
 	}
 	public static function error($msg, $file_name = null) {
-		self::record($msg, Minz_Log::ERROR, $file_name);
+		self::record($msg, LOG_ERR, $file_name);
 	}
 }


### PR DESCRIPTION
False by default.
Makes it easy to monitor all logs from Syslog or STDERR (e.g. `docker logs -f freshrss`).