### PR TITLE
Fix categories sorting

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -208,7 +208,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 			return $categories;
 		}
 
-		usort($categories, function ($a, $b) {
+		uasort($categories, function ($a, $b) {
 			$aPosition = $a->attributes('position');
 			$bPosition = $b->attributes('position');
 			if ($aPosition === $bPosition) {


### PR DESCRIPTION
I had a bug when some articles in a category were unread. Sometimes,
filtering the category displayed all the articles, even with the "Adjust
showing" option.

A reasonably good guess was to look the last commits that impacted the
categories and, indeed, it was introduced by the new category sorting
system.

The sort function (`usort`) doesn't keep the index association, which is
important here. I must admit I don't understand exactly why (I didn't
search), but the keys are probably used somewhere. Another fix would be
to not rely on these keys anymore.

The bug was introduced in 042fcd5e93884690efdd2f957ca02751958c0724

- Ref PR: https://github.com/FreshRSS/FreshRSS/pull/2592
- Ref usort: https://www.php.net/manual/en/function.usort.php
- Ref uasort: https://www.php.net/manual/en/function.uasort.php