### PR TITLE
[fix] Origine unread CSS style

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -782,12 +782,15 @@ a.btn {
 }
 
 .flux.not_read {
-	background: #fff3ed;
 	border-left: 2px solid #ff5300;
 }
 
-.flux.not_read:not(.current):hover .item.title {
+.flux.not_read:not(.current) {
 	background: #fff3ed;
+}
+
+.flux.not_read:not(.current):hover .item.title {
+	background: inherit;
 }
 
 .flux.favorite {


### PR DESCRIPTION
Fixes #2604. Regression in #2477.

<hr>

NB I likely introduced the issue in other themes as well. It looked sane when I tested it at the time but I failed to notice the specific issue as in #2604. I'll test and fix other themes tomorrow (if applicable).