### PR TITLE
Update navigation on empty feeds

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -461,34 +461,58 @@ function next_entry(skipping) {
 
 function prev_feed() {
 	let found = false;
+	let adjacent = null;
 	const feeds = document.querySelectorAll('#aside_feed .feed');
 	for (let i = feeds.length - 1; i >= 0; i--) {
 		const feed = feeds[i];
-		if (found && getComputedStyle(feed).display !== 'none') {
-			delayedClick(feed.querySelector('a.item-title'));
-			break;
-		} else if (feed.classList.contains('active')) {
+		if (feed.classList.contains('active')) {
 			found = true;
+			continue;
+		}
+		if (!found) {
+			continue;
+		}
+		if (getComputedStyle(feed).display === 'none') {
+			continue;
+		}
+		if (feed.dataset.unread != 0) {
+			return delayedClick(feed.querySelector('a.item-title'));
+		} else if (adjacent === null) {
+			adjacent = feed;
 		}
 	}
-	if (!found) {
+	if (found) {
+		delayedClick(adjacent.querySelector('a.item-title'));
+	} else {
 		last_feed();
 	}
 }
 
 function next_feed() {
 	let found = false;
+	let adjacent = null;
 	const feeds = document.querySelectorAll('#aside_feed .feed');
 	for (let i = 0; i < feeds.length; i++) {
 		const feed = feeds[i];
-		if (found && getComputedStyle(feed).display !== 'none') {
-			delayedClick(feed.querySelector('a.item-title'));
-			break;
-		} else if (feed.classList.contains('active')) {
+		if (feed.classList.contains('active')) {
 			found = true;
+			continue;
+		}
+		if (!found) {
+			continue;
+		}
+		if (getComputedStyle(feed).display === 'none') {
+			continue;
+		}
+		if (feed.dataset.unread != 0) {
+			return delayedClick(feed.querySelector('a.item-title'));
+		} else if (adjacent === null) {
+			adjacent = feed;
 		}
 	}
-	if (!found) {
+	if (found) {
+		delayedClick(adjacent.querySelector('a.item-title'));
+	} else {
 		first_feed();
 	}
 }


### PR DESCRIPTION
When using feed navigation, the previous behavior was to cycle through all
available feeds regardless of their content. To match the behaviour of the
first feed and last feed navigation shortcuts, the navigation now skips
empty feeds. Now it's consistent through out the application.
When using feed navigation with only empty feeds, the new behavior is to
cycle through all available feeds.

See #2385