### PR TITLE
fix: Gitignore opml.xml

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -7,3 +7,4 @@ last_update.txt
 no-cache.txt
 update.php
 tos.html
+opml.xml


### PR DESCRIPTION
This file is used to add default feeds to new users. It was added in
7819a43197d34ef7a6c5626e9e48d7db075c37c9

Problem is that the file is not ignored by Git and risk to be deleted
during a git update.