### PR TITLE
Fix adding categories in MySQL 5.5

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -81,7 +81,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 
 	public function addCategory($valuesTmp) {
 		$sql = 'INSERT INTO `_category`(name, attributes) '
-		     . 'SELECT * FROM (SELECT TRIM(?), ?) c2 '	//TRIM() to provide a type hint as text for PostgreSQL
+		     . 'SELECT * FROM (SELECT TRIM(?) AS name, TRIM(?) AS attributes) c2 '	//TRIM() to provide a type hint as text
 		     . 'WHERE NOT EXISTS (SELECT 1 FROM `_tag` WHERE name = TRIM(?))';	//No tag of the same name
 		$stm = $this->pdo->prepare($sql);
 


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/issues/2670 (from https://github.com/FreshRSS/FreshRSS/pull/2335 )
Tested with MySQL 5.5.40, the oldest version on Docker Hub
Debian 8.0 Jessie ships MySQL 5.5.43