### PR TITLE
Fix DB optimize for MySQL

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -156,7 +156,12 @@ class FreshRSS_DatabaseDAO extends Minz_ModelPdo {
 
 		foreach ($tables as $table) {
 			$sql = 'OPTIMIZE TABLE `_' . $table . '`';	//MySQL
-			$ok &= ($this->pdo->exec($sql) !== false);
+			$stm = $this->pdo->query($sql);
+			if ($stm == false || $stm->fetchAll(PDO::FETCH_ASSOC) === false) {
+				$ok = false;
+				$info = $stm == null ? $this->pdo->errorInfo() : $stm->errorInfo();
+				Minz_Log::warning(__METHOD__ . ' error: ' . $sql . ' : ' . json_encode($info));
+			}
 		}
 		return $ok;
 	}

--- a/app/Models/DatabaseDAOPGSQL.php
+++ b/app/Models/DatabaseDAOPGSQL.php
@@ -79,7 +79,11 @@ class FreshRSS_DatabaseDAOPGSQL extends FreshRSS_DatabaseDAOSQLite {
 
 		foreach ($tables as $table) {
 			$sql = 'VACUUM `_' . $table . '`';
-			$ok &= ($this->pdo->exec($sql) !== false);
+			if ($this->pdo->exec($sql) === false) {
+				$ok = false;
+				$info = $this->pdo->errorInfo();
+				Minz_Log::warning(__METHOD__ . ' error: ' . $sql . ' : ' . json_encode($info));
+			}
 		}
 		return $ok;
 	}

--- a/app/Models/DatabaseDAOSQLite.php
+++ b/app/Models/DatabaseDAOSQLite.php
@@ -66,6 +66,11 @@ class FreshRSS_DatabaseDAOSQLite extends FreshRSS_DatabaseDAO {
 	}
 
 	public function optimize() {
-		return $this->pdo->exec('VACUUM') !== false;
+		$ok = $this->pdo->exec('VACUUM') !== false;
+		if (!$ok) {
+			$info = $this->pdo->errorInfo();
+			Minz_Log::warning(__METHOD__ . ' error: ' . $sql . ' : ' . json_encode($info));
+		}
+		return $ok;
 	}
 }


### PR DESCRIPTION
`pdo->exec()` is not appropriate for MySQL `OPTIMIZE` because `OPTIMIZE` returns some data and not only a code and then fails.
Adds some error log for SQLite and PostgreSQL at the same time.