### PR TITLE
fix: Fix undefined function _t on WebSub

### DIFF
--- a/p/api/pshb.php
+++ b/p/api/pshb.php
@@ -117,6 +117,7 @@ if ($self !== base64url_decode($canonical64)) {
 }
 
 Minz_ExtensionManager::init();
+Minz_Translate::init();
 
 $nb = 0;
 foreach ($users as $userFilename) {
@@ -136,6 +137,7 @@ foreach ($users as $userFilename) {
 		FreshRSS_Context::init();
 		if (FreshRSS_Context::$user_conf != null) {
 			Minz_ExtensionManager::enableByList(FreshRSS_Context::$user_conf->extensions_enabled);
+			Minz_Translate::reset(FreshRSS_Context::$user_conf->language);
 		}
 
 		list($updated_feeds, $feed, $nb_new_articles) = FreshRSS_feed_Controller::actualizeFeed(0, $self, false, $simplePie);


### PR DESCRIPTION
I published an article via WebSub, but I never received it. So I checked
my logs to find why and I found the following stacktrace:

```
29/Dec/2019:15:58:32 +0000 "POST /api/pshb.php" 500
NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function _t() in /path/app/Models/Category.php:83
Stack trace:
/path/app/Models/CategoryDAO.php(417): FreshRSS_Category->_id(1)
/path/app/Models/CategoryDAO.php(192): FreshRSS_CategoryDAO::daoToCategory(Array)
/path/app/Models/Feed.php(466): FreshRSS_CategoryDAO->searchById('1')
/path/app/Controllers/feedController.php(416): FreshRSS_Feed->cleanOldEntries()
/path/p/api/pshb.php(141): FreshRSS_feed_Controller::actualizeFeed(0, 'https://flus.io...', false, Object(SimplePie))
{main}
  thrown in /path/app/Models/Category.php on line 83
```

The `_t` function should be loaded with the Minz_Translate class, but
the latter isn't initialized on WebSub endpoint.

In my opinion, we should not have to care about this kind of detail of
implementation and it reveals a deeper architectural misconception, but
for now the fix should be enough. It’s quite difficult to reproduce
locally though.