### PR TITLE
Fix favorite display for "current" articles

### DIFF
--- a/p/themes/Ansum/_list-view.scss
+++ b/p/themes/Ansum/_list-view.scss
@@ -20,24 +20,19 @@
 		border-left-color: $main-first;
 	}
 
-	&.not_read {
+	&.not_read:not(.current) {
 		background: $unread-bg; //--------------------
-		// border-left-color: #FF5300;
-		&:hover {
-			background: $unread-bg-light; //--------------------
+
+		&:hover .item.title {
+			background: $unread-bg;
 		}
+	}
 
-		&:not(.current):hover .item.title {
-			background: $unread-bg-light;
-
-
-		}
-
+	&.not_read {
 		.item.title {
 			a {
 				color: $unread-font-color; //--------------------
 			}
-
 		}
 
 		.item.website {
@@ -52,12 +47,15 @@
 	}
 
 	&.favorite {
-		background: $fav-light;
 		border-left-color: $fav-bg;
 
 		@include transition(all, 0.15s, ease-in-out);
+	}
 
-		&:not(.current):hover .item.title {
+	&.favorite:not(.current) {
+		background: $fav-light;
+
+		&:hover .item.title {
 			background: $fav-light;
 		}
 	}

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -963,25 +963,24 @@ form th {
   .flux.current {
     background: #fff;
     border-left-color: #ca7227; }
-  .flux.not_read {
+  .flux.not_read:not(.current) {
     background: #f2f6f8; }
-    .flux.not_read:hover {
-      background: #fdfdfe; }
     .flux.not_read:not(.current):hover .item.title {
-      background: #fdfdfe; }
-    .flux.not_read .item.title a {
-      color: #161a38; }
-    .flux.not_read .item.website a {
-      color: #161a38; }
-    .flux.not_read .item.date {
-      color: #161a3899; }
+      background: #f2f6f8; }
+  .flux.not_read .item.title a {
+    color: #161a38; }
+  .flux.not_read .item.website a {
+    color: #161a38; }
+  .flux.not_read .item.date {
+    color: #161a3899; }
   .flux.favorite {
-    background: #fff6da;
     border-left-color: #ffc300;
     -webkit-transition: all 0.15s ease-in-out;
     -moz-transition: all 0.15s ease-in-out;
     -o-transition: all 0.15s ease-in-out;
     transition: all 0.15s ease-in-out; }
+  .flux.favorite:not(.current) {
+    background: #fff6da; }
     .flux.favorite:not(.current):hover .item.title {
       background: #fff6da; }
   .flux .website a {

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -803,8 +803,11 @@ a.btn {
 }
 
 .flux.favorite {
-	background: #fff6da;
 	border-left-color: #ffc300;
+}
+
+.flux.favorite:not(.current) {
+	background: #fff6da;
 }
 
 .flux.favorite:not(.current):hover .item.title {

--- a/p/themes/Mapco/_list-view.scss
+++ b/p/themes/Mapco/_list-view.scss
@@ -20,19 +20,15 @@
 		border-left-color: $main-first;
 	}
 
-	&.not_read {
+	&.not_read:not(.current) {
 		background: $unread-bg; //--------------------
-		// border-left-color: #FF5300;
-		&:hover {
-			background: $unread-bg-light; //--------------------
+
+		&:hover .item.title {
+			background: $unread-bg;
 		}
+	}
 
-		&:not(.current):hover .item.title {
-			background: $unread-bg-light;
-
-
-		}
-
+	&.not_read {
 		.item.title {
 			a {
 				color: $unread-font-color; //--------------------
@@ -52,12 +48,15 @@
 	}
 
 	&.favorite {
-		background: $fav-light;
 		border-left-color: $fav-bg;
 
 		@include transition(all, 0.15s, ease-in-out);
+	}
 
-		&:not(.current):hover .item.title {
+	&.favorite:not(.current) {
+		background: $fav-light;
+
+		&:hover .item.title {
 			background: $fav-light;
 		}
 	}

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -970,26 +970,25 @@ form th {
   .flux.current {
     background: #f9fafb;
     border-left-color: #36c; }
-  .flux.not_read {
+  .flux.not_read:not(.current) {
     background: #f2f6f8; }
-    .flux.not_read:hover {
-      background: #fdfdfe; }
     .flux.not_read:not(.current):hover .item.title {
-      background: #fdfdfe; }
-    .flux.not_read .item.title a {
-      color: #36c; }
-    .flux.not_read .item.website a {
-      color: #36c; }
-    .flux.not_read .item.date {
-      color: #36c99; }
+      background: #f2f6f8; }
+  .flux.not_read .item.title a {
+    color: #36c; }
+  .flux.not_read .item.website a {
+    color: #36c; }
+  .flux.not_read .item.date {
+    color: #36c99; }
   .flux.favorite {
-    background: #fff6da;
     border-left-color: #ffc300;
     -webkit-transition: all 0.15s ease-in-out;
     -moz-transition: all 0.15s ease-in-out;
     -o-transition: all 0.15s ease-in-out;
     -ms-transition: all 0.15s ease-in-out;
     transition: all 0.15s ease-in-out; }
+  .flux.favorite:not(.current) {
+    background: #fff6da; }
     .flux.favorite:not(.current):hover .item.title {
       background: #fff6da; }
   .flux .website a {

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -837,8 +837,11 @@ a.btn,
 }
 
 .flux.favorite {
-	background: #fff6da;
 	border-left: 2px solid #ffc300;
+}
+
+.flux.favorite:not(.current) {
+	background: #fff6da;
 }
 
 .flux.favorite:not(.current):hover .item.title {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -794,8 +794,11 @@ a.btn {
 }
 
 .flux.favorite {
-	background: #fff6da;
 	border-left: 2px solid #ffc300;
+}
+
+.flux.favorite:not(.current) {
+	background: #fff6da;
 }
 
 .flux.favorite:not(.current):hover .item.title {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -798,8 +798,11 @@ a.btn {
 }
 
 .flux.favorite {
-	background: #fff6da;
 	border-left: 2px solid #428bca;
+}
+
+.flux.favorite:not(.current) {
+	background: #fff6da;
 }
 
 .flux.favorite:not(.current):hover .item.title {

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -585,14 +585,14 @@ form th {
     .flux:hover:not(.current):hover .item.title,
     .flux .current:not(.current):hover .item.title {
       background: #fff; }
-  .flux.not_read:not(.current) {
-    background: #fff3ed; }
-  .flux.not_read:not(.current):hover .item.title {
-    background: #fff3ed; }
-  .flux.favorite {
+  .flux.favorite:not(.current) {
     background: #fff6da; }
     .flux.favorite:not(.current):hover .item.title {
       background: #fff6da; }
+  .flux.not_read:not(.current) {
+    background: #fff3ed; }
+    .flux.not_read:not(.current):hover .item.title {
+      background: #fff3ed; }
   .flux .date {
     color: #969696;
     font-size: 0.7rem; }

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -928,21 +928,19 @@ form {
 		}
 	}
 
-	&.not_read {
-		&:not(.current) {
-			background: $color_unread;
-		}
+	&.favorite:not(.current) {
+		background: $color_stared;
 
-		&:not(.current):hover .item.title {
-			background: $color_unread;
+		&:hover .item.title {
+			background: $color_stared;
 		}
 	}
 
-	&.favorite, {
-		background: $color_stared;
+	&.not_read:not(.current) {
+		background: $color_unread;
 
-		&:not(.current):hover .item.title {
-			background: $color_stared;
+		&:hover .item.title {
+			background: $color_unread;
 		}
 	}
 


### PR DESCRIPTION
Favorite articles have, in most of the themes, a gold background to
distinguish them from the other articles. However, it can be distracting
to have such a background when reading the articles, so we should turn
them back to the "default" background when articles are opened (class
`.current`).

Bug introduced in e9ce27d8d991d7806ca2c2af7e5282279e378885

I didn't apply the fix to the Ansum and Mapco designs because they
already had this behaviour before the commit.

Related PRs:

- https://github.com/FreshRSS/FreshRSS/pull/2477
- https://github.com/FreshRSS/FreshRSS/pull/2611
- https://github.com/FreshRSS/FreshRSS/pull/2612

Closes https://github.com/FreshRSS/FreshRSS/issues/2618