### PR TITLE
Pass the entries to 'entry_before_display' extension hook

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -920,10 +920,9 @@ $user = authorizationToUser();
 FreshRSS_Context::$user_conf = null;
 if ($user !== '') {
 	FreshRSS_Context::$user_conf = get_user_configuration($user);
-	Minz_Translate::init(FreshRSS_Context::$user_conf->language);
-
 	Minz_ExtensionManager::init();
-
+	Minz_Translate::init(FreshRSS_Context::$user_conf->language);
+	
 	if (FreshRSS_Context::$user_conf != null) {
 		Minz_ExtensionManager::enableByList(FreshRSS_Context::$user_conf->extensions_enabled);
 	}

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -922,7 +922,7 @@ if ($user !== '') {
 	FreshRSS_Context::$user_conf = get_user_configuration($user);
 	Minz_ExtensionManager::init();
 	Minz_Translate::init(FreshRSS_Context::$user_conf->language);
-	
+
 	if (FreshRSS_Context::$user_conf != null) {
 		Minz_ExtensionManager::enableByList(FreshRSS_Context::$user_conf->extensions_enabled);
 	}

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -481,7 +481,11 @@ function entriesToArray($entries) {
 	}
 
 	$items = array();
-	foreach ($entries as $entry) {
+	foreach ($entries as $item) {
+		$entry = Minz_ExtensionManager::callHook('entry_before_display', $item);
+		if ($entry == null) {
+			continue;
+		}
 		$f_id = $entry->feed();
 		if (isset($arrayFeedCategoryNames[$f_id])) {
 			$c_name = $arrayFeedCategoryNames[$f_id]['c_name'];
@@ -917,6 +921,12 @@ FreshRSS_Context::$user_conf = null;
 if ($user !== '') {
 	FreshRSS_Context::$user_conf = get_user_configuration($user);
 	Minz_Translate::init(FreshRSS_Context::$user_conf->language);
+
+	Minz_ExtensionManager::init();
+
+	if (FreshRSS_Context::$user_conf != null) {
+		Minz_ExtensionManager::enableByList(FreshRSS_Context::$user_conf->extensions_enabled);
+	}
 } else {
 	Minz_Translate::init();
 }


### PR DESCRIPTION
Closes #2762

Changes proposed in this pull request:

- Pass feed entries processed by greader API to the 'entry_before_display' extension hook.

How to test the feature manually:

1. Enable some extension like YouTube, which put YouTube video in-line.
2. Add a YouTube feed to your FreshRSS instance.
3. Check that you see the in-line YouTube video in-line in your RSS client.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

Note: I'm not a PHP developer. Feel free to reject if you don't want this change, or if you want to elaborate a more complete solution.