### PR TITLE
fix: Rename COPY_LOG_TO_STDERR in COPY_LOG_TO_SYSLOG

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -32,7 +32,7 @@ safe_define('FRESHRSS_USERAGENT', 'FreshRSS/' . FRESHRSS_VERSION . ' (' . PHP_OS
 // PHP text output compression http://php.net/ob_gzhandler (better to do it at Web server level)
 safe_define('PHP_COMPRESSION', false);
 
-safe_define('COPY_LOG_TO_STDERR', filter_var(getenv('COPY_LOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
+safe_define('COPY_LOG_TO_SYSLOG', filter_var(getenv('COPY_LOG_TO_SYSLOG'), FILTER_VALIDATE_BOOLEAN));
 // For cases when syslog is not available
 safe_define('COPY_SYSLOG_TO_STDERR', filter_var(getenv('COPY_SYSLOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
 


### PR DESCRIPTION
The constant was badly named. The bug was introduced in 3c49986ec,
probably because of a copy/paste.

There is no other occurrences of COPY_LOG_TO_STDERR in the code (checked
with `git grep`).