### PR TITLE
FreshRSS 1.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# FreshRSS changelog
 
-## 2019-11-XX FreshRSS 1.15.3-dev
+## 2019-11-22 FreshRSS 1.15.3
 
 * Bix fixing (regression from 1.15.x)
 	* Fix adding categories in MySQL 5.5 [#2670](https://github.com/FreshRSS/FreshRSS/issues/2670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2019-11-22 FreshRSS 1.15.3
 
-* Bug fixing (regression from 1.15.x)
+* Bug fixing (regressions from 1.15.x)
 	* Fix adding categories in MySQL 5.5 [#2670](https://github.com/FreshRSS/FreshRSS/issues/2670)
 	* Fix saving sharing integrations [#2669](https://github.com/FreshRSS/FreshRSS/pull/2669)
 * Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# FreshRSS changelog
 
+## 20XX-XX-XX FreshRSS 1.15.3-dev
+
+
+
 ## 2019-11-12 FreshRSS 1.15.2
 
 * Bug fixing (regressions from 1.15.x)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Compatibility
 	* Add fallback for systems with old ICU < 4.6 (*International Components for Unicode*) [#2680](https://github.com/FreshRSS/FreshRSS/pull/2680)
 * API
-	* Do not obbey `rel=self` feed redirections when WebSub is disabled [#2659](https://github.com/FreshRSS/FreshRSS/pull/2659)
+	* Do not obey `rel=self` feed redirections when WebSub is disabled [#2659](https://github.com/FreshRSS/FreshRSS/pull/2659)
 * UI
 	* Start adding support for RTL (*right-to-left*) languages [#2656](https://github.com/FreshRSS/FreshRSS/pull/2656)
 * Deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
 ﻿# FreshRSS changelog
 
-## 20XX-XX-XX FreshRSS 1.15.3-dev
+## 2019-11-XX FreshRSS 1.15.3-dev
 
+* Bix fixing (regression from 1.15.x)
+	* Fix adding categories in MySQL 5.5 [#2670](https://github.com/FreshRSS/FreshRSS/issues/2670)
+	* Fix saving sharing integrations [#2669](https://github.com/FreshRSS/FreshRSS/pull/2669)
+* Compatibility
+	* Add fallback for systems with old ICU < 4.6 (*International Components for Unicode*) [#2680](https://github.com/FreshRSS/FreshRSS/pull/2680)
+* API
+	* Do not obbey `rel=self` feed redirections when WebSub is disabled [#2659](https://github.com/FreshRSS/FreshRSS/pull/2659)
+* UI
+	* Start adding support for RTL (*right-to-left*) languages [#2656](https://github.com/FreshRSS/FreshRSS/pull/2656)
+* Deployment
+	* Docker: Ubuntu image updated to PHP 7.3.11
+* Misc.
+	* Add more log when errors occur when saving a profile [#2663](https://github.com/FreshRSS/FreshRSS/issues/2663)
+	* Improve Makefile with port override [#2660](https://github.com/FreshRSS/FreshRSS/pull/2660)
+	* Update a few external links to HTTPS [#2662](https://github.com/FreshRSS/FreshRSS/pull/2662)
 
 
 ## 2019-11-12 FreshRSS 1.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2019-11-22 FreshRSS 1.15.3
 
-* Bix fixing (regression from 1.15.x)
+* Bug fixing (regression from 1.15.x)
 	* Fix adding categories in MySQL 5.5 [#2670](https://github.com/FreshRSS/FreshRSS/issues/2670)
 	* Fix saving sharing integrations [#2669](https://github.com/FreshRSS/FreshRSS/pull/2669)
 * Compatibility

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ ifndef TAG
 	TAG=dev-alpine
 endif
 
+PORT ?= 8080
+
 ifeq ($(findstring alpine,$(TAG)),alpine)
 	DOCKERFILE=Dockerfile-Alpine
 else ifeq ($(findstring arm,$(TAG)),arm)
@@ -24,7 +26,7 @@ start: ## Start the development environment (use Docker)
 	docker run \
 		--rm \
 		-v $(shell pwd):/var/www/FreshRSS:z \
-		-p 8080:80 \
+		-p $(PORT):80 \
 		-e FRESHRSS_ENV=development \
 		--name freshrss-dev \
 		freshrss/freshrss:$(TAG)

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -415,8 +415,8 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				$entryDAO->commit();
 			}
 
-			if ($feed->hubUrl() && $feed->selfUrl()) {	//selfUrl has priority for WebSub
-				if ($feed->selfUrl() !== $url) {	//https://code.google.com/p/pubsubhubbub/wiki/MovingFeedsOrChangingHubs
+			if ($pubSubHubbubEnabled && $feed->hubUrl() && $feed->selfUrl()) {	//selfUrl has priority for WebSub
+				if ($feed->selfUrl() !== $url) {	// https://github.com/pubsubhubbub/PubSubHubbub/wiki/Moving-Feeds-or-changing-Hubs
 					$selfUrl = checkUrl($feed->selfUrl());
 					if ($selfUrl) {
 						Minz_Log::debug('WebSub unsubscribe ' . $feed->url(false));

--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -81,7 +81,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 
 	public function addCategory($valuesTmp) {
 		$sql = 'INSERT INTO `_category`(name, attributes) '
-		     . 'SELECT * FROM (SELECT TRIM(?), ?) c2 '	//TRIM() to provide a type hint as text for PostgreSQL
+		     . 'SELECT * FROM (SELECT TRIM(?) AS name, TRIM(?) AS attributes) c2 '	//TRIM() to provide a type hint as text
 		     . 'WHERE NOT EXISTS (SELECT 1 FROM `_tag` WHERE name = TRIM(?))';	//No tag of the same name
 		$stm = $this->pdo->prepare($sql);
 

--- a/app/Models/TagDAO.php
+++ b/app/Models/TagDAO.php
@@ -106,9 +106,9 @@ class FreshRSS_TagDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 	public function updateTagAttribute($tag, $key, $value) {
 		if ($tag instanceof FreshRSS_Tag) {
 			$tag->_attributes($key, $value);
-			return $this->updateFeed(
+			return $this->updateTag(
 					$tag->id(),
-					array('attributes' => $feed->attributes())
+					[ 'attributes' => $tag->attributes() ]
 				);
 		}
 		return false;

--- a/app/views/configure/integration.phtml
+++ b/app/views/configure/integration.phtml
@@ -3,7 +3,7 @@
 <div class="post">
 	<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
 
-	<form method="post" action="<?= _url('configure', 'sharing') ?>"
+	<form method="post" action="<?= _url('configure', 'integration') ?>"
 		data-simple='<div class="form-group" id="group-share-##key##"><label class="group-name">##label##</label><div class="group-controls"><div class="stick"><input type="text" id="share_##key##_name" name="share[##key##][name]" class="extend" value="##label##" placeholder="<?= _t('conf.sharing.share_name') ?>" size="64" />
 			<input type="url" id="share_##key##_url" name="share[##key##][url]" class="extend" value="" placeholder="<?= _t('gen.short.not_applicable') ?>" size="64" disabled /><a href="#" class="remove btn btn-attention" data-remove="group-share-##key##"><?= _i('close') ?></a></div>
 			<input type="hidden" id="share_##key##_type" name="share[##key##][type]" value="##type##" /></div></div>'

--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -42,7 +42,7 @@
 					<input type="text" name="url_rss" id="url" class="extend" value="<?= $this->feed->url() ?>" />
 					<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>"><?= _i('link') ?></a>
 				</div>
-				<a class="btn" target="_blank" rel="noreferrer" href="http://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
+				<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
 			</div>
 		</div>
 		<div class="form-group">

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -49,7 +49,7 @@
 					<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>"><?= _i('link') ?></a>
 				</div>
 
-				<a class="btn" target="_blank" rel="noreferrer" href="http://validator.w3.org/feed/check.cgi?url=<?= rawurlencode(htmlspecialchars_decode($this->feed->url(), ENT_QUOTES)) ?>"><?= _t('sub.feed.validator') ?></a>
+				<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?= rawurlencode(htmlspecialchars_decode($this->feed->url(), ENT_QUOTES)) ?>"><?= _t('sub.feed.validator') ?></a>
 			</div>
 		</div>
 		<div class="form-group">

--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -28,7 +28,7 @@
 		}
 	}
 	?><li class="item website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>"><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" /> <span><?= $this->feed->name() ?></span></a></li>
-	<li class="item title"><a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>"><?= $this->entry->title() ?></a><?php
+	<li class="item title" dir="auto"><a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>"><?= $this->entry->title() ?></a><?php
 		if ($topline_display_authors):
 			?><div class="item author"><?php
 			$authors = $this->entry->authors();

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -64,7 +64,7 @@ if (!empty($this->entries)) {
 
 			$this->renderHelper('index/normal/entry_header');
 
-		?><div class="flux_content">
+		?><div class="flux_content" dir="auto">
 			<div class="content <?= $content_width ?>">
 				<h1 class="title"><a target="_blank" rel="noreferrer" class="go_website" href="<?= $this->entry->link() ?>"><?= $this->entry->title() ?></a></h1>
 				<div class="author"><?php

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -17,7 +17,7 @@ if (!empty($this->entries)) {
 			continue;
 		}
 	?><div class="flux<?= !$item->isRead() ? ' not_read' : '' ?><?= $item->isFavorite() ? ' favorite' : '' ?>" id="flux_<?= $item->id() ?>">
-		<div class="flux_content">
+		<div class="flux_content" dir="auto">
 			<div class="content <?= $content_width ?>">
 				<?php
 					$feed = FreshRSS_CategoryDAO::findFeed($this->categories, $item->feed());	//We most likely already have the feed object in cache

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.15.3-dev');
+define('FRESHRSS_VERSION', '1.15.3');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_VERSION', '1.15.2');
+define('FRESHRSS_VERSION', '1.15.3-dev');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');
 

--- a/docs/en/users/02_First_steps.md
+++ b/docs/en/users/02_First_steps.md
@@ -2,7 +2,7 @@ Learning how to handle a new application is not always easy. We build FreshRSS t
 
 This section guides you to the pages you need as a new comer.
 
-[After installing the application](../admins/02_Installation.md), the first step is to add some feeds. You have a few options:
+[After installing the application](../admins/03_Installation.md), the first step is to add some feeds. You have a few options:
 
 1. [Add a feed manually](04_Subscriptions.md#adding-a-feed)
 2. [Import an OPML or JSON file](04_Subscriptions.md#import-and-export)

--- a/docs/en/users/07_Frequently_Asked_Questions.md
+++ b/docs/en/users/07_Frequently_Asked_Questions.md
@@ -13,7 +13,7 @@ Of course, ```/i``` has a purpose! We used it for performance and usability:
 
 To increase security, FreshRSS is hosted in two sections. The first section is public (```./p``` folder) and the second section is private (everything else). Therefore the ```robots.txt``` file is located in ```./p``` sub-folder.
 
-As explained in the [security section](/en/User_documentation/Installation/Security), it is highly recommended to make only the public section available at the domain level. With that configuration, ```./p``` is the root folder for http://demo.freshrss.org/, thus making ```robots.txt``` available at the root of the application.
+As explained in the [security section](/en/User_documentation/Installation/Security), it is highly recommended to make only the public section available at the domain level. With that configuration, ```./p``` is the root folder for https://demo.freshrss.org/, thus making ```robots.txt``` available at the root of the application.
 
 The same rule applies for ```favicon.ico``` and ```.htaccess```.
 
@@ -24,15 +24,9 @@ The feed syntax can be invalid, it can be unrecognized by the SimplePie library.
 The first step is to identify what causes the problem.
 Here are the steps to follow:
 
-1. __Verify if the feed syntax is valid__ with the [W3C on-line tool](http://validator.w3.org/feed/ "RSS and Atom feed validator"). If it is not valid, there is nothing we can do.
-1. __Verify SimplePie validation__ with the [SimplePie on-line tool](http://simplepie.org/demo/ "SimplePie official demo"). If it is not recognized, there is nothing we can do.
-1. __Verify FreshRSS integration__ with the [demo](http://demo.freshrss.org "FreshRSS official demo"). If it is not working, you need to [create an issue on Github](https://github.com/FreshRSS/FreshRSS/issues/new "Create an issue for FreshRSS") so we can have a look at it. If it is working, there is probably something fishy with the hosting server.
-
-Here is a list of feeds which don't work:
-
-* http://foulab.org/fr/rss/Foulab_News: is not a W3C valid feed (November 2014)
-* http://eu.battle.net/hearthstone/fr/feed/news: is not a W3C valid feed (Novembre 2014)
-* http://webseriesmag.blogs.liberation.fr/we/atom.xml: is not working for the user but succeed on all the described validations (November 2014)
+1. __Verify if the feed syntax is valid__ with the [W3C on-line tool](https://validator.w3.org/feed/ "RSS and Atom feed validator"). If it is not valid, there is nothing we can do.
+1. __Verify SimplePie validation__ with the [SimplePie on-line tool](https://simplepie.org/demo/ "SimplePie official demo"). If it is not recognized, there is nothing we can do.
+1. __Verify FreshRSS integration__ with the [demo](https://demo.freshrss.org "FreshRSS official demo"). If it is not working, you need to [create an issue on Github](https://github.com/FreshRSS/FreshRSS/issues/new "Create an issue for FreshRSS") so we can have a look at it. If it is working, there is probably something fishy with the hosting server.
 
 ## How to change a forgotten password?
 

--- a/docs/fr/users/07_Frequently_Asked_Questions.md
+++ b/docs/fr/users/07_Frequently_Asked_Questions.md
@@ -24,7 +24,7 @@ Le flux peut avoir une syntaxe invalide, il peut ne pas être reconnu par la bib
 Il faut dans un premier temps déterminer la cause du problème.
 Voici la liste des étapes à suivre pour la déterminer :
 
-1. __Vérifier la validité du flux__ grâce à l'[outil en ligne du W3C](http://validator.w3.org/feed/ "Validateur en ligne de flux RSS et Atom"). Si ça ne fonctionne pas, nous ne pouvons rien faire.
+1. __Vérifier la validité du flux__ grâce à l'[outil en ligne du W3C](https://validator.w3.org/feed/ "Validateur en ligne de flux RSS et Atom"). Si ça ne fonctionne pas, nous ne pouvons rien faire.
 1. __Vérifier la reconnaissance par SimplePie__ grâce à l'[outil en ligne de SimplePie](http://simplepie.org/demo/ "Démo officielle de SimplePie"). Si ça ne fonctionne pas, nous ne pouvons rien faire.
 1. __Vérifier l'intégration dans FreshRSS__ grâce à la [démo](http://demo.freshrss.org "Démo officielle de FreshRSS"). Si ça ne fonctionne pas, il faut [créer un ticket sur Github](https://github.com/FreshRSS/FreshRSS/issues/new "Créer un ticket pour FreshRSS") pour que l'on puisse regarder ce qui se passe. Si ça fonctionne, il y a probablement un problème avec l'hébergement.
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -49,13 +49,19 @@ spl_autoload_register('classAutoloader');
 
 function idn_to_puny($url) {
 	if (function_exists('idn_to_ascii')) {
-		$parts = parse_url($url);
-		if (!empty($parts['host'])) {
-			$idn = $parts['host'];
-			$puny = idn_to_ascii($idn, 0, INTL_IDNA_VARIANT_UTS46);
+		$idn = parse_url($url, PHP_URL_HOST);
+		if ($idn != '') {
+			// https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
+			if (defined('INTL_IDNA_VARIANT_UTS46')) {
+				$puny = idn_to_ascii($idn, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+			} elseif (defined('INTL_IDNA_VARIANT_2003')) {
+				$puny = idn_to_ascii($idn, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
+			} else {
+				$puny = idn_to_ascii($idn);
+			}
 			$pos = strpos($url, $idn);
-			if ($pos !== false) {
-				return substr_replace($url, $puny, $pos, strlen($idn));
+			if ($puny != '' && $pos !== false) {
+				$url = substr_replace($url, $puny, $pos, strlen($idn));
 			}
 		}
 	}


### PR DESCRIPTION
Quick release of [FreshRSS 1.15.3](https://github.com/FreshRSS/FreshRSS/milestones/1.15.3) to some bugs following [FreshRSS 1.15.2](https://github.com/FreshRSS/FreshRSS/pull/2655) and previous 1.15.x releases.

Full [changelog](https://github.com/FreshRSS/FreshRSS/blob/dev/CHANGELOG.md):

* Bix fixing (regression from 1.15.x)
	* Fix adding categories in MySQL 5.5 [#2670](https://github.com/FreshRSS/FreshRSS/issues/2670)
	* Fix saving sharing integrations [#2669](https://github.com/FreshRSS/FreshRSS/pull/2669)
* Compatibility
	* Add fallback for systems with old ICU < 4.6 (*International Components for Unicode*) [#2680](https://github.com/FreshRSS/FreshRSS/pull/2680)
* API
	* Do not obbey `rel=self` feed redirections when WebSub is disabled [#2659](https://github.com/FreshRSS/FreshRSS/pull/2659)
* UI
	* Start adding support for RTL (*right-to-left*) languages [#2656](https://github.com/FreshRSS/FreshRSS/pull/2656)
* Deployment
	* Docker: Ubuntu image updated to PHP 7.3.11
* Misc.
	* Add more log when errors occur when saving a profile [#2663](https://github.com/FreshRSS/FreshRSS/issues/2663)
	* Improve Makefile with port override [#2660](https://github.com/FreshRSS/FreshRSS/pull/2660)
	* Update a few external links to HTTPS [#2662](https://github.com/FreshRSS/FreshRSS/pull/2662)