### PR TITLE
tec: Add ~ID~ placeholder in share system

### DIFF
--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -76,6 +76,7 @@ class FreshRSS_Share {
 	private $help_url = '';
 	private $custom_name = null;
 	private $base_url = null;
+	private $id = null;
 	private $title = null;
 	private $link = null;
 	private $method = 'GET';
@@ -118,12 +119,13 @@ class FreshRSS_Share {
 	/**
 	 * Update a FreshRSS_Share object with information from an array.
 	 * @param $options is a list of informations to update where keys should be
-	 *        in this list: name, url, title, link.
+	 *        in this list: name, url, id, title, link.
 	 */
 	public function update($options) {
 		$available_options = array(
 			'name' => 'custom_name',
 			'url' => 'base_url',
+			'id' => 'id',
 			'title' => 'title',
 			'link' => 'link',
 			'method' => 'method',
@@ -196,16 +198,30 @@ class FreshRSS_Share {
 	 */
 	public function url() {
 		$matches = array(
+			'~ID~',
 			'~URL~',
 			'~TITLE~',
 			'~LINK~',
 		);
 		$replaces = array(
+			$this->id(),
 			$this->base_url,
 			$this->title(),
 			$this->link(),
 		);
 		return str_replace($matches, $replaces, $this->url_transform);
+	}
+
+	/**
+	 * Return the id.
+	 * @param $raw true if we should get the id without transformations.
+	 */
+	public function id($raw = false) {
+		if ($raw) {
+			return $this->id;
+		}
+
+		return $this->transform($this->id, $this->getTransform('id'));
 	}
 
 	/**

--- a/app/shares.php
+++ b/app/shares.php
@@ -8,10 +8,12 @@
  * For each share there is different configuration options. Here is the description
  * of those options:
  *   - url is a mandatory option. It is a string representing the share URL. It
- *     supports 3 different placeholders for custom data. The ~URL~ placeholder
+ *     supports 4 different placeholders for custom data. The ~URL~ placeholder
  *     represents the URL of the system used to share, it is configured by the
  *     user. The ~LINK~ placeholder represents the link of the shared article.
- *     The ~TITLE~ placeholder represents the title of the shared article.
+ *     The ~TITLE~ placeholder represents the title of the shared article. The
+ *     ~ID~ placeholder represents the id of the shared article (only useful
+ *     for internal use)
  *   - transform is an array of transformation to apply on links and titles
  *   - help is a URL to a help page
  *   - form is the type of form to display during configuration. It's either

--- a/app/views/helpers/index/normal/entry_bottom.phtml
+++ b/app/views/helpers/index/normal/entry_bottom.phtml
@@ -78,6 +78,7 @@
 
 			<ul class="dropdown-menu">
 				<li class="dropdown-close"><a href="#close">❌</a></li><?php
+					$id = $this->entry->id();
 					$link = $this->entry->link();
 					$title = $this->entry->title() . ' · ' . $this->feed->name();
 					foreach (FreshRSS_Context::$user_conf->sharing as $share_options) {
@@ -85,6 +86,7 @@
 						if ($share === null) {
 							continue;
 						}
+						$share_options['id'] = $id;
 						$share_options['link'] = $link;
 						$share_options['title'] = $title;
 						$share->update($share_options);


### PR DESCRIPTION
I'm currently playing on a small extension to improve the email sharing
system. It allows to create a message and send an email directly through
FreshRSS. For that, I need to retrieve the shared article. I could use
the link or the title but it would be less robust and less efficient.

Reference: https://github.com/FreshRSS/FreshRSS/issues/300