### PR TITLE
Make master the rolling release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 ifndef TAG
-	TAG=dev-alpine
+	TAG=alpine
 endif
 
 PORT ?= 8080

--- a/README.fr.md
+++ b/README.fr.md
@@ -50,11 +50,10 @@ FreshRSS n’est fourni avec aucune garantie.
 
 
 # Téléchargement
-Voir la [liste des versions](../../releases).
 
-## À propos des branches
-* Utilisez [la branche master](https://github.com/FreshRSS/FreshRSS/tree/master/) si vous souhaitez des versions moins fréquentes et stables.
-* Utilisez [la branche dev](https://github.com/FreshRSS/FreshRSS/tree/dev) si vous vouler une publication continue (rolling release) avec les dernières nouveautés, ou bien aider à tester ou développer la future version stable.
+Si vous préférez que votre FreshRSS soit stable, vous devriez télécharger la dernière version. De nouvelles versions sont publiées tous les 2 ou 3 mois. Voir la [liste des versions](https://github.com/FreshRSS/FreshRSS/releases).
+
+Si vous voulez une publication continue (rolling release) avec les dernières nouveautés, ou bien aider à tester ou développer la future version stable, vous pouvez utiliser [la branche master](https://github.com/FreshRSS/FreshRSS/tree/master/).
 
 
 # [Installation](https://freshrss.github.io/FreshRSS/fr/users/01_Installation.html)
@@ -97,8 +96,8 @@ sudo apt-get install git
 sudo git clone https://github.com/FreshRSS/FreshRSS.git
 cd FreshRSS
 
-# Si vous souhaitez utiliser la branche développement de FreshRSS
-sudo git checkout -b dev origin/dev
+# Si vous souhaitez utiliser la dernière version stable de FreshRSS
+sudo git checkout $(git describe --tags --abbrev=0)
 
 # Mettre les droits d’accès pour le serveur Web
 sudo chown -R :www-data . && sudo chmod -R g+r . && sudo chmod -R g+w ./data/

--- a/README.md
+++ b/README.md
@@ -50,11 +50,10 @@ FreshRSS comes with absolutely no warranty.
 
 
 # Releases
-See the [list of releases](../../releases).
 
-## About branches
-* Use [the master branch](https://github.com/FreshRSS/FreshRSS/tree/master/) if you need less frequent stable versions.
-* Use [the dev branch](https://github.com/FreshRSS/FreshRSS/tree/dev) if you want a rolling release with the newest features, or help testing or developing the next stable version.
+The latest stable release can be found [here](https://github.com/FreshRSS/FreshRSS/releases/latest). New versions are released every two to three months.
+
+If you want a rolling release with the newest features, or want to help testing or developing the next stable version, you can use [the `master` branch](https://github.com/FreshRSS/FreshRSS/tree/master/).
 
 
 # [Installation](https://freshrss.github.io/FreshRSS/en/admins/03_Installation.html)

--- a/docs/en/admins/02_Prerequisites.md
+++ b/docs/en/admins/02_Prerequisites.md
@@ -15,11 +15,11 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 
 # Getting the appropriate version of FreshRSS
 
-FreshRSS has three different releases or branches. Each branch has its own release frequency. So it is better if you spend some time to understand the purpose of each release.
+FreshRSS has two different releases. It is better if you spend some time to understand the purpose of each release.
 
 ## Stable release
 
-[Download](https://github.com/FreshRSS/FreshRSS/archive/master.zip)
+[Download](https://github.com/FreshRSS/FreshRSS/releases/latest)
 
 This version is really stable, tested thoroughly, and you should not face any major bugs.
 
@@ -29,11 +29,11 @@ It could happen that we make two releases in a short span of time if we have a r
 
 ## Development version
 
-[Download](https://github.com/FreshRSS/FreshRSS/archive/dev.zip)
+[Download](https://github.com/FreshRSS/FreshRSS/archive/master.zip)
 
 As its name suggests, the development version is the working codebase, intended for developers. **This release may be unstable!**
 
-If you want to keep track of the most recent enhancements or help the developers with bug reports, this is the branch for you. If you use this version, please keep in mind that you need to follow the branch activity on Github (via [the branch RSS feed](https://github.com/FreshRSS/FreshRSS/commits/dev.atom), for instance), and manually pull new commits.
+If you want to keep track of the most recent enhancements or help the developers with bug reports, this is the branch for you. If you use this version, please keep in mind that you need to follow the branch activity on Github (via [the branch RSS feed](https://github.com/FreshRSS/FreshRSS/commits/master.atom), for instance), and manually pull new commits.
 
 Some say that the main developers use this branch on a daily basis without problem. They may know what they are doing…
 

--- a/docs/en/admins/07_LinuxUpdate.md
+++ b/docs/en/admins/07_LinuxUpdate.md
@@ -1,6 +1,8 @@
-# Updating on Debian 9/Ubuntu 16.04
+# Updating on Linux
 
 This tutorial demonstrates commands for updating FreshRSS. It assumes that your main FreshRSS directory is `/usr/share/FreshRSS`; If you've installed it somewhere else, substitute your path as necessary.
+
+**Note that FreshRSS contains a built-in update system.** It's easier to use if you don't understand the commands that follow. It's available through the web interface of your FreshRSS installation, Administration → Update.
 
 ## Using git
 
@@ -13,58 +15,46 @@ If your local user doesn't have write access to the FreshRSS folder, use a sudo 
 cd /usr/share/FreshRSS/
 ```
 
-2. Verify the branch you're currently on. For stable releases, this should be `master`. 
-```
-git branch
-```
-
-
-3. Fetch the most recent code from the FreshRSS github Page
+2. Fetch the most recent code from GitHub
 ```
 git fetch --all
 ```
 
-Note: If you wish to switch to a specific version of FreshRSS, or switch to/from the dev branch, this is the time to do that. Example commands for switching branches are found below, in "Switching Branches"
-
-4. Check for an update
-```
-git status
-```
-
-If there's not an update, you're done! If there is, continue the following steps:
-
-5. Discard manual changes and delete manual additions
+3. Discard manual changes and delete manual additions
 ```
 git reset --hard
 git clean -f -d
 ```
+
+Note: If you wish to keep your changes, it's better to [create a pull request](https://github.com/FreshRSS/FreshRSS/compare) or [an extension](../developers/03_Backend/05_Extensions.md).
+
+4. Update FreshRSS
+```
+git checkout master
+git pull
+git checkout $(git describe --tags --abbrev=0)
+```
+
+Note: If you want to use the rolling release, the last command is optional.
+
+5. (optional) Make sure you use the correct version
+```
+git status
+```
+
+The command should tell you the tag that you're using. It must be the same as the one associated with [the latest release on GitHub](https://github.com/FreshRSS/FreshRSS/releases/latest). If you use the rolling release, it should tell you that your `master` branch is up to date with `origin`.
 
 6. Delete the file that triggers the install wizard
 ```
 rm data/do-install.txt
 ```
 
-7. Update to the new version of FreshRSS
-```
-git pull
-```
-
-8. Re-set correct permissions so that your web server can access the files
+7. Re-set correct permissions so that your web server can access the files
 ```
 chown -R :www-data . && chmod -R g+r . && chmod -R g+w ./data/
 ```
 
-### Switching Branches
-
-Any command listed here should be run between steps 3 and 4 in the previous section.
-
-To switch from stable to dev (if you haven't before) use the following command: `git checkout -b dev origin/dev`
-
-If you've checked out dev and want to go back to master, the command would be `git checkout master`. After the first time you check out the dev branch, you can use this syntax to switch between the two main branches at will.
-
-If you wish to switch to [a specific release of FreshRSS](https://github.com/FreshRSS/FreshRSS/releases), you would use the command `git checkout <release_name>`, where <release_name> is the specific release number you wish to check out (for example, `git checkout 1.12.0`). Be aware that checking out a specific release will leave you in a state where you can't automatically update; you'll need to run `git checkout master` or `git checkout dev` before you'll be able to pull updates from git automatically.
-
-## Using the zip Archive
+## Using the Zip archive
 
 If your local user doesn't have write access to the FreshRSS folder, use a sudo shell (`sudo -s`), prefix the following commands with `sudo `, or switch to an account that does have write access to the folder.
 
@@ -73,15 +63,17 @@ If your local user doesn't have write access to the FreshRSS folder, use a sudo 
 cd /usr/share/FreshRSS/
 ```
 
-2. Download and unzip the update file
+2. Get the link to the Zip archive for [the latest release](https://github.com/FreshRSS/FreshRSS/releases/latest). It should be something like `https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip` (the numbers can change). If you want to use the rolling release, the link is `https://github.com/FreshRSS/FreshRSS/archive/master.zip`
+
+3. Download and unzip the update file
 ```
-wget https://github.com/FreshRSS/FreshRSS/archive/master.zip
-unzip master.zip
+wget -o freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip
+unzip freshrss.zip
 ```
 
 3. Overwrite all your existing files with the new ones
 ```
-cp -R FreshRSS-master/* .
+cp -R FreshRSS-*/* .
 ```
 
 4. Re-set permissions
@@ -91,7 +83,7 @@ chown -R :www-data . && chmod -R g+r . && chmod -R g+w ./data/
 
 5. Clean up the FreshRSS directory by deleting the downloaded zip, the file forcing the setup wizard and the temporary directory
 ```
-rm -f master.zip
+rm -f freshrss.zip
 rm -f data/do-install.txt
-rm -rf FreshRSS-master/
+rm -rf FreshRSS-*/
 ```

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -32,7 +32,7 @@ Would you like to fix a bug? For optimum coordination between collaborators, you
 1. Be sure the bug is associated with a ticket and indicate that you'll work on it.
 2. [Fork the project repository](https://help.github.com/articles/fork-a-repo/).
 3. [Create a new branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/). The name of the branch should be clear, and ideally prefixed by the related ticket id. For instance, `783-contributing-file` to fix [ticket #783](https://github.com/FreshRSS/FreshRSS/issues/783).
-4. Make your changes to your fork and [send a pull request](https://help.github.com/articles/using-pull-requests/) on the **dev branch**.
+4. Make your changes to your fork and [send a pull request](https://help.github.com/articles/using-pull-requests/).
 
 If you have to write code, please follow [our coding style recommendations](developers/01_First_steps.md).
 

--- a/docs/en/developers/01_First_steps.md
+++ b/docs/en/developers/01_First_steps.md
@@ -37,10 +37,10 @@ $ make stop
 
 If you're interested in the configuration, the `make` commands are defined in the [`Makefile`](/Makefile).
 
-If you need to use a different tag image (default is `dev-alpine`), you can set the `TAG` environment variable:
+If you need to use a different tag image (default is `alpine`), you can set the `TAG` environment variable:
 
 ```console
-$ TAG=dev-arm make start
+$ TAG=arm make start
 ```
 
 You can find the full list of available tags [on the Docker hub](https://hub.docker.com/r/freshrss/freshrss/tags).
@@ -50,10 +50,10 @@ If you want to build the Docker image yourself, you can use the following comman
 ```console
 $ make build
 $ # or
-$ TAG=dev-arm make build
+$ TAG=arm make build
 ```
 
-The `TAG` variable can be anything (e.g. `dev-local`). You can target a specific architecture by adding `-alpine` or `-arm` at the end of the tag (e.g. `dev-local-arm`).
+The `TAG` variable can be anything (e.g. `local`). You can target a specific architecture by adding `-alpine` or `-arm` at the end of the tag (e.g. `local-arm`).
 
 # Project architecture
 

--- a/docs/en/developers/02_Github.md
+++ b/docs/en/developers/02_Github.md
@@ -88,8 +88,8 @@ git remote -v show
 
 Now you can pull the latest development code:
 ```bash
-git checkout dev
-git pull upstream dev
+git checkout master
+git pull upstream master
 ```
 
 ## Starting a new development branch
@@ -110,7 +110,7 @@ git show
 git push
 ```
 
-Now you can create a PR based on your branch. Please make sure to file it against the `dev` branch!
+Now you can create a PR based on your branch.
 
 ## How to write a commit message
 

--- a/docs/en/developers/05_Release_new_version.md
+++ b/docs/en/developers/05_Release_new_version.md
@@ -8,14 +8,13 @@ It's also recommended to make the announcement on mailing@freshrss.org.
 
 Before releasing a new version of FreshRSS, you must ensure that the code is stable and free of major bugs. Ideally, our tests should be automated and executed before any publication.
 
-You must also **make sure that the CHANGELOG file is up to date** in the dev branch with the updates of the version(s) to be released.
+You must also **make sure that the CHANGELOG file is up to date** with the updates of the version to be released.
 
 # Git process
 
 ```bash
 $ git checkout master
 $ git pull
-$ git merge --ff dev
 $ vim constants.php
 # Update version number x.y.y.z of FRESHRSS_VERSION
 $ git commit -a
@@ -33,7 +32,7 @@ The repository managing the code is located on GitHub: [FreshRSS/update.freshrss
 
 ## Writing the update script
 
-The scripts are located in the `./scripts/` directory and must take the form `update_to_x.y.z.z.php`. This directory  also contains `update_to_dev.php` intended for updates of the dev branch (this script must not include code specific to a particular version!) and `update_util.php`, which contains a list of functions useful for all scripts.
+The scripts are located in the `./scripts/` directory and must take the form `update_to_x.y.z.z.php`. This directory  also contains `update_to_dev.php` intended for updates of the `master` branch (this script must not include code specific to a particular version!) and `update_util.php`, which contains a list of functions useful for all scripts.
 
 In order to write a new script, it's better to copy/paste the last version or to start from `update_to_dev.php`. The first thing to do is to define the URL from which the FreshRSS package will be downloaded (`PACKAGE_URL`). The URL is in the form  of `https://codeload.github.com/FreshRSS/FreshRSS/zip/x.y.z`.
 
@@ -68,7 +67,7 @@ return array(
 And here's how this table works:
 
 * on the left you can find the N version, on the right the N+1 version;
-* the `x.y.z.z-dev` versions are **all** updated to `dev`;
+* the `x.y.z.z-dev` versions are **all** updated to `master`;
 * stable versions are updated to stable versions;
 * it's possible to skip several versions at once, provided that the update scripts support it;
 * it's advisable to indicate the correspondence of the current version to its potential future version by specifying that this version does not yet exist. As long as the corresponding script does not exist, nothing will happen.
@@ -100,7 +99,7 @@ When everything's working, it's time to announce the release to the world!
 # Starting the next development version
 
 ```bash
-$ git checkout dev
+$ git checkout master
 $ vim constants.php
 # Update the FRESHRSS_VERSION
 $ vim CHANGELOG.md

--- a/docs/fr/contributing.md
+++ b/docs/fr/contributing.md
@@ -55,9 +55,8 @@ les collaborateurs, vous devrez suivre ces indications :
    l'identifiant du ticket correspondant. Par exemple,
    `783-contributing-file` pour réparer [ticket
    #783](https://github.com/FreshRSS/FreshRSS/issues/783).
-4. Apportez vos modifications à votre fork et [envoyez une demande de
-   pull](https://help.github.com/articles/using-pull-requests/) sur la
-   branche **dev**.
+4. Ajoutez vos modifications à votre fork et [ouvrez une demande de pull
+   request](https://help.github.com/articles/using-pull-requests/).
 
 Si vous devez écrire du code, veuillez suivre [nos recommandations de style
 de codage](developers/01_First_steps.md).

--- a/docs/fr/developers/01_First_steps.md
+++ b/docs/fr/developers/01_First_steps.md
@@ -59,12 +59,12 @@ Si la configuration vous intéresse, les commandes `make' sont définies dans
 le fichier [`Makefile`](/Makefile).
 
 Si vous avez besoin d'utiliser une image Docker identifiée par un tag
-différent (par défaut `dev-alpine`), vous pouvez surcharger de la manière
+différent (par défaut `alpine`), vous pouvez surcharger de la manière
 suivante la variable d'environnement `TAG` au moment de l'exécution de la
 commande :
 
 ```console
-$ TAG=dev-arm make start
+$ TAG=arm make start
 ```
 
 Vous pouvez trouver la liste complète des tags disponibles [sur le hub
@@ -76,12 +76,12 @@ suivante :
 ```console
 $ make build
 $ # ou
-$ TAG=dev-arm make build
+$ TAG=arm make build
 ```
 
 La valeur de la variable `TAG` peut contenir n'importe quelle valeur (par
-exemple `dev-local`). Vous pouvez cibler une architecture spécifique en
-ajoutant `-alpine` ou `-arm` à la fin du tag (par exemple `dev-local-arm`).
+exemple `local`). Vous pouvez cibler une architecture spécifique en ajoutant
+`-alpine` ou `-arm` à la fin du tag (par exemple `local-arm`).
 
 # Architecture du projet
 

--- a/docs/fr/developers/02_Github.md
+++ b/docs/fr/developers/02_Github.md
@@ -130,8 +130,8 @@ git remote -v show
 
 Vous pouvez maintenant pull le dernier code de développement :
 ```bash
-git checkout dev
-git pull upstream dev
+git checkout master
+git pull upstream master
 ```
 
 ## Lancer une nouvelle branche de développement
@@ -152,8 +152,7 @@ git show
 git push
 ```
 
-Vous pouvez maintenant créer un PR en fonction de votre branche. S'il vous
-plaît, assurez-vous de le soumettre contre la branche `dev` !
+Vous pouvez maintenant créer une PR en fonction de votre branche.
 
 ## Comment écrire un message de commit
 

--- a/docs/fr/developers/05_Release_new_version.md
+++ b/docs/fr/developers/05_Release_new_version.md
@@ -14,15 +14,14 @@ le code est stable et ne présente pas de bugs majeurs. Idéalement, il
 faudrait que nos tests soient automatisés et exécutés avant toute
 publication.
 
-Il faut aussi **vous assurer que le fichier CHANGELOG est à jour** dans la
-branche de dev avec les mises à jour de la ou les version(s) à sortir.
+Il faut aussi **vous assurer que le fichier CHANGELOG est à jour** avec les
+mises à jour de la version à sortir.
 
 # Processus Git
 
 ```bash
 $ git checkout master
 $ git pull
-$ git merge --ff dev
 $ vim constants.php
 # Mettre à jour le numéro de version x.y.z de FRESHRSS_VERSION
 $ git commit -a
@@ -44,9 +43,9 @@ Le dépot gérant le code se trouve sur GitHub :
 
 Les scripts se trouvent dans le répertoire `./scripts/` et doivent être de
 la forme `update_to_x.y.z.php`. On trouve aussi dans ce répertoire
-`update_to_dev.php` destiné aux mises à jour de la branche de dev (ce script
-ne doit pas inclure de code spécifique à une version particulière !) et
-`update_util.php` contenant une liste de fonctions utiles à tous les
+`update_to_dev.php` destiné aux mises à jour de la branche `master` (ce
+script ne doit pas inclure de code spécifique à une version particulière !)
+et `update_util.php` contenant une liste de fonctions utiles à tous les
 scripts.
 
 Afin d'écrire un nouveau script, il est préférable de copier / coller celui
@@ -99,7 +98,7 @@ return array(
 Et voici comment fonctionne cette table :
 
 * à gauche se trouve la version N, à droite la version N+1 ;
-* les versions `x.y.z-dev` sont **toutes** mises à jour vers `dev` ;
+* les versions `x.y.z-dev` sont **toutes** mises à jour vers `master` ;
 * les versions stables sont mises à jour vers des versions stables ;
 * il est possible de sauter plusieurs versions d'un coup à condition que les
   scripts de mise à jour le prennent en charge ;
@@ -145,7 +144,7 @@ Lorsque tout fonctionne, il est temps d'annoncer la sortie au monde entier !
 # Lancer la prochaine version de développement
 
 ```bash
-$ git checkout dev
+$ git checkout master
 $ vim constants.php
 # Mettre à jour le numéro de version de FRESHRSS_VERSION
 $ vim CHANGELOG.md

--- a/docs/i18n/freshrss.fr.po
+++ b/docs/i18n/freshrss.fr.po
@@ -4,20 +4,22 @@
 #
 # Automatically generated, 2019.
 # Frans de Jonge <fransdejonge@gmail.com>, 2019.
+# Marien Fressinaud <dev@marienfressinaud.fr>, 2019.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: FreshRSS\n"
 "Report-Msgid-Bugs-To: https://github.com/FreshRSS/FreshRSS/issues\n"
-"POT-Creation-Date: 2019-11-15 10:34+0100\n"
-"PO-Revision-Date: 2019-11-15 10:34+0100\n"
-"Last-Translator: Frans de Jonge <fransdejonge@gmail.com>\n"
-"Language-Team: English <kde-i18n-doc@kde.org>\n"
+"POT-Creation-Date: 2019-12-07 10:49+0100\n"
+"PO-Revision-Date: 2019-12-07 10:50+0100\n"
+"Last-Translator: Marien Fressinaud <dev@marienfressinaud.fr>\n"
+"Language-Team: French <>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Lokalize 2.0\n"
+"X-Generator: Gtranslator 3.34.0\n"
 
 #. type: Title ##
 #: en/./contributing.md:1
@@ -208,11 +210,10 @@ msgstr ""
 #: en/./contributing.md:36
 msgid ""
 "Make your changes to your fork and [send a pull request](https://help.github."
-"com/articles/using-pull-requests/) on the **dev branch**."
+"com/articles/using-pull-requests/)."
 msgstr ""
-"Apportez vos modifications à votre fork et [envoyez une demande de pull]"
-"(https://help.github.com/articles/using-pull-requests/) sur la branche "
-"**dev**."
+"Ajoutez vos modifications à votre fork et [ouvrez une demande de pull "
+"request](https://help.github.com/articles/using-pull-requests/)."
 
 #. type: Plain text
 #: en/./contributing.md:38
@@ -455,19 +456,19 @@ msgstr ""
 #. type: Plain text
 #: en/./developers/01_First_steps.md:41
 msgid ""
-"If you need to use a different tag image (default is `dev-alpine`), you can "
-"set the `TAG` environment variable:"
+"If you need to use a different tag image (default is `alpine`), you can set "
+"the `TAG` environment variable:"
 msgstr ""
 "Si vous avez besoin d'utiliser une image Docker identifiée par un tag "
-"différent (par défaut `dev-alpine`), vous pouvez surcharger de la manière "
+"différent (par défaut `alpine`), vous pouvez surcharger de la manière "
 "suivante la variable d'environnement `TAG` au moment de l'exécution de la "
 "commande :"
 
 #. type: Plain text
 #: en/./developers/01_First_steps.md:42
 #, no-wrap
-msgid "$ TAG=dev-arm make start\n"
-msgstr "$ TAG=dev-arm make start\n"
+msgid "$ TAG=arm make start\n"
+msgstr "$ TAG=arm make start\n"
 
 #. type: Plain text
 #: en/./developers/01_First_steps.md:47
@@ -493,22 +494,22 @@ msgstr ""
 msgid ""
 "$ make build\n"
 "$ # or\n"
-"$ TAG=dev-arm make build\n"
+"$ TAG=arm make build\n"
 msgstr ""
 "$ make build\n"
 "$ # ou\n"
-"$ TAG=dev-arm make build\n"
+"$ TAG=arm make build\n"
 
 #. type: Plain text
 #: en/./developers/01_First_steps.md:57
 msgid ""
-"The `TAG` variable can be anything (e.g. `dev-local`). You can target a "
-"specific architecture by adding `-alpine` or `-arm` at the end of the tag (e."
-"g. `dev-local-arm`)."
+"The `TAG` variable can be anything (e.g. `local`). You can target a specific "
+"architecture by adding `-alpine` or `-arm` at the end of the tag (e.g. "
+"`local-arm`)."
 msgstr ""
 "La valeur de la variable `TAG` peut contenir n'importe quelle valeur (par "
-"exemple `dev-local`). Vous pouvez cibler une architecture spécifique en "
-"ajoutant `-alpine` ou `-arm` à la fin du tag (par exemple `dev-local-arm`)."
+"exemple `local`). Vous pouvez cibler une architecture spécifique en ajoutant "
+"`-alpine` ou `-arm` à la fin du tag (par exemple `local-arm`)."
 
 #. type: Title #
 #: en/./developers/01_First_steps.md:58
@@ -634,7 +635,7 @@ msgstr ""
 #: en/./developers/03_Backend/05_Extensions.md:166
 #: en/./developers/03_Backend/05_Extensions.md:188
 #: en/./developers/03_Backend/05_Extensions.md:225
-#: en/./developers/05_Release_new_version.md:54 en/./users/06_Fever_API.md:107
+#: en/./developers/05_Release_new_version.md:53 en/./users/06_Fever_API.md:107
 #, no-wrap
 msgid "php"
 msgstr "php"
@@ -679,7 +680,7 @@ msgstr ""
 #: en/./developers/02_Github.md:85 en/./developers/02_Github.md:90
 #: en/./developers/02_Github.md:96 en/./developers/02_Github.md:102
 #: en/./developers/05_Release_new_version.md:15
-#: en/./developers/05_Release_new_version.md:102
+#: en/./developers/05_Release_new_version.md:101
 #, no-wrap
 msgid "bash"
 msgstr "bash"
@@ -1472,11 +1473,11 @@ msgstr "Vous pouvez maintenant pull le dernier code de développement :"
 #: en/./developers/02_Github.md:90
 #, no-wrap
 msgid ""
-"git checkout dev\n"
-"git pull upstream dev\n"
+"git checkout master\n"
+"git pull upstream master\n"
 msgstr ""
-"git checkout dev\n"
-"git pull upstream dev\n"
+"git checkout master\n"
+"git pull upstream master\n"
 
 #. type: Title ##
 #: en/./developers/02_Github.md:95
@@ -1520,12 +1521,8 @@ msgstr ""
 
 #. type: Plain text
 #: en/./developers/02_Github.md:114
-msgid ""
-"Now you can create a PR based on your branch. Please make sure to file it "
-"against the `dev` branch!"
-msgstr ""
-"Vous pouvez maintenant créer un PR en fonction de votre branche. S'il vous "
-"plaît, assurez-vous de le soumettre contre la branche `dev` !"
+msgid "Now you can create a PR based on your branch."
+msgstr "Vous pouvez maintenant créer une PR en fonction de votre branche."
 
 #. type: Title ##
 #: en/./developers/02_Github.md:115
@@ -3068,11 +3065,11 @@ msgstr ""
 #. type: Plain text
 #: en/./developers/05_Release_new_version.md:12
 msgid ""
-"You must also **make sure that the CHANGELOG file is up to date** in the dev "
-"branch with the updates of the version(s) to be released."
+"You must also **make sure that the CHANGELOG file is up to date** with the "
+"updates of the version to be released."
 msgstr ""
-"Il faut aussi **vous assurer que le fichier CHANGELOG est à jour** dans la "
-"branche de dev avec les mises à jour de la ou les version(s) à sortir."
+"Il faut aussi **vous assurer que le fichier CHANGELOG est à jour** avec les "
+"mises à jour de la version à sortir."
 
 #. type: Title #
 #: en/./developers/05_Release_new_version.md:13
@@ -3086,7 +3083,6 @@ msgstr "Processus Git"
 msgid ""
 "$ git checkout master\n"
 "$ git pull\n"
-"$ git merge --ff dev\n"
 "$ vim constants.php\n"
 "# Update version number x.y.y.z of FRESHRSS_VERSION\n"
 "$ git commit -a\n"
@@ -3097,7 +3093,6 @@ msgid ""
 msgstr ""
 "$ git checkout master\n"
 "$ git pull\n"
-"$ git merge --ff dev\n"
 "$ vim constants.php\n"
 "# Mettre à jour le numéro de version x.y.z de FRESHRSS_VERSION\n"
 "$ git commit -a\n"
@@ -3107,13 +3102,13 @@ msgstr ""
 "$ git push && git push --tags\n"
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:28
+#: en/./developers/05_Release_new_version.md:27
 #, no-wrap
 msgid "Updating `update.freshrss.org`"
 msgstr "Mise à jour de update.freshrss.org"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:31
+#: en/./developers/05_Release_new_version.md:30
 msgid ""
 "It's important to update update.freshrss.org since this is the default "
 "service for automatic FreshRSS updates."
@@ -3122,7 +3117,7 @@ msgstr ""
 "service par défaut gérant les mises à jour automatiques de FreshRSS."
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:33
+#: en/./developers/05_Release_new_version.md:32
 msgid ""
 "The repository managing the code is located on GitHub: [FreshRSS/update."
 "freshrss.org] (https://github.com/FreshRSS/update.freshrss.org/)."
@@ -3131,28 +3126,29 @@ msgstr ""
 "(https://github.com/FreshRSS/update.freshrss.org/)."
 
 #. type: Title ##
-#: en/./developers/05_Release_new_version.md:34
+#: en/./developers/05_Release_new_version.md:33
 #, no-wrap
 msgid "Writing the update script"
 msgstr "Écriture du script de mise à jour"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:37
+#: en/./developers/05_Release_new_version.md:36
 msgid ""
 "The scripts are located in the `./scripts/` directory and must take the form "
 "`update_to_x.y.z.z.php`. This directory also contains `update_to_dev.php` "
-"intended for updates of the dev branch (this script must not include code "
-"specific to a particular version!) and `update_util.php`, which contains a "
-"list of functions useful for all scripts."
+"intended for updates of the `master` branch (this script must not include "
+"code specific to a particular version!) and `update_util.php`, which "
+"contains a list of functions useful for all scripts."
 msgstr ""
 "Les scripts se trouvent dans le répertoire `./scripts/` et doivent être de "
 "la forme `update_to_x.y.z.php`. On trouve aussi dans ce répertoire "
-"`update_to_dev.php` destiné aux mises à jour de la branche de dev (ce script "
-"ne doit pas inclure de code spécifique à une version particulière !) et "
-"`update_util.php` contenant une liste de fonctions utiles à tous les scripts."
+"`update_to_dev.php` destiné aux mises à jour de la branche `master` (ce "
+"script ne doit pas inclure de code spécifique à une version particulière !) "
+"et `update_util.php` contenant une liste de fonctions utiles à tous les "
+"scripts."
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:39
+#: en/./developers/05_Release_new_version.md:38
 msgid ""
 "In order to write a new script, it's better to copy/paste the last version "
 "or to start from `update_to_dev.php`. The first thing to do is to define the "
@@ -3167,12 +3163,12 @@ msgstr ""
 "github.com/FreshRSS/FreshRSS/zip/x.y.z`."
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:41
+#: en/./developers/05_Release_new_version.md:40
 msgid "There are then 5 functions that have to be executed:"
 msgstr "Il existe ensuite 5 fonctions à remplir :"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`apply_update()` takes care of saving the directory containing the data, "
 "checking its structure, downloading the FreshRSS package, deploying it and "
@@ -3188,7 +3184,7 @@ msgstr ""
 "ou une chaîne de caractères indiquant un soucis ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`need_info_update()` returns `true` if the user must intervene during the "
 "update or `false` if not;"
@@ -3197,7 +3193,7 @@ msgstr ""
 "la mise à jour ou `false` sinon ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`ask_info_update()` displays a form to the user if `need_info_update()` has "
 "returned `true`;"
@@ -3206,7 +3202,7 @@ msgstr ""
 "`need_info_update()` a retourné `true` ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`save_info_update()` is responsible for saving the information filled out by "
 "the user (from the `ask_info_update()` form);"
@@ -3215,7 +3211,7 @@ msgstr ""
 "par l'utilisateur (issues du formulaire de `ask_info_update()`) ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`do_post_update()` is executed at the end of the update and takes into "
 "account the code of the new version (e.g., if the new version changes the "
@@ -3226,13 +3222,13 @@ msgstr ""
 "l'objet `Minz_Configuration`, vous bénéficierez de ces améliorations)."
 
 #. type: Title ##
-#: en/./developers/05_Release_new_version.md:48
+#: en/./developers/05_Release_new_version.md:47
 #, no-wrap
 msgid "Updating the versions file"
 msgstr "Mise à jour du fichier de versions"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:51
+#: en/./developers/05_Release_new_version.md:50
 msgid ""
 "Once the script has been written and versioned, it's necessary to update the "
 "`./versions.php' file which contains a mapping table indicating which "
@@ -3243,12 +3239,12 @@ msgstr ""
 "indiquant quelles versions sont mises à jour vers quelles autres versions."
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:53
+#: en/./developers/05_Release_new_version.md:52
 msgid "Here's an example of a `versions.php` file:"
 msgstr "Voici un exemple de fichier `versions.php` :"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:54
+#: en/./developers/05_Release_new_version.md:53
 #, no-wrap
 msgid ""
 "<?php\n"
@@ -3276,27 +3272,27 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:69
+#: en/./developers/05_Release_new_version.md:68
 msgid "And here's how this table works:"
 msgstr "Et voici comment fonctionne cette table :"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid "on the left you can find the N version, on the right the N+1 version;"
 msgstr "à gauche se trouve la version N, à droite la version N+1 ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
-msgid "the `x.y.z.z-dev` versions are **all** updated to `dev`;"
-msgstr "les versions `x.y.z-dev` sont **toutes** mises à jour vers `dev` ;"
+#: en/./developers/05_Release_new_version.md:74
+msgid "the `x.y.z.z-dev` versions are **all** updated to `master`;"
+msgstr "les versions `x.y.z-dev` sont **toutes** mises à jour vers `master` ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid "stable versions are updated to stable versions;"
 msgstr "les versions stables sont mises à jour vers des versions stables ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid ""
 "it's possible to skip several versions at once, provided that the update "
 "scripts support it;"
@@ -3305,7 +3301,7 @@ msgstr ""
 "scripts de mise à jour le prennent en charge ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid ""
 "it's advisable to indicate the correspondence of the current version to its "
 "potential future version by specifying that this version does not yet exist. "
@@ -3316,7 +3312,7 @@ msgstr ""
 "encore. Tant que le script correspondant n'existera pas, rien ne se passera."
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:77
+#: en/./developers/05_Release_new_version.md:76
 msgid ""
 "It's **very strongly** recommended to keep this file organized according to "
 "version numbers by separating stable and dev versions."
@@ -3325,13 +3321,13 @@ msgstr ""
 "numéros de versions en séparant les versions stables et de dev."
 
 #. type: Title ##
-#: en/./developers/05_Release_new_version.md:78
+#: en/./developers/05_Release_new_version.md:77
 #, no-wrap
 msgid "Deployment"
 msgstr "Déploiement"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:81
+#: en/./developers/05_Release_new_version.md:80
 msgid ""
 "Before updating update.freshrss.org, it's better to test with dev.update."
 "freshrss.org, which corresponds to pre-production. So update dev.update."
@@ -3345,7 +3341,7 @@ msgstr ""
 "déroule correctement."
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:83
+#: en/./developers/05_Release_new_version.md:82
 msgid ""
 "When you're satisfied, update update.freshrss.org with the new script, test "
 "it again, and then move on."
@@ -3354,43 +3350,43 @@ msgstr ""
 "nouveau script et en testant de nouveau puis passez à la suite."
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:84
+#: en/./developers/05_Release_new_version.md:83
 #, no-wrap
 msgid "Updating the FreshRSS services"
 msgstr "Mise à jour des services FreshRSS"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:87
+#: en/./developers/05_Release_new_version.md:86
 msgid "Two services need to be updated immediately after the update."
 msgstr ""
 "Deux services sont à mettre à jour immédiatement après la mise à jour de "
 "update.freshrss.org :"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:90
+#: en/./developers/05_Release_new_version.md:89
 msgid "rss.freshrss.org;"
 msgstr "rss.freshrss.org ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:90
+#: en/./developers/05_Release_new_version.md:89
 msgid "demo.freshrss.org (public login: `demo` / `demodemo`)."
 msgstr "demo.freshrss.org (identifiants publics : `demo` / `demodemo`)."
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:91
+#: en/./developers/05_Release_new_version.md:90
 #, no-wrap
 msgid "Publicly announce the release"
 msgstr "Annoncer publiquement la sortie"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:94
+#: en/./developers/05_Release_new_version.md:93
 msgid ""
 "When everything's working, it's time to announce the release to the world!"
 msgstr ""
 "Lorsque tout fonctionne, il est temps d'annoncer la sortie au monde entier !"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid ""
 "on GitHub by creating[a new release](https://github.com/FreshRSS/FreshRSS/"
 "releases/new)"
@@ -3399,7 +3395,7 @@ msgstr ""
 "FreshRSS/releases/new) ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid ""
 "on the freshrss.org blog, at least for stable versions (write the article "
 "on[FreshRSS/freshrss.org](https://github.com/FreshRSS/freshrss.org))"
@@ -3409,33 +3405,33 @@ msgstr ""
 "org))."
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid "on Twitter ([@FreshRSS](https://twitter.com/FreshRSS) account)"
 msgstr "sur Twitter (compte [@FreshRSS](https://twitter.com/FreshRSS)) ;"
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid "and on mailing@freshrss.org"
 msgstr "et sur mailing@freshrss.org ;"
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:100
+#: en/./developers/05_Release_new_version.md:99
 #, no-wrap
 msgid "Starting the next development version"
 msgstr "Lancer la prochaine version de développement"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:102
+#: en/./developers/05_Release_new_version.md:101
 #, no-wrap
 msgid ""
-"$ git checkout dev\n"
+"$ git checkout master\n"
 "$ vim constants.php\n"
 "# Update the FRESHRSS_VERSION\n"
 "$ vim CHANGELOG.md\n"
 "# Prepare the changelog for the next version\n"
 "$ git add CHANGELOG.md && git commit && git push\n"
 msgstr ""
-"$ git checkout dev\n"
+"$ git checkout master\n"
 "$ vim constants.php\n"
 "# Mettre à jour le numéro de version de FRESHRSS_VERSION\n"
 "$ vim CHANGELOG.md\n"
@@ -3443,7 +3439,7 @@ msgstr ""
 "$ git add CHANGELOG.md && git commit && git push\n"
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:111
+#: en/./developers/05_Release_new_version.md:110
 msgid ""
 "Also remember to update update.freshrss.org so that it takes the current "
 "development version into account."

--- a/docs/i18n/templates/freshrss.pot
+++ b/docs/i18n/templates/freshrss.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/FreshRSS/FreshRSS/issues\n"
-"POT-Creation-Date: 2019-11-15 10:34+0100\n"
+"POT-Creation-Date: 2019-12-07 10:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -167,8 +167,7 @@ msgstr ""
 #: en/./contributing.md:36
 msgid ""
 "Make your changes to your fork and [send a pull "
-"request](https://help.github.com/articles/using-pull-requests/) on the **dev "
-"branch**."
+"request](https://help.github.com/articles/using-pull-requests/)."
 msgstr ""
 
 #. type: Plain text
@@ -374,14 +373,14 @@ msgstr ""
 #. type: Plain text
 #: en/./developers/01_First_steps.md:41
 msgid ""
-"If you need to use a different tag image (default is `dev-alpine`), you can "
-"set the `TAG` environment variable:"
+"If you need to use a different tag image (default is `alpine`), you can set "
+"the `TAG` environment variable:"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/01_First_steps.md:42
 #, no-wrap
-msgid "$ TAG=dev-arm make start\n"
+msgid "$ TAG=arm make start\n"
 msgstr ""
 
 #. type: Plain text
@@ -404,15 +403,15 @@ msgstr ""
 msgid ""
 "$ make build\n"
 "$ # or\n"
-"$ TAG=dev-arm make build\n"
+"$ TAG=arm make build\n"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/01_First_steps.md:57
 msgid ""
-"The `TAG` variable can be anything (e.g. `dev-local`). You can target a "
-"specific architecture by adding `-alpine` or `-arm` at the end of the tag "
-"(e.g. `dev-local-arm`)."
+"The `TAG` variable can be anything (e.g. `local`). You can target a specific "
+"architecture by adding `-alpine` or `-arm` at the end of the tag "
+"(e.g. `local-arm`)."
 msgstr ""
 
 #. type: Title #
@@ -492,7 +491,7 @@ msgid ""
 msgstr ""
 
 #. type: Code fence info string
-#: en/./developers/01_First_steps.md:81 en/./developers/01_First_steps.md:111 en/./developers/01_First_steps.md:123 en/./developers/01_First_steps.md:158 en/./developers/01_First_steps.md:173 en/./developers/01_First_steps.md:186 en/./developers/01_First_steps.md:196 en/./developers/01_First_steps.md:213 en/./developers/01_First_steps.md:228 en/./developers/03_Backend/05_Extensions.md:47 en/./developers/03_Backend/05_Extensions.md:88 en/./developers/03_Backend/05_Extensions.md:130 en/./developers/03_Backend/05_Extensions.md:149 en/./developers/03_Backend/05_Extensions.md:166 en/./developers/03_Backend/05_Extensions.md:188 en/./developers/03_Backend/05_Extensions.md:225 en/./developers/05_Release_new_version.md:54 en/./users/06_Fever_API.md:107
+#: en/./developers/01_First_steps.md:81 en/./developers/01_First_steps.md:111 en/./developers/01_First_steps.md:123 en/./developers/01_First_steps.md:158 en/./developers/01_First_steps.md:173 en/./developers/01_First_steps.md:186 en/./developers/01_First_steps.md:196 en/./developers/01_First_steps.md:213 en/./developers/01_First_steps.md:228 en/./developers/03_Backend/05_Extensions.md:47 en/./developers/03_Backend/05_Extensions.md:88 en/./developers/03_Backend/05_Extensions.md:130 en/./developers/03_Backend/05_Extensions.md:149 en/./developers/03_Backend/05_Extensions.md:166 en/./developers/03_Backend/05_Extensions.md:188 en/./developers/03_Backend/05_Extensions.md:225 en/./developers/05_Release_new_version.md:53 en/./users/06_Fever_API.md:107
 #, no-wrap
 msgid "php"
 msgstr ""
@@ -526,7 +525,7 @@ msgid ""
 msgstr ""
 
 #. type: Code fence info string
-#: en/./developers/01_First_steps.md:92 en/./developers/02_Github.md:80 en/./developers/02_Github.md:85 en/./developers/02_Github.md:90 en/./developers/02_Github.md:96 en/./developers/02_Github.md:102 en/./developers/05_Release_new_version.md:15 en/./developers/05_Release_new_version.md:102
+#: en/./developers/01_First_steps.md:92 en/./developers/02_Github.md:80 en/./developers/02_Github.md:85 en/./developers/02_Github.md:90 en/./developers/02_Github.md:96 en/./developers/02_Github.md:102 en/./developers/05_Release_new_version.md:15 en/./developers/05_Release_new_version.md:101
 #, no-wrap
 msgid "bash"
 msgstr ""
@@ -1171,8 +1170,8 @@ msgstr ""
 #: en/./developers/02_Github.md:90
 #, no-wrap
 msgid ""
-"git checkout dev\n"
-"git pull upstream dev\n"
+"git checkout master\n"
+"git pull upstream master\n"
 msgstr ""
 
 #. type: Title ##
@@ -1209,9 +1208,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/./developers/02_Github.md:114
-msgid ""
-"Now you can create a PR based on your branch. Please make sure to file it "
-"against the `dev` branch!"
+msgid "Now you can create a PR based on your branch."
 msgstr ""
 
 #. type: Title ##
@@ -2458,8 +2455,8 @@ msgstr ""
 #. type: Plain text
 #: en/./developers/05_Release_new_version.md:12
 msgid ""
-"You must also **make sure that the CHANGELOG file is up to date** in the dev "
-"branch with the updates of the version(s) to be released."
+"You must also **make sure that the CHANGELOG file is up to date** with the "
+"updates of the version to be released."
 msgstr ""
 
 #. type: Title #
@@ -2474,7 +2471,6 @@ msgstr ""
 msgid ""
 "$ git checkout master\n"
 "$ git pull\n"
-"$ git merge --ff dev\n"
 "$ vim constants.php\n"
 "# Update version number x.y.y.z of FRESHRSS_VERSION\n"
 "$ git commit -a\n"
@@ -2485,20 +2481,20 @@ msgid ""
 msgstr ""
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:28
+#: en/./developers/05_Release_new_version.md:27
 #, no-wrap
 msgid "Updating `update.freshrss.org`"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:31
+#: en/./developers/05_Release_new_version.md:30
 msgid ""
 "It's important to update update.freshrss.org since this is the default "
 "service for automatic FreshRSS updates."
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:33
+#: en/./developers/05_Release_new_version.md:32
 msgid ""
 "The repository managing the code is located on GitHub: "
 "[FreshRSS/update.freshrss.org] "
@@ -2506,23 +2502,23 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: en/./developers/05_Release_new_version.md:34
+#: en/./developers/05_Release_new_version.md:33
 #, no-wrap
 msgid "Writing the update script"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:37
+#: en/./developers/05_Release_new_version.md:36
 msgid ""
 "The scripts are located in the `./scripts/` directory and must take the form "
 "`update_to_x.y.z.z.php`. This directory also contains `update_to_dev.php` "
-"intended for updates of the dev branch (this script must not include code "
-"specific to a particular version!) and `update_util.php`, which contains a "
-"list of functions useful for all scripts."
+"intended for updates of the `master` branch (this script must not include "
+"code specific to a particular version!) and `update_util.php`, which "
+"contains a list of functions useful for all scripts."
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:39
+#: en/./developers/05_Release_new_version.md:38
 msgid ""
 "In order to write a new script, it's better to copy/paste the last version "
 "or to start from `update_to_dev.php`. The first thing to do is to define the "
@@ -2532,12 +2528,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:41
+#: en/./developers/05_Release_new_version.md:40
 msgid "There are then 5 functions that have to be executed:"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`apply_update()` takes care of saving the directory containing the data, "
 "checking its structure, downloading the FreshRSS package, deploying it and "
@@ -2547,28 +2543,28 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`need_info_update()` returns `true` if the user must intervene during the "
 "update or `false` if not;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`ask_info_update()` displays a form to the user if `need_info_update()` has "
 "returned `true`;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`save_info_update()` is responsible for saving the information filled out by "
 "the user (from the `ask_info_update()` form);"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:47
+#: en/./developers/05_Release_new_version.md:46
 msgid ""
 "`do_post_update()` is executed at the end of the update and takes into "
 "account the code of the new version (e.g., if the new version changes the "
@@ -2576,13 +2572,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: en/./developers/05_Release_new_version.md:48
+#: en/./developers/05_Release_new_version.md:47
 #, no-wrap
 msgid "Updating the versions file"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:51
+#: en/./developers/05_Release_new_version.md:50
 msgid ""
 "Once the script has been written and versioned, it's necessary to update the "
 "`./versions.php' file which contains a mapping table indicating which "
@@ -2590,12 +2586,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:53
+#: en/./developers/05_Release_new_version.md:52
 msgid "Here's an example of a `versions.php` file:"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:54
+#: en/./developers/05_Release_new_version.md:53
 #, no-wrap
 msgid ""
 "<?php\n"
@@ -2612,34 +2608,34 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:69
+#: en/./developers/05_Release_new_version.md:68
 msgid "And here's how this table works:"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid "on the left you can find the N version, on the right the N+1 version;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
-msgid "the `x.y.z.z-dev` versions are **all** updated to `dev`;"
+#: en/./developers/05_Release_new_version.md:74
+msgid "the `x.y.z.z-dev` versions are **all** updated to `master`;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid "stable versions are updated to stable versions;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid ""
 "it's possible to skip several versions at once, provided that the update "
 "scripts support it;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:75
+#: en/./developers/05_Release_new_version.md:74
 msgid ""
 "it's advisable to indicate the correspondence of the current version to its "
 "potential future version by specifying that this version does not yet "
@@ -2648,20 +2644,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:77
+#: en/./developers/05_Release_new_version.md:76
 msgid ""
 "It's **very strongly** recommended to keep this file organized according to "
 "version numbers by separating stable and dev versions."
 msgstr ""
 
 #. type: Title ##
-#: en/./developers/05_Release_new_version.md:78
+#: en/./developers/05_Release_new_version.md:77
 #, no-wrap
 msgid "Deployment"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:81
+#: en/./developers/05_Release_new_version.md:80
 msgid ""
 "Before updating update.freshrss.org, it's better to test with "
 "dev.update.freshrss.org, which corresponds to pre-production. So update "
@@ -2670,79 +2666,79 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:83
+#: en/./developers/05_Release_new_version.md:82
 msgid ""
 "When you're satisfied, update update.freshrss.org with the new script, test "
 "it again, and then move on."
 msgstr ""
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:84
+#: en/./developers/05_Release_new_version.md:83
 #, no-wrap
 msgid "Updating the FreshRSS services"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:87
+#: en/./developers/05_Release_new_version.md:86
 msgid "Two services need to be updated immediately after the update."
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:90
+#: en/./developers/05_Release_new_version.md:89
 msgid "rss.freshrss.org;"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:90
+#: en/./developers/05_Release_new_version.md:89
 msgid "demo.freshrss.org (public login: `demo` / `demodemo`)."
 msgstr ""
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:91
+#: en/./developers/05_Release_new_version.md:90
 #, no-wrap
 msgid "Publicly announce the release"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:94
+#: en/./developers/05_Release_new_version.md:93
 msgid "When everything's working, it's time to announce the release to the world!"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid ""
 "on GitHub by creating[a new "
 "release](https://github.com/FreshRSS/FreshRSS/releases/new)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid ""
 "on the freshrss.org blog, at least for stable versions (write the article "
 "on[FreshRSS/freshrss.org](https://github.com/FreshRSS/freshrss.org))"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid "on Twitter ([@FreshRSS](https://twitter.com/FreshRSS) account)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: en/./developers/05_Release_new_version.md:99
+#: en/./developers/05_Release_new_version.md:98
 msgid "and on mailing@freshrss.org"
 msgstr ""
 
 #. type: Title #
-#: en/./developers/05_Release_new_version.md:100
+#: en/./developers/05_Release_new_version.md:99
 #, no-wrap
 msgid "Starting the next development version"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:102
+#: en/./developers/05_Release_new_version.md:101
 #, no-wrap
 msgid ""
-"$ git checkout dev\n"
+"$ git checkout master\n"
 "$ vim constants.php\n"
 "# Update the FRESHRSS_VERSION\n"
 "$ vim CHANGELOG.md\n"
@@ -2751,7 +2747,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/05_Release_new_version.md:111
+#: en/./developers/05_Release_new_version.md:110
 msgid ""
 "Also remember to update update.freshrss.org so that it takes the current "
 "development version into account."


### PR DESCRIPTION
As discussed in #2668, this PR changes the main branch to keep only `master`. It changes mainly the documentation, plus a minor fix in the `Makefile`.

After merging this PR, next steps will be to:

- [ ] change default branch back to master in GitHub settings
- [ ] merge dev in master
- [ ] update PRs to be against master instead of dev
- [ ] drop dev
- [ ] remove dev build rules on Docker hub
- [ ] change the URL of the `update_to_dev` script for the update server 