### PR TITLE
Separate the update API password endpoint

### DIFF
--- a/app/Controllers/apiController.php
+++ b/app/Controllers/apiController.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This controller manage API-related features.
+ */
+class FreshRSS_api_Controller extends Minz_ActionController {
+	/**
+	 * This action updates the user API password.
+	 *
+	 * Parameter is:
+	 * - apiPasswordPlain: the new user password
+	 */
+	public function updatePasswordAction() {
+		if (!FreshRSS_Auth::hasAccess()) {
+			Minz_Error::error(403);
+		}
+
+		$return_url = array('c' => 'user', 'a' => 'profile');
+
+		if (!Minz_Request::isPost()) {
+			Minz_Request::forward($return_url, true);
+		}
+
+		$apiPasswordPlain = Minz_Request::param('apiPasswordPlain', '', true);
+		if ($apiPasswordPlain == '') {
+			Minz_Request::forward($return_url, true);
+		}
+
+		$username = Minz_Session::param('currentUser');
+		$userConfig = FreshRSS_Context::$user_conf;
+
+		$apiPasswordHash = FreshRSS_password_Util::hash($apiPasswordPlain);
+		$userConfig->apiPasswordHash = $apiPasswordHash;
+
+		if (!FreshRSS_fever_Util::checkFeverPath()) {
+			Minz_Log::error("Could not save Fever API credentials. The directory does not have write access.");
+			Minz_Request::bad(_t('feedback.api.password.failed'), $return_url);
+		}
+
+		$feverKey = FreshRSS_fever_Util::updateKey($username, $apiPasswordPlain);
+		if (!$feverKey) {
+			Minz_Log::warning('Could not save Fever API credentials. Unknown error.', ADMIN_LOG);
+			Minz_Request::bad(_t('feedback.api.password.failed'), $return_url);
+		}
+
+		$userConfig->feverKey = $feverKey;
+		if ($userConfig->save()) {
+			Minz_Request::good(_t('feedback.api.password.updated'), $return_url);
+		} else {
+			Minz_Request::bad(_t('feedback.api.password.failed'), $return_url);
+		}
+	}
+}

--- a/app/Controllers/apiController.php
+++ b/app/Controllers/apiController.php
@@ -32,14 +32,8 @@ class FreshRSS_api_Controller extends Minz_ActionController {
 		$apiPasswordHash = FreshRSS_password_Util::hash($apiPasswordPlain);
 		$userConfig->apiPasswordHash = $apiPasswordHash;
 
-		if (!FreshRSS_fever_Util::checkFeverPath()) {
-			Minz_Log::error("Could not save Fever API credentials. The directory does not have write access.");
-			Minz_Request::bad(_t('feedback.api.password.failed'), $return_url);
-		}
-
 		$feverKey = FreshRSS_fever_Util::updateKey($username, $apiPasswordPlain);
 		if (!$feverKey) {
-			Minz_Log::warning('Could not save Fever API credentials. Unknown error.', ADMIN_LOG);
 			Minz_Request::bad(_t('feedback.api.password.failed'), $return_url);
 		}
 

--- a/app/Controllers/javascriptController.php
+++ b/app/Controllers/javascriptController.php
@@ -47,7 +47,7 @@ class FreshRSS_javascript_Controller extends Minz_ActionController {
 			Minz_Log::notice('Nonce failure due to invalid username!');
 		}
 		//Failure: Return random data.
-		$this->view->salt1 = sprintf('$2a$%02d$', FreshRSS_user_Controller::BCRYPT_COST);
+		$this->view->salt1 = sprintf('$2a$%02d$', FreshRSS_password_Util::BCRYPT_COST);
 		$alphabet = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 		for ($i = 22; $i > 0; $i--) {
 			$this->view->salt1 .= $alphabet[mt_rand(0, 63)];

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -4,17 +4,6 @@
  * Controller to handle user actions.
  */
 class FreshRSS_user_Controller extends Minz_ActionController {
-	// Will also have to be computed client side on mobile devices,
-	// so do not use a too high cost
-	const BCRYPT_COST = 9;
-
-	public static function hashPassword($passwordPlain) {
-		$passwordHash = password_hash($passwordPlain, PASSWORD_BCRYPT, array('cost' => self::BCRYPT_COST));
-		$passwordPlain = '';
-		$passwordHash = preg_replace('/^\$2[xy]\$/', '\$2a\$', $passwordHash);	//Compatibility with bcrypt.js
-		return $passwordHash == '' ? '' : $passwordHash;
-	}
-
 	/**
 	 * The username is also used as folder name, file name, and part of SQL table name.
 	 * '_' is a reserved internal username.
@@ -51,12 +40,12 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 		}
 
 		if ($passwordPlain != '') {
-			$passwordHash = self::hashPassword($passwordPlain);
+			$passwordHash = FreshRSS_password_Util::hash($passwordPlain);
 			$userConfig->passwordHash = $passwordHash;
 		}
 
 		if ($apiPasswordPlain != '') {
-			$apiPasswordHash = self::hashPassword($apiPasswordPlain);
+			$apiPasswordHash = FreshRSS_password_Util::hash($apiPasswordPlain);
 			$userConfig->apiPasswordHash = $apiPasswordHash;
 
 			$feverPath = DATA_PATH . '/fever/';

--- a/app/Utils/feverUtil.php
+++ b/app/Utils/feverUtil.php
@@ -1,0 +1,70 @@
+<?php
+
+class FreshRSS_fever_Util {
+	const FEVER_PATH = DATA_PATH . '/fever';
+
+	/**
+	 * Make sure the fever path exists and is writable.
+	 *
+	 * @return boolean true if the path is writable, else false.
+	 */
+	public static function checkFeverPath() {
+		if (!file_exists(self::FEVER_PATH)) {
+			@mkdir(self::FEVER_PATH, 0770, true);
+		}
+
+		return is_writable(self::FEVER_PATH);
+	}
+
+	/**
+	 * Return the corresponding path for a fever key.
+	 *
+	 * @param string
+	 * @return string
+	 */
+	public static function getKeyPath($feverKey) {
+		$salt = sha1(FreshRSS_Context::$system_conf->salt);
+		return self::FEVER_PATH . '/.key-' . $salt . '-' . $feverKey . '.txt';
+	}
+
+	/**
+	 * Update the fever key of a user.
+	 *
+	 * @param string
+	 * @param string
+	 * @return string the Fever key, or false if the update failed
+	 */
+	public static function updateKey($username, $passwordPlain) {
+		self::deleteKey($username);
+
+		$feverKey = strtolower(md5("{$username}:{$passwordPlain}"));
+		$feverKeyPath = self::getKeyPath($feverKey);
+		$res = file_put_contents($feverKeyPath, $username);
+		if ($res !== false) {
+			return $feverKey;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Delete the Fever key of a user.
+	 *
+	 * @param string
+	 * @return boolean true if the deletion succeeded, else false.
+	 */
+	public static function deleteKey($username) {
+		$userConfig = get_user_configuration($username);
+		if ($userConfig === null) {
+			return false;
+		}
+
+		$feverKey = $userConfig->feverKey;
+		if (!ctype_xdigit($feverKey)) {
+			return false;
+		}
+
+		$feverKeyPath = self::getKeyPath($feverKey);
+		return @unlink($feverKeyPath);
+	}
+}

--- a/app/Utils/feverUtil.php
+++ b/app/Utils/feverUtil.php
@@ -13,7 +13,11 @@ class FreshRSS_fever_Util {
 			@mkdir(self::FEVER_PATH, 0770, true);
 		}
 
-		return is_writable(self::FEVER_PATH);
+		$ok = is_writable(self::FEVER_PATH);
+		if (!$ok) {
+			Minz_Log::error("Could not save Fever API credentials. The directory does not have write access.");
+		}
+		return $ok;
 	}
 
 	/**
@@ -35,6 +39,11 @@ class FreshRSS_fever_Util {
 	 * @return string the Fever key, or false if the update failed
 	 */
 	public static function updateKey($username, $passwordPlain) {
+		$ok = self::checkFeverPath();
+		if (!$ok) {
+			return false;
+		}
+
 		self::deleteKey($username);
 
 		$feverKey = strtolower(md5("{$username}:{$passwordPlain}"));
@@ -43,6 +52,7 @@ class FreshRSS_fever_Util {
 		if ($res !== false) {
 			return $feverKey;
 		} else {
+			Minz_Log::warning('Could not save Fever API credentials. Unknown error.', ADMIN_LOG);
 			return false;
 		}
 	}

--- a/app/Utils/passwordUtil.php
+++ b/app/Utils/passwordUtil.php
@@ -1,0 +1,27 @@
+<?php
+
+class FreshRSS_password_Util {
+	// Will also have to be computed client side on mobile devices,
+	// so do not use a too high cost
+	const BCRYPT_COST = 9;
+
+	/**
+	 * Return a hash of a plain password, using BCRYPT
+	 *
+	 * @param string
+	 * @return string
+	 */
+	public static function hash($passwordPlain) {
+		$passwordHash = password_hash(
+			$passwordPlain,
+			PASSWORD_BCRYPT,
+			array('cost' => self::BCRYPT_COST)
+		);
+		$passwordPlain = '';
+
+		// Compatibility with bcrypt.js
+		$passwordHash = preg_replace('/^\$2[xy]\$/', '\$2a\$', $passwordHash);
+
+		return $passwordHash == '' ? '' : $passwordHash;
+	}
+}

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Správa profilu',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Smazání účtu',
 			'warn' => 'Váš účet bude smazán spolu se všemi souvisejícími daty',

--- a/app/i18n/cz/feedback.php
+++ b/app/i18n/cz/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Nemáte oprávnění přistupovat na tuto stránku',
 		'not_found' => 'Tato stránka neexistuje',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Nastal problém s konfigurací přihlašovacího systému. Zkuste to prosím později.',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Profil-Verwaltung',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Accountlöschung',
 			'warn' => 'Dein Account und alle damit bezogenen Daten werden gelöscht.',

--- a/app/i18n/de/feedback.php
+++ b/app/i18n/de/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Sie haben nicht die Berechtigung, diese Seite aufzurufen',
 		'not_found' => 'Sie suchen nach einer Seite, die nicht existiert',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Während der Konfiguration des Authentifikationssystems trat ein Fehler auf. Bitte versuchen Sie es später erneut.',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Profile management',
+		'api' => 'API management',
 		'delete' => array(
 			'_' => 'Account deletion',
 			'warn' => 'Your account and all related data will be deleted.',

--- a/app/i18n/en/feedback.php
+++ b/app/i18n/en/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'You don’t have permission to access this page',
 		'not_found' => 'You are looking for a page which doesn’t exist',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified',
+			'updated' => 'Your password has been modified',
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'A problem occured during authentication system configuration. Please retry later.',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Administración de perfiles',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Borrar cuenta',
 			'warn' => 'Tu cuenta y todos los datos asociados serán eliminados.',

--- a/app/i18n/es/feedback.php
+++ b/app/i18n/es/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'No dispones de permiso para acceder a esta página',
 		'not_found' => 'La página que buscas no existe',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Hubo un problema durante la configuración del sistema de idenfificación. Por favor, inténtalo más tarde.',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Gestion du profil',
+		'api' => 'Gestion de l’API',
 		'delete' => array(
 			'_' => 'Suppression du compte',
 			'warn' => 'Le compte et toutes les données associées vont être supprimées.',

--- a/app/i18n/fr/feedback.php
+++ b/app/i18n/fr/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Vous n’avez pas le droit d’accéder à cette page !',
 		'not_found' => 'La page que vous cherchez n’existe pas !',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Votre mot de passe n’a pas pu être mis à jour',
+			'updated' => 'Votre mot de passe a été mis à jour',
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Un problème est survenu lors de la configuration de votre système d’authentification. Veuillez réessayer plus tard.',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Profile management',	//TODO - Translation
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Account deletion',	//TODO - Translation
 			'warn' => 'Your account and all related data will be deleted.',	//TODO - Translation

--- a/app/i18n/he/feedback.php
+++ b/app/i18n/he/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'אין לך הרשאות לצפות בדף זה',
 		'not_found' => 'הדף הזה לא נמצא',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'אירעה שגיאה במהלך הגדרת מערכת האימיות. אנא נסו שוב מאוחר יותר.',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Gestione profili',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Cancellazione account',
 			'warn' => 'Il tuo account e tutti i dati associati saranno cancellati.',

--- a/app/i18n/it/feedback.php
+++ b/app/i18n/it/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Non hai i permessi per accedere a questa pagina',
 		'not_found' => 'Pagina non disponibile',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Si è verificato un problema alla configurazione del sistema di autenticazione. Per favore riprova più tardi.',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => '프로필 관리',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => '계정 삭제',
 			'warn' => '당신의 계정과 관련된 모든 데이터가 삭제됩니다.',

--- a/app/i18n/kr/feedback.php
+++ b/app/i18n/kr/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => '이 페이지에 접근할 수 있는 권한이 없습니다',
 		'not_found' => '이 페이지는 존재하지 않습니다',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => '인증 시스템을 설정하는 동안 문제가 발생했습니다. 잠시 후 다시 시도하세요.',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Profiel beheer',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Account verwijderen',
 			'warn' => 'Uw account en alle gerelateerde gegvens worden verwijderd.',

--- a/app/i18n/nl/feedback.php
+++ b/app/i18n/nl/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'U hebt geen rechten om deze pagina te bekijken.',
 		'not_found' => 'Deze pagina bestaat niet',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Er is een probleem opgetreden tijdens de controle van de systeemconfiguratie. Probeer het later nog eens.',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -51,6 +51,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Gestion del perfil',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Supression del compte',
 			'warn' => 'Lo compte e totas las donadas ligadas seràn suprimits.',

--- a/app/i18n/oc/feedback.php
+++ b/app/i18n/oc/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Avètz pas l’autorizacion d’accedir a aquesta pagina',
 		'not_found' => 'La pagina que cercatz existís pas',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Un problèma es aparegut pendent la configuracion del sistèma d’autentificacion. Tonatz ensajar ai tard.',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Gerenciamento de perfil',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Remover conta',
 			'warn' => 'Sua conta e todos os dados relacionados serão removidos.',

--- a/app/i18n/pt-br/feedback.php
+++ b/app/i18n/pt-br/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Você não tem permissão para acessar esta página',
 		'not_found' => 'VocÊ está buscando por uma página que não existe',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Um problema ocorreu durante o sistema de configuração para autenticação. Por favor tente mais tarde.',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Profile management',	//TODO - Translation
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Account deletion',	//TODO - Translation
 			'warn' => 'Your account and all the related data will be deleted.',	//TODO - Translation

--- a/app/i18n/ru/feedback.php
+++ b/app/i18n/ru/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'You don’t have permission to access this page',	//TODO - Translation
 		'not_found' => 'You are looking for a page which doesn’t exist',	//TODO - Translation
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'A problem occured during authentication system configuration. Please retry later.',	//TODO - Translation

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -42,6 +42,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Správca profilu',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Vymazanie účtu',
 			'warn' => 'Váš účet a všetky údaje v ňom budú vymazané.',

--- a/app/i18n/sk/feedback.php
+++ b/app/i18n/sk/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Na prístup k tejto stránke nemáte oprávnenie',
 		'not_found' => 'Hľadáte stránku, ktorá neexistuje',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Nastavl problém pri nastavovaní prihlasovacieho systému. Prosím, skúste to znova neskôr.',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => 'Profil yönetimi',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => 'Hesap silme',
 			'warn' => 'Hesabınız ve tüm verileriniz silinecek.',

--- a/app/i18n/tr/feedback.php
+++ b/app/i18n/tr/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => 'Bu sayfaya erişim yetkiniz yok',
 		'not_found' => 'Varolmayan bir sayfa arıyorsunuz',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => 'Sistem yapılandırma kimlik doğrulaması sırasında hata oldu. Lütfen daha sonra tekrar deneyin.',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -50,6 +50,7 @@ return array(
 	),
 	'profile' => array(
 		'_' => '帐户管理',
+		'api' => 'API management', // TODO - Translation
 		'delete' => array(
 			'_' => '账户删除',
 			'warn' => '你的帐户和所有相关数据都将被删除。',

--- a/app/i18n/zh-cn/feedback.php
+++ b/app/i18n/zh-cn/feedback.php
@@ -8,6 +8,12 @@ return array(
 		'denied' => '你无权访问此页面',
 		'not_found' => '你寻找的页面不存在',
 	),
+	'api' => array(
+		'password' => array(
+			'failed' => 'Your password cannot be modified', // TODO - Translation
+			'updated' => 'Your password has been modified', // TODO - Translation
+		),
+	),
 	'auth' => array(
 		'form' => array(
 			'not_set' => '配置认证方式时出错。请稍后重试。',

--- a/app/install.php
+++ b/app/install.php
@@ -221,7 +221,6 @@ function saveStep3() {
 				$_SESSION['default_user'],
 				'',	//TODO: Add e-mail
 				$password_plain,
-				'',
 				[
 					'language' => $_SESSION['language'],
 				]

--- a/app/views/user/profile.phtml
+++ b/app/views/user/profile.phtml
@@ -48,19 +48,6 @@
 			</div>
 		</div>
 
-		<?php if (FreshRSS_Context::$system_conf->api_enabled) { ?>
-		<div class="form-group">
-			<label class="group-name" for="apiPasswordPlain"><?= _t('conf.profile.password_api') ?></label>
-			<div class="group-controls">
-				<div class="stick">
-					<input type="password" id="apiPasswordPlain" name="apiPasswordPlain" autocomplete="new-password" pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
-					<a class="btn toggle-password" data-toggle="apiPasswordPlain"><?= _i('key') ?></a>
-				</div>
-				<?= _i('help') ?> <kbd><a href="../api/"><?= Minz_Url::display('/api/', 'html', true) ?></a></kbd>
-			</div>
-		</div>
-		<?php } ?>
-
 		<?php if (FreshRSS_Auth::accessNeedsAction()) { ?>
 		<div class="form-group">
 			<label class="group-name" for="token"><?= _t('admin.auth.token') ?></label>
@@ -81,6 +68,30 @@
 			</div>
 		</div>
 	</form>
+
+	<?php if (FreshRSS_Context::$system_conf->api_enabled) { ?>
+		<form method="post" action="<?= _url('api', 'updatePassword') ?>">
+			<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+			<legend><?= _t('conf.profile.api') ?></legend>
+
+			<div class="form-group">
+				<label class="group-name" for="apiPasswordPlain"><?= _t('conf.profile.password_api') ?></label>
+				<div class="group-controls">
+					<div class="stick">
+						<input type="password" id="apiPasswordPlain" name="apiPasswordPlain" autocomplete="new-password" pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
+						<a class="btn toggle-password" data-toggle="apiPasswordPlain"><?= _i('key') ?></a>
+					</div>
+					<?= _i('help') ?> <kbd><a href="../api/"><?= Minz_Url::display('/api/', 'html', true) ?></a></kbd>
+				</div>
+			</div>
+
+			<div class="form-group form-actions">
+				<div class="group-controls">
+					<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				</div>
+			</div>
+		</form>
+	<?php } ?>
 
 	<?php if (!FreshRSS_Auth::hasAccess('admin')) { ?>
 	<form id="crypto-form" method="post" action="<?= _url('user', 'delete') ?>">

--- a/cli/_update-or-create-user.php
+++ b/cli/_update-or-create-user.php
@@ -4,7 +4,6 @@ require(__DIR__ . '/_cli.php');
 $params = array(
 		'user:',
 		'password:',
-		'api_password:',
 		'language:',
 		'email:',
 		'token:',
@@ -24,7 +23,7 @@ $options = getopt('', $params);
 
 if (!validateOptions($argv, $params) || empty($options['user'])) {
 	fail('Usage: ' . basename($_SERVER['SCRIPT_FILENAME']) .
-		" --user username ( --password 'password' --api_password 'api_password'" .
+		" --user username ( --password 'password'" .
 		" --language en --email user@example.net --token 'longRandomString'" .
 		($isUpdate ? '' : '--no_default_feeds') .
 		" --purge_after_months 3 --feed_min_articles_default 50 --feed_ttl_default 3600" .

--- a/cli/create-user.php
+++ b/cli/create-user.php
@@ -20,7 +20,6 @@ $ok = FreshRSS_user_Controller::createUser(
 	$username,
 	empty($options['mail_login']) ? '' : $options['mail_login'],
 	empty($options['password']) ? '' : $options['password'],
-	empty($options['api_password']) ? '' : $options['api_password'],
 	$values,
 	!isset($options['no_default_feeds'])
 );

--- a/cli/update-user.php
+++ b/cli/update-user.php
@@ -11,7 +11,6 @@ $ok = FreshRSS_user_Controller::updateUser(
 	$username,
 	empty($options['mail_login']) ? null : $options['mail_login'],
 	empty($options['password']) ? '' : $options['password'],
-	empty($options['api_password']) ? '' : $options['api_password'],
 	$values);
 
 if (!$ok) {


### PR DESCRIPTION
As I mentioned in https://github.com/FreshRSS/FreshRSS/pull/2664, it would be great to simplify the `userController` endpoints, especially to enhance the feedback to the user.

This PR aims to extract the "update API password" endpoint. It should be more easily reviewed commit by commit.

First step is to extract some methods which don't belong to the controller but are more or less "utility" functions. So I added a new `app/Utils` folder for these methods. I needed to do this because some are used in two different controllers then, and I don't want to call controller methods from another controller.

The second step is to actually move the endpoint in a new API controller. There are two consequences:

- I moved the API password input in another form
- I removed the possibility to update the API password from the CLI (it could be done quite easily with a bit more code, but I'm not sure it's really useful)

Then, I updated the locales (nothing fancy but it would be easier with https://github.com/FreshRSS/FreshRSS/pull/2673 :smile:)

The last commit is optional, I just tried to simplify the controller a bit more by hiding the presence check of the fever directory. I'm not totally satisfied with this because it makes the fever `updateKey` method a bit more complex. Let me know what you think about this!

It looks like this:

![Capture d’écran de 2019-11-19 10-26-38](https://user-images.githubusercontent.com/1436309/69133989-1ec8f200-0ab7-11ea-80e8-b6e961e3c99b.png)

Last point I want to mention: I initially wanted to move the form in a new "Mobile & desktop" page, with the "Allow API access" checkbox from the "Authentication" page. It could also contain the list of the supported mobile applications and some explanations on how to configure them (e.g. giving the correct URL directly on this page). It was too much code for this PR though, so I stopped.