### PR TITLE
fix: Allow to refresh feeds if user isn't verified

### DIFF
--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -155,6 +155,7 @@ class FreshRSS extends Minz_FrontController {
 			Minz_Request::is('user', 'profile') ||
 			Minz_Request::is('user', 'delete') ||
 			Minz_Request::is('auth', 'logout') ||
+			Minz_Request::is('feed', 'actualize') ||
 			Minz_Request::is('javascript', 'nonce')
 		);
 		if ($email_not_verified && !$action_is_allowed) {


### PR DESCRIPTION
While I was looking at the number of articles of my users, I discovered
some of them had none, while having a bunch of feeds though. I took a
look at the logs generated by `app/actualize_script.php` and discovered
that the script stopped strangely (in this example, "OK" for denise is
expected, and more users too):

```
FreshRSS[1681]: FreshRSS Start feeds actualization...
Starting feed actualization at 2019-11-29T16:37:19+00:00
Actualize alice...
Actualize denise...
Results:
alice OK
denise
```

After digging a bit, I quickly realized the script stopped always on
users who didn't validate their emails. And indeed, we trigger a
`Minz_Request::forward(..., true)` for these users, in the `FreshRSS`
class. This function calls the `exit` function, which stops the script.

This patch only allows the feed#actualize action to be executed for
unverified users in order to avoid an early-`exit`. This is a quick-win
solution, but I don't think it's a good one on the long term. I'll
propose an alternative in another patch, later.