### PR TITLE
replacing some http links with https links

### DIFF
--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -42,7 +42,7 @@
 					<input type="text" name="url_rss" id="url" class="extend" value="<?= $this->feed->url() ?>" />
 					<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>"><?= _i('link') ?></a>
 				</div>
-				<a class="btn" target="_blank" rel="noreferrer" href="http://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
+				<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
 			</div>
 		</div>
 		<div class="form-group">

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -49,7 +49,7 @@
 					<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>"><?= _i('link') ?></a>
 				</div>
 
-				<a class="btn" target="_blank" rel="noreferrer" href="http://validator.w3.org/feed/check.cgi?url=<?= rawurlencode(htmlspecialchars_decode($this->feed->url(), ENT_QUOTES)) ?>"><?= _t('sub.feed.validator') ?></a>
+				<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?= rawurlencode(htmlspecialchars_decode($this->feed->url(), ENT_QUOTES)) ?>"><?= _t('sub.feed.validator') ?></a>
 			</div>
 		</div>
 		<div class="form-group">

--- a/docs/en/users/07_Frequently_Asked_Questions.md
+++ b/docs/en/users/07_Frequently_Asked_Questions.md
@@ -13,7 +13,7 @@ Of course, ```/i``` has a purpose! We used it for performance and usability:
 
 To increase security, FreshRSS is hosted in two sections. The first section is public (```./p``` folder) and the second section is private (everything else). Therefore the ```robots.txt``` file is located in ```./p``` sub-folder.
 
-As explained in the [security section](/en/User_documentation/Installation/Security), it is highly recommended to make only the public section available at the domain level. With that configuration, ```./p``` is the root folder for http://demo.freshrss.org/, thus making ```robots.txt``` available at the root of the application.
+As explained in the [security section](/en/User_documentation/Installation/Security), it is highly recommended to make only the public section available at the domain level. With that configuration, ```./p``` is the root folder for https://demo.freshrss.org/, thus making ```robots.txt``` available at the root of the application.
 
 The same rule applies for ```favicon.ico``` and ```.htaccess```.
 
@@ -24,14 +24,14 @@ The feed syntax can be invalid, it can be unrecognized by the SimplePie library.
 The first step is to identify what causes the problem.
 Here are the steps to follow:
 
-1. __Verify if the feed syntax is valid__ with the [W3C on-line tool](http://validator.w3.org/feed/ "RSS and Atom feed validator"). If it is not valid, there is nothing we can do.
-1. __Verify SimplePie validation__ with the [SimplePie on-line tool](http://simplepie.org/demo/ "SimplePie official demo"). If it is not recognized, there is nothing we can do.
-1. __Verify FreshRSS integration__ with the [demo](http://demo.freshrss.org "FreshRSS official demo"). If it is not working, you need to [create an issue on Github](https://github.com/FreshRSS/FreshRSS/issues/new "Create an issue for FreshRSS") so we can have a look at it. If it is working, there is probably something fishy with the hosting server.
+1. __Verify if the feed syntax is valid__ with the [W3C on-line tool](https://validator.w3.org/feed/ "RSS and Atom feed validator"). If it is not valid, there is nothing we can do.
+1. __Verify SimplePie validation__ with the [SimplePie on-line tool](https://simplepie.org/demo/ "SimplePie official demo"). If it is not recognized, there is nothing we can do.
+1. __Verify FreshRSS integration__ with the [demo](https://demo.freshrss.org "FreshRSS official demo"). If it is not working, you need to [create an issue on Github](https://github.com/FreshRSS/FreshRSS/issues/new "Create an issue for FreshRSS") so we can have a look at it. If it is working, there is probably something fishy with the hosting server.
 
 Here is a list of feeds which don't work:
 
-* http://foulab.org/fr/rss/Foulab_News: is not a W3C valid feed (November 2014)
-* http://eu.battle.net/hearthstone/fr/feed/news: is not a W3C valid feed (Novembre 2014)
+* https://foulab.org/fr/rss/Foulab_News: is not a W3C valid feed (November 2014)
+* https://eu.battle.net/hearthstone/fr/feed/news: is not a W3C valid feed (Novembre 2014)
 * http://webseriesmag.blogs.liberation.fr/we/atom.xml: is not working for the user but succeed on all the described validations (November 2014)
 
 ## How to change a forgotten password?

--- a/docs/en/users/07_Frequently_Asked_Questions.md
+++ b/docs/en/users/07_Frequently_Asked_Questions.md
@@ -28,12 +28,6 @@ Here are the steps to follow:
 1. __Verify SimplePie validation__ with the [SimplePie on-line tool](https://simplepie.org/demo/ "SimplePie official demo"). If it is not recognized, there is nothing we can do.
 1. __Verify FreshRSS integration__ with the [demo](https://demo.freshrss.org "FreshRSS official demo"). If it is not working, you need to [create an issue on Github](https://github.com/FreshRSS/FreshRSS/issues/new "Create an issue for FreshRSS") so we can have a look at it. If it is working, there is probably something fishy with the hosting server.
 
-Here is a list of feeds which don't work:
-
-* https://foulab.org/fr/rss/Foulab_News: is not a W3C valid feed (November 2014)
-* https://eu.battle.net/hearthstone/fr/feed/news: is not a W3C valid feed (Novembre 2014)
-* http://webseriesmag.blogs.liberation.fr/we/atom.xml: is not working for the user but succeed on all the described validations (November 2014)
-
 ## How to change a forgotten password?
 
 Since [1.10.0](https://github.com/FreshRSS/FreshRSS/releases/tag/1.10.0) release, admins are able to change user passwords directly from the interface. This interface is available under  ```Administration → Manage users```.

--- a/docs/fr/users/07_Frequently_Asked_Questions.md
+++ b/docs/fr/users/07_Frequently_Asked_Questions.md
@@ -24,7 +24,7 @@ Le flux peut avoir une syntaxe invalide, il peut ne pas être reconnu par la bib
 Il faut dans un premier temps déterminer la cause du problème.
 Voici la liste des étapes à suivre pour la déterminer :
 
-1. __Vérifier la validité du flux__ grâce à l'[outil en ligne du W3C](http://validator.w3.org/feed/ "Validateur en ligne de flux RSS et Atom"). Si ça ne fonctionne pas, nous ne pouvons rien faire.
+1. __Vérifier la validité du flux__ grâce à l'[outil en ligne du W3C](https://validator.w3.org/feed/ "Validateur en ligne de flux RSS et Atom"). Si ça ne fonctionne pas, nous ne pouvons rien faire.
 1. __Vérifier la reconnaissance par SimplePie__ grâce à l'[outil en ligne de SimplePie](http://simplepie.org/demo/ "Démo officielle de SimplePie"). Si ça ne fonctionne pas, nous ne pouvons rien faire.
 1. __Vérifier l'intégration dans FreshRSS__ grâce à la [démo](http://demo.freshrss.org "Démo officielle de FreshRSS"). Si ça ne fonctionne pas, il faut [créer un ticket sur Github](https://github.com/FreshRSS/FreshRSS/issues/new "Créer un ticket pour FreshRSS") pour que l'on puisse regarder ce qui se passe. Si ça fonctionne, il y a probablement un problème avec l'hébergement.
 


### PR DESCRIPTION
I am trying to replace http links with https ones on websites that have https support.
using https from start instead of using http and hoping user or browser with use https and is not a good idea.
not all sites have hsts support in browser and using https from start when we know https works is better anyway.
