### PR TITLE
Fix loader display in Dark theme

### DIFF
--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -470,6 +470,7 @@ a.btn {
 
 .pagination .loading,
 .pagination a:hover.loading {
+	background: url("loader.gif") center center no-repeat;
 	font-size: 0;
 }
 


### PR DESCRIPTION
Before, the default loader was used. It rendered poorly since it has a white
border.
Now, the theme loader is used.