### PR TITLE
tec: Add a test target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/bin
 constants.local.php
 
 # Temp files

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -5,7 +5,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
 	apache2 php7-apache2 \
 	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
-	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-opcache php7-session php7-simplexml php7-xmlreader php7-zlib \
+	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-opcache php7-phar php7-session php7-simplexml php7-xmlreader php7-zlib \
 	php7-pdo_sqlite php7-pdo_mysql php7-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,24 @@ start: ## Start the development environment (use Docker)
 stop: ## Stop FreshRSS container if any
 	docker stop freshrss-dev
 
+###########
+## Tests ##
+###########
+bin/phpunit: ## Install PHPUnit for test purposes
+	mkdir -p bin/
+	wget -O bin/phpunit https://phar.phpunit.de/phpunit-7.5.9.phar
+	echo '5404288061420c3921e53dd3a756bf044be546c825c5e3556dea4c51aa330f69 bin/phpunit' | sha256sum -c - || rm bin/phpunit
+
+.PHONY: test
+test: ## Run the test suite
+	docker run \
+		--rm \
+		--volume $(shell pwd):/var/www/FreshRSS:z \
+		--env FRESHRSS_ENV=development \
+		--name freshrss-test \
+		freshrss/freshrss:$(TAG) \
+		php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
+
 ##########
 ## I18N ##
 ##########

--- a/docs/en/developers/03_Running_tests.md
+++ b/docs/en/developers/03_Running_tests.md
@@ -4,27 +4,19 @@ FreshRSS is tested with [PHPUnit](https://phpunit.de/). No code should be merged
 
 ## Locally
 
-As a developer, you can run the test suite on your PC easily with `make` commands. First, you should install PHPUnit with:
+As a developer, you can run the test suite on your PC easily with `make` commands. You can run the test suite with:
 
 ```console
-$ make bin/phpunit
+$ make test
 ```
 
-This commands download the binary and verify its checksum. If the verification fails, the file is deleted. In this case, you should [open an issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let maintainers know about the problem.
+This command downloads the PHPUnit binary and verifies its checksum. If the verification fails, the file is deleted. In this case, you should [open an issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let maintainers know about the problem.
 
-Then, you can run the test suite with:
+Then, it executes PHPUnit in a Docker container. If you don't use Docker, you can run the command directly with:
 
 ```console
-$ make tests
+$ NO_DOCKER=true make test
 ```
-
-It executes PHPUnit in a Docker container. If you don't use Docker, you can run the command directly with:
-
-```console
-$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
-```
-
-If the command fails, you can take a look at the Makefile to verify if the command had changed.
 
 ## Travis
 

--- a/docs/en/developers/03_Running_tests.md
+++ b/docs/en/developers/03_Running_tests.md
@@ -1,0 +1,33 @@
+# Running tests
+
+FreshRSS is tested with [PHPUnit](https://phpunit.de/). No code should be merged in `master` if the tests don't pass.
+
+## Locally
+
+As a developer, you can run the test suite on your PC easily with `make` commands. First, you should install PHPUnit with:
+
+```console
+$ make bin/phpunit
+```
+
+This commands download the binary and verify its checksum. If the verification fails, the file is deleted. In this case, you should [open an issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let maintainers know about the problem.
+
+Then, you can run the test suite with:
+
+```console
+$ make tests
+```
+
+It executes PHPUnit in a Docker container. If you don't use Docker, you can run the command directly with:
+
+```console
+$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
+```
+
+If the command fails, you can take a look at the Makefile to verify if the command had changed.
+
+## Travis
+
+Tests are automatically run when you open a pull request on GitHub. It is done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is done to ensure there is no regressions in your code. We cannot merge a PR if the tests fail so we'll ask you to fix bugs before to review your code.
+
+If you're interested in, you can take a look at [the configuration file](https://github.com/FreshRSS/FreshRSS/blob/master/.travis.yml).

--- a/docs/fr/developers/03_Running_tests.md
+++ b/docs/fr/developers/03_Running_tests.md
@@ -1,0 +1,44 @@
+# Running tests
+
+FreshRSS is tested with [PHPUnit](https://phpunit.de/). No code should be
+merged in `master` if the tests don't pass.
+
+## Locally
+
+As a developer, you can run the test suite on your PC easily with `make`
+commands. First, you should install PHPUnit with:
+
+```console
+$ make bin/phpunit
+```
+
+This commands download the binary and verify its checksum. If the
+verification fails, the file is deleted. In this case, you should [open an
+issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let
+maintainers know about the problem.
+
+Then, you can run the test suite with:
+
+```console
+$ make tests
+```
+
+It executes PHPUnit in a Docker container. If you don't use Docker, you can
+run the command directly with:
+
+```console
+$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
+```
+
+If the command fails, you can take a look at the Makefile to verify if the
+command had changed.
+
+## Travis
+
+Tests are automatically run when you open a pull request on GitHub. It is
+done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is
+done to ensure there is no regressions in your code. We cannot merge a PR if
+the tests fail so we'll ask you to fix bugs before to review your code.
+
+If you're interested in, you can take a look at [the configuration
+file](https://github.com/FreshRSS/FreshRSS/blob/master/.travis.yml).

--- a/docs/fr/developers/03_Running_tests.md
+++ b/docs/fr/developers/03_Running_tests.md
@@ -6,32 +6,23 @@ merged in `master` if the tests don't pass.
 ## Locally
 
 As a developer, you can run the test suite on your PC easily with `make`
-commands. First, you should install PHPUnit with:
+commands. You can run the test suite with:
 
 ```console
-$ make bin/phpunit
+$ make test
 ```
 
-This commands download the binary and verify its checksum. If the
+This command downloads the PHPUnit binary and verifies its checksum. If the
 verification fails, the file is deleted. In this case, you should [open an
 issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let
 maintainers know about the problem.
 
-Then, you can run the test suite with:
+Then, it executes PHPUnit in a Docker container. If you don't use Docker,
+you can run the command directly with:
 
 ```console
-$ make tests
+$ NO_DOCKER=true make test
 ```
-
-It executes PHPUnit in a Docker container. If you don't use Docker, you can
-run the command directly with:
-
-```console
-$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
-```
-
-If the command fails, you can take a look at the Makefile to verify if the
-command had changed.
 
 ## Travis
 

--- a/docs/i18n/freshrss.fr.po
+++ b/docs/i18n/freshrss.fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: FreshRSS\n"
 "Report-Msgid-Bugs-To: https://github.com/FreshRSS/FreshRSS/issues\n"
-"POT-Creation-Date: 2019-12-24 16:18+0100\n"
+"POT-Creation-Date: 2019-12-29 11:00+0100\n"
 "PO-Revision-Date: 2019-12-07 10:50+0100\n"
 "Last-Translator: Marien Fressinaud <dev@marienfressinaud.fr>\n"
 "Language-Team: French <>\n"
@@ -380,7 +380,6 @@ msgstr ""
 #: en/./developers/01_First_steps.md:34 en/./developers/01_First_steps.md:42
 #: en/./developers/01_First_steps.md:50 en/./developers/03_Running_tests.md:9
 #: en/./developers/03_Running_tests.md:17
-#: en/./developers/03_Running_tests.md:23
 #, no-wrap
 msgid "console"
 msgstr "console"
@@ -3008,19 +3007,20 @@ msgstr ""
 #: en/./developers/03_Running_tests.md:8
 msgid ""
 "As a developer, you can run the test suite on your PC easily with `make` "
-"commands. First, you should install PHPUnit with:"
+"commands. You can run the test suite with:"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:9
-#, no-wrap
-msgid "$ make bin/phpunit\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "$ make stop\n"
+msgid "$ make test\n"
+msgstr "$ make stop\n"
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:14
 msgid ""
-"This commands download the binary and verify its checksum. If the "
+"This command downloads the PHPUnit binary and verifies its checksum. If the "
 "verification fails, the file is deleted. In this case, you should [open an "
 "issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let "
 "maintainers know about the problem."
@@ -3028,44 +3028,26 @@ msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:16
-msgid "Then, you can run the test suite with:"
+msgid ""
+"Then, it executes PHPUnit in a Docker container. If you don't use Docker, "
+"you can run the command directly with:"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:17
 #, fuzzy, no-wrap
 #| msgid "$ make stop\n"
-msgid "$ make tests\n"
+msgid "$ NO_DOCKER=true make test\n"
 msgstr "$ make stop\n"
 
-#. type: Plain text
-#: en/./developers/03_Running_tests.md:22
-msgid ""
-"It executes PHPUnit in a Docker container. If you don't use Docker, you can "
-"run the command directly with:"
-msgstr ""
-
-#. type: Plain text
-#: en/./developers/03_Running_tests.md:23
-#, no-wrap
-msgid "$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests\n"
-msgstr ""
-
-#. type: Plain text
-#: en/./developers/03_Running_tests.md:28
-msgid ""
-"If the command fails, you can take a look at the Makefile to verify if the "
-"command had changed."
-msgstr ""
-
 #. type: Title ##
-#: en/./developers/03_Running_tests.md:29
+#: en/./developers/03_Running_tests.md:21
 #, no-wrap
 msgid "Travis"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/03_Running_tests.md:32
+#: en/./developers/03_Running_tests.md:24
 msgid ""
 "Tests are automatically run when you open a pull request on GitHub. It is "
 "done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is "
@@ -3074,7 +3056,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/03_Running_tests.md:33
+#: en/./developers/03_Running_tests.md:25
 #, fuzzy
 #| msgid ""
 #| "If your request is new, [open a new bug ticket](https://github.com/"

--- a/docs/i18n/freshrss.fr.po
+++ b/docs/i18n/freshrss.fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: FreshRSS\n"
 "Report-Msgid-Bugs-To: https://github.com/FreshRSS/FreshRSS/issues\n"
-"POT-Creation-Date: 2019-12-07 10:49+0100\n"
+"POT-Creation-Date: 2019-12-24 16:18+0100\n"
 "PO-Revision-Date: 2019-12-07 10:50+0100\n"
 "Last-Translator: Marien Fressinaud <dev@marienfressinaud.fr>\n"
 "Language-Team: French <>\n"
@@ -378,7 +378,9 @@ msgstr ""
 #. type: Code fence info string
 #: en/./developers/01_First_steps.md:15 en/./developers/01_First_steps.md:24
 #: en/./developers/01_First_steps.md:34 en/./developers/01_First_steps.md:42
-#: en/./developers/01_First_steps.md:50
+#: en/./developers/01_First_steps.md:50 en/./developers/03_Running_tests.md:9
+#: en/./developers/03_Running_tests.md:17
+#: en/./developers/03_Running_tests.md:23
 #, no-wrap
 msgid "console"
 msgstr "console"
@@ -2982,6 +2984,107 @@ msgid ""
 "When you want to support user configurations for your extension or simply "
 "display some information, you have to create the `configure.phtml` file."
 msgstr ""
+
+#. type: Title #
+#: en/./developers/03_Running_tests.md:1
+#, no-wrap
+msgid "Running tests"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:4
+msgid ""
+"FreshRSS is tested with [PHPUnit](https://phpunit.de/). No code should be "
+"merged in `master` if the tests don't pass."
+msgstr ""
+
+#. type: Title ##
+#: en/./developers/03_Running_tests.md:5
+#, no-wrap
+msgid "Locally"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:8
+msgid ""
+"As a developer, you can run the test suite on your PC easily with `make` "
+"commands. First, you should install PHPUnit with:"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:9
+#, no-wrap
+msgid "$ make bin/phpunit\n"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:14
+msgid ""
+"This commands download the binary and verify its checksum. If the "
+"verification fails, the file is deleted. In this case, you should [open an "
+"issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let "
+"maintainers know about the problem."
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:16
+msgid "Then, you can run the test suite with:"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:17
+#, fuzzy, no-wrap
+#| msgid "$ make stop\n"
+msgid "$ make tests\n"
+msgstr "$ make stop\n"
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:22
+msgid ""
+"It executes PHPUnit in a Docker container. If you don't use Docker, you can "
+"run the command directly with:"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:23
+#, no-wrap
+msgid "$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests\n"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:28
+msgid ""
+"If the command fails, you can take a look at the Makefile to verify if the "
+"command had changed."
+msgstr ""
+
+#. type: Title ##
+#: en/./developers/03_Running_tests.md:29
+#, no-wrap
+msgid "Travis"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:32
+msgid ""
+"Tests are automatically run when you open a pull request on GitHub. It is "
+"done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is "
+"done to ensure there is no regressions in your code. We cannot merge a PR if "
+"the tests fail so we'll ask you to fix bugs before to review your code."
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:33
+#, fuzzy
+#| msgid ""
+#| "If your request is new, [open a new bug ticket](https://github.com/"
+#| "FreshRSS/FreshRSS/issues/new)"
+msgid ""
+"If you're interested in, you can take a look at [the configuration file]"
+"(https://github.com/FreshRSS/FreshRSS/blob/master/.travis.yml)."
+msgstr ""
+"Si votre demande est nouvelle, [ouvrez un nouveau ticket de bug](https://"
+"github.com/FreshRSS/FreshRSS/issues/new)"
 
 #. type: Title #
 #: en/./developers/04_Frontend/01_View_files.md:1

--- a/docs/i18n/templates/freshrss.pot
+++ b/docs/i18n/templates/freshrss.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/FreshRSS/FreshRSS/issues\n"
-"POT-Creation-Date: 2019-12-07 10:49+0100\n"
+"POT-Creation-Date: 2019-12-24 16:18+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -301,7 +301,7 @@ msgid "Once you're done, clone the repository with:"
 msgstr ""
 
 #. type: Code fence info string
-#: en/./developers/01_First_steps.md:15 en/./developers/01_First_steps.md:24 en/./developers/01_First_steps.md:34 en/./developers/01_First_steps.md:42 en/./developers/01_First_steps.md:50
+#: en/./developers/01_First_steps.md:15 en/./developers/01_First_steps.md:24 en/./developers/01_First_steps.md:34 en/./developers/01_First_steps.md:42 en/./developers/01_First_steps.md:50 en/./developers/03_Running_tests.md:9 en/./developers/03_Running_tests.md:17 en/./developers/03_Running_tests.md:23
 #, no-wrap
 msgid "console"
 msgstr ""
@@ -2379,6 +2379,100 @@ msgstr ""
 msgid ""
 "When you want to support user configurations for your extension or simply "
 "display some information, you have to create the `configure.phtml` file."
+msgstr ""
+
+#. type: Title #
+#: en/./developers/03_Running_tests.md:1
+#, no-wrap
+msgid "Running tests"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:4
+msgid ""
+"FreshRSS is tested with [PHPUnit](https://phpunit.de/). No code should be "
+"merged in `master` if the tests don't pass."
+msgstr ""
+
+#. type: Title ##
+#: en/./developers/03_Running_tests.md:5
+#, no-wrap
+msgid "Locally"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:8
+msgid ""
+"As a developer, you can run the test suite on your PC easily with `make` "
+"commands. First, you should install PHPUnit with:"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:9
+#, no-wrap
+msgid "$ make bin/phpunit\n"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:14
+msgid ""
+"This commands download the binary and verify its checksum. If the "
+"verification fails, the file is deleted. In this case, you should [open an "
+"issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let "
+"maintainers know about the problem."
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:16
+msgid "Then, you can run the test suite with:"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:17
+#, no-wrap
+msgid "$ make tests\n"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:22
+msgid ""
+"It executes PHPUnit in a Docker container. If you don't use Docker, you can "
+"run the command directly with:"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:23
+#, no-wrap
+msgid "$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests\n"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:28
+msgid ""
+"If the command fails, you can take a look at the Makefile to verify if the "
+"command had changed."
+msgstr ""
+
+#. type: Title ##
+#: en/./developers/03_Running_tests.md:29
+#, no-wrap
+msgid "Travis"
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:32
+msgid ""
+"Tests are automatically run when you open a pull request on GitHub. It is "
+"done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is "
+"done to ensure there is no regressions in your code. We cannot merge a PR if "
+"the tests fail so we'll ask you to fix bugs before to review your code."
+msgstr ""
+
+#. type: Plain text
+#: en/./developers/03_Running_tests.md:33
+msgid ""
+"If you're interested in, you can take a look at [the configuration "
+"file](https://github.com/FreshRSS/FreshRSS/blob/master/.travis.yml)."
 msgstr ""
 
 #. type: Title #

--- a/docs/i18n/templates/freshrss.pot
+++ b/docs/i18n/templates/freshrss.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/FreshRSS/FreshRSS/issues\n"
-"POT-Creation-Date: 2019-12-24 16:18+0100\n"
+"POT-Creation-Date: 2019-12-29 11:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -301,7 +301,7 @@ msgid "Once you're done, clone the repository with:"
 msgstr ""
 
 #. type: Code fence info string
-#: en/./developers/01_First_steps.md:15 en/./developers/01_First_steps.md:24 en/./developers/01_First_steps.md:34 en/./developers/01_First_steps.md:42 en/./developers/01_First_steps.md:50 en/./developers/03_Running_tests.md:9 en/./developers/03_Running_tests.md:17 en/./developers/03_Running_tests.md:23
+#: en/./developers/01_First_steps.md:15 en/./developers/01_First_steps.md:24 en/./developers/01_First_steps.md:34 en/./developers/01_First_steps.md:42 en/./developers/01_First_steps.md:50 en/./developers/03_Running_tests.md:9 en/./developers/03_Running_tests.md:17
 #, no-wrap
 msgid "console"
 msgstr ""
@@ -2404,19 +2404,19 @@ msgstr ""
 #: en/./developers/03_Running_tests.md:8
 msgid ""
 "As a developer, you can run the test suite on your PC easily with `make` "
-"commands. First, you should install PHPUnit with:"
+"commands. You can run the test suite with:"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:9
 #, no-wrap
-msgid "$ make bin/phpunit\n"
+msgid "$ make test\n"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:14
 msgid ""
-"This commands download the binary and verify its checksum. If the "
+"This command downloads the PHPUnit binary and verifies its checksum. If the "
 "verification fails, the file is deleted. In this case, you should [open an "
 "issue on GitHub](https://github.com/FreshRSS/FreshRSS/issues/new) to let "
 "maintainers know about the problem."
@@ -2424,43 +2424,25 @@ msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:16
-msgid "Then, you can run the test suite with:"
+msgid ""
+"Then, it executes PHPUnit in a Docker container. If you don't use Docker, "
+"you can run the command directly with:"
 msgstr ""
 
 #. type: Plain text
 #: en/./developers/03_Running_tests.md:17
 #, no-wrap
-msgid "$ make tests\n"
-msgstr ""
-
-#. type: Plain text
-#: en/./developers/03_Running_tests.md:22
-msgid ""
-"It executes PHPUnit in a Docker container. If you don't use Docker, you can "
-"run the command directly with:"
-msgstr ""
-
-#. type: Plain text
-#: en/./developers/03_Running_tests.md:23
-#, no-wrap
-msgid "$ php ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests\n"
-msgstr ""
-
-#. type: Plain text
-#: en/./developers/03_Running_tests.md:28
-msgid ""
-"If the command fails, you can take a look at the Makefile to verify if the "
-"command had changed."
+msgid "$ NO_DOCKER=true make test\n"
 msgstr ""
 
 #. type: Title ##
-#: en/./developers/03_Running_tests.md:29
+#: en/./developers/03_Running_tests.md:21
 #, no-wrap
 msgid "Travis"
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/03_Running_tests.md:32
+#: en/./developers/03_Running_tests.md:24
 msgid ""
 "Tests are automatically run when you open a pull request on GitHub. It is "
 "done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is "
@@ -2469,7 +2451,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/./developers/03_Running_tests.md:33
+#: en/./developers/03_Running_tests.md:25
 msgid ""
 "If you're interested in, you can take a look at [the configuration "
 "file](https://github.com/FreshRSS/FreshRSS/blob/master/.travis.yml)."

--- a/docs/po4a.conf
+++ b/docs/po4a.conf
@@ -10,6 +10,7 @@
 [type: text] en/./developers/03_Backend/03_External_libraries.md $lang:$lang/./developers/03_Backend/03_External_libraries.md opt:"-o markdown" opt:"-M utf-8"
 [type: text] en/./developers/03_Backend/04_Changing_source_code.md $lang:$lang/./developers/03_Backend/04_Changing_source_code.md opt:"-o markdown" opt:"-M utf-8"
 [type: text] en/./developers/03_Backend/05_Extensions.md $lang:$lang/./developers/03_Backend/05_Extensions.md opt:"-o markdown" opt:"-M utf-8"
+[type: text] en/./developers/03_Running_tests.md $lang:$lang/./developers/03_Running_tests.md opt:"-o markdown" opt:"-M utf-8"
 [type: text] en/./developers/04_Frontend/01_View_files.md $lang:$lang/./developers/04_Frontend/01_View_files.md opt:"-o markdown" opt:"-M utf-8"
 [type: text] en/./developers/04_Frontend/02_Design.md $lang:$lang/./developers/04_Frontend/02_Design.md opt:"-o markdown" opt:"-M utf-8"
 [type: text] en/./developers/05_Release_new_version.md $lang:$lang/./developers/05_Release_new_version.md opt:"-o markdown" opt:"-M utf-8"


### PR DESCRIPTION
Following of #2722 

It works pretty good but my main issue with this PR is that I don't check the `phpunit` binary. Instructions are given in the documentation, but it doesn't seem to be so easy: https://phpunit.readthedocs.io/en/latest/installation.html#verifying-phpunit-phar-releases

The composer solution inside a Docker image looks more secure.