### PR TITLE
Use a real timestamp in greader API.

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -493,7 +493,7 @@ function entriesToArray($entries) {
 		$item = array(
 			'id' => 'tag:google.com,2005:reader/item/' . dec2hex($entry->id()),	//64-bit hexa http://code.google.com/p/google-reader-api/wiki/ItemId
 			'crawlTimeMsec' => '' . ($entry->date(true) * 1000),
-			'timestampUsec' => '' . ($entry->date(true) * 1000000),	//EasyRSS
+			'timestampUsec' => '' . ($entry->date(true) * 1000000),	//EasyRSS + Reeder
 			'published' => $entry->date(true),
 			'title' => escapeToUnicodeAlternative($entry->title(), false),
 			'summary' => array('content' => $entry->content()),

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -492,8 +492,8 @@ function entriesToArray($entries) {
 		}
 		$item = array(
 			'id' => 'tag:google.com,2005:reader/item/' . dec2hex($entry->id()),	//64-bit hexa http://code.google.com/p/google-reader-api/wiki/ItemId
-			'crawlTimeMsec' => substr($entry->id(), 0, -3),
-			'timestampUsec' => '' . $entry->id(),	//EasyRSS
+			'crawlTimeMsec' => '' . ($entry->date(true) * 1000),
+			'timestampUsec' => '' . ($entry->date(true) * 1000000),	//EasyRSS
 			'published' => $entry->date(true),
 			'title' => escapeToUnicodeAlternative($entry->title(), false),
 			'summary' => array('content' => $entry->content()),


### PR DESCRIPTION
Closes #2759

Changes proposed in this pull request:

- Use a real timestamp in greader API.

How to test the feature manually:

1. Connect to a FreshRSS instance with Reeder (macOS or iOS), and see that dates are related to RSS `pubDate` dates.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

Note: I'm not a PHP developer. Feel free to reject if you don't want this change, or if you want to elaborate a more complete solution.