### PR TITLE
Remove magicQuotesOff (#2697)

### DIFF
--- a/lib/Minz/Helper.php
+++ b/lib/Minz/Helper.php
@@ -8,17 +8,6 @@
  * La classe Helper représente une aide pour des tâches récurrentes
  */
 class Minz_Helper {
-	/**
-	 * Annule les effets des magic_quotes pour une variable donnée
-	 * @param $var variable à traiter (tableau ou simple variable)
-	 */
-	public static function stripslashes_r($var) {
-		if (is_array($var)) {
-			return array_map(array('Minz_Helper', 'stripslashes_r'), $var);
-		} else {
-			return stripslashes($var);
-		}
-	}
 
 	/**
 	 * Wrapper for htmlspecialchars.

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -100,7 +100,6 @@ class Minz_Request {
 	 * Initialise la Request
 	 */
 	public static function init() {
-		self::magicQuotesOff();
 		self::initJSON();
 	}
 
@@ -290,20 +289,6 @@ class Minz_Request {
 			return $_POST[$param];
 		} else {
 			return $default;
-		}
-	}
-
-	/**
-	 * Méthode désactivant les magic_quotes pour les variables
-	 *   $_GET
-	 *   $_POST
-	 *   $_COOKIE
-	 */
-	private static function magicQuotesOff() {
-		if (get_magic_quotes_gpc()) {
-			$_GET = Minz_Helper::stripslashes_r($_GET);
-			$_POST = Minz_Helper::stripslashes_r($_POST);
-			$_COOKIE = Minz_Helper::stripslashes_r($_COOKIE);
 		}
 	}
 


### PR DESCRIPTION
Magic quotes have been deprecated since PHP 5.4 and as of PHP 7.4 `get_magic_quotes_gpc()` displays a warning.