### PR TITLE
Docker: Alpine Linux 3.11

### DIFF
--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 
 ENV TZ UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.11.0-released.html
Apache/2.4.41 (unchanged), PHP 7.3.13 (updated from 7.3.11 when Alpine
3.10 was released, but unchanged since the latest build of 3.10)