### PR TITLE
Manual update to SimplePie 1.5.3

### DIFF
--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -33,7 +33,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.5.2
+ * @version 1.5.3
  * @copyright 2004-2017 Ryan Parman, Geoffrey Sneddon, Ryan McCue
  * @author Ryan Parman
  * @author Geoffrey Sneddon
@@ -50,7 +50,7 @@ define('SIMPLEPIE_NAME', 'SimplePie');
 /**
  * SimplePie Version
  */
-define('SIMPLEPIE_VERSION', '1.5.2');
+define('SIMPLEPIE_VERSION', '1.5.3');
 
 /**
  * SimplePie Build

--- a/lib/SimplePie/SimplePie/Locator.php
+++ b/lib/SimplePie/SimplePie/Locator.php
@@ -402,7 +402,7 @@ class SimplePie_Locator
 			{
 				break;
 			}
-			if (preg_match('/(rss|rdf|atom|xml)/i', $value))
+			if (preg_match('/(feed|rss|rdf|atom|xml)/i', $value))
 			{
 				$this->checked_feeds++;
 				$headers = array(

--- a/lib/SimplePie/SimplePie/Parse/Date.php
+++ b/lib/SimplePie/SimplePie/Parse/Date.php
@@ -145,6 +145,14 @@ class SimplePie_Parse_Date
 		'Παρ' => 5,
 		'Σαβ' => 6,
 		'Κυρ' => 7,
+		// Russian
+		'Пн.' => 1,
+		'Вт.' => 2,
+		'Ср.' => 3,
+		'Чт.' => 4,
+		'Пт.' => 5,
+		'Сб.' => 6,
+		'Вс.' => 7,
 	);
 
 	/**
@@ -290,6 +298,31 @@ class SimplePie_Parse_Date
 		'Οκτ' => 10,
 		'Νοέ' => 11,
 		'Δεκ' => 12,
+		// Russian
+		'Янв' => 1,
+		'января' => 1,
+		'Фев' => 2,
+		'февраля' => 2,
+		'Мар' => 3,
+		'марта' => 3,
+		'Апр' => 4,
+		'апреля' => 4,
+		'Май' => 5,
+		'мая' => 5,
+		'Июн' => 6,
+		'июня' => 6,
+		'Июл' => 7,
+		'июля' => 7,
+		'Авг' => 8,
+		'августа' => 8,
+		'Сен' => 9,
+		'сентября' => 9,
+		'Окт' => 10,
+		'октября' => 10,
+		'Ноя' => 11,
+		'ноября' => 11,
+		'Дек' => 12,
+		'декабря' => 12,
 	);
 
 	/**
@@ -541,8 +574,8 @@ class SimplePie_Parse_Date
 	 */
 	public function __construct()
 	{
-		$this->day_pcre = '(' . implode(array_keys($this->day), '|') . ')';
-		$this->month_pcre = '(' . implode(array_keys($this->month), '|') . ')';
+		$this->day_pcre = '(' . implode('|', array_keys($this->day)) . ')';
+		$this->month_pcre = '(' . implode('|', array_keys($this->month)) . ')';
 
 		static $cache;
 		if (!isset($cache[get_class($this)]))
@@ -690,7 +723,7 @@ class SimplePie_Parse_Date
 			}
 
 			// Convert the number of seconds to an integer, taking decimals into account
-			$second = round((int)$match[6] + (int)$match[7] / pow(10, strlen($match[7])));
+			$second = round((int)$match[6] + (int)$match[7] / (10 ** strlen($match[7])));
 
 			return gmmktime($match[4], $match[5], $second, $match[2], $match[3], $match[1]) - $timezone;
 		}


### PR DESCRIPTION
Changelogs:
 * https://github.com/simplepie/simplepie/releases/tag/1.5.3

I've manually applied these changes:
https://github.com/simplepie/simplepie/compare/1.5.2..1.5.3

This is of particular interest as it eliminates some warnings when run with PHP 7.4:
```
PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/localhost/htdocs/FreshRSS/lib/SimplePie/SimplePie/Parse/Date.php on line 544
PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/localhost/htdocs/FreshRSS/lib/SimplePie/SimplePie/Parse/Date.php on line 545
```
See https://github.com/simplepie/simplepie/commit/38b504969ed08903cb12718e8270263a8c93080e