### PR TITLE
Show Favorites as Unread

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -57,6 +57,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			FreshRSS_Context::$user_conf->bottomline_link = Minz_Request::param('bottomline_link', false);
 			FreshRSS_Context::$user_conf->html5_notif_timeout = Minz_Request::param('html5_notif_timeout', 0);
 			FreshRSS_Context::$user_conf->show_nav_buttons = Minz_Request::param('show_nav_buttons', false);
+			FreshRSS_Context::$user_conf->show_fav_unread = Minz_Request::param('show_fav_unread', false);
 			FreshRSS_Context::$user_conf->save();
 
 			Minz_Session::_param('language', FreshRSS_Context::$user_conf->language);

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -57,7 +57,6 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			FreshRSS_Context::$user_conf->bottomline_link = Minz_Request::param('bottomline_link', false);
 			FreshRSS_Context::$user_conf->html5_notif_timeout = Minz_Request::param('html5_notif_timeout', 0);
 			FreshRSS_Context::$user_conf->show_nav_buttons = Minz_Request::param('show_nav_buttons', false);
-			FreshRSS_Context::$user_conf->show_fav_unread = Minz_Request::param('show_fav_unread', false);
 			FreshRSS_Context::$user_conf->save();
 
 			Minz_Session::_param('language', FreshRSS_Context::$user_conf->language);
@@ -106,6 +105,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			FreshRSS_Context::$user_conf->posts_per_page = Minz_Request::param('posts_per_page', 10);
 			FreshRSS_Context::$user_conf->view_mode = Minz_Request::param('view_mode', 'normal');
 			FreshRSS_Context::$user_conf->default_view = Minz_Request::param('default_view', 'adaptive');
+			FreshRSS_Context::$user_conf->show_fav_unread = Minz_Request::param('show_fav_unread', false);
 			FreshRSS_Context::$user_conf->auto_load_more = Minz_Request::param('auto_load_more', false);
 			FreshRSS_Context::$user_conf->display_posts = Minz_Request::param('display_posts', false);
 			FreshRSS_Context::$user_conf->display_categories = Minz_Request::param('display_categories', false);

--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -177,7 +177,7 @@ class FreshRSS_ConfigurationSetter {
 	private function _show_nav_buttons(&$data, $value) {
 		$data['show_nav_buttons'] = $this->handleBool($value);
 	}
-	
+
 	private function _show_fav_unread(&$data, $value) {
 		$data['show_fav_unread'] = $this->handleBool($value);
 	}

--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -177,6 +177,10 @@ class FreshRSS_ConfigurationSetter {
 	private function _show_nav_buttons(&$data, $value) {
 		$data['show_nav_buttons'] = $this->handleBool($value);
 	}
+	
+	private function _show_fav_unread(&$data, $value) {
+		$data['show_fav_unread'] = $this->handleBool($value);
+	}
 
 	private function _display_categories(&$data, $value) {
 		$data['display_categories'] = $this->handleBool($value);

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Po “označit vše jako přečtené”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Počet článků na stranu',
 		'auto_load_more' => 'Načítat další články dole na stránce',
 		'auto_remove_article' => 'Po přečtení články schovat',

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Po “označit vše jako přečtené”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Počet článků na stranu',
 		'auto_load_more' => 'Načítat další články dole na stránce',
 		'auto_remove_article' => 'Po přečtení články schovat',

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Po “označit vše jako přečtené”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Počet článků na stranu',
 		'auto_load_more' => 'Načítat další články dole na stránce',
 		'auto_remove_article' => 'Po přečtení články schovat',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Nach „Alle als gelesen markieren“,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Anzahl der Artikel pro Seite',
 		'auto_load_more' => 'Die nächsten Artikel am Seitenende laden',
 		'auto_remove_article' => 'Artikel nach dem Lesen verstecken',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -37,7 +37,7 @@ return array(
 			'timeout' => 'Zeitüberschreitung für HTML5-Benachrichtigung',
 		),
 		'show_nav_buttons' => 'Zeige Navigations-Buttons',
-		'show_fav_unread' => 'Zeige Favoriten als "Ungelesen"',
+		'show_fav_unread' => 'Immer Favoriten zeigen',
 		'theme' => 'Erscheinungsbild',
 		'title' => 'Anzeige',
 		'width' => array(

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Nach „Alle als gelesen markieren“,',
-		'always_show_favorites' => 'Immer Favoriten zeigen',
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Anzahl der Artikel pro Seite',
 		'auto_load_more' => 'Die nächsten Artikel am Seitenende laden',
 		'auto_remove_article' => 'Artikel nach dem Lesen verstecken',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -37,6 +37,7 @@ return array(
 			'timeout' => 'Zeitüberschreitung für HTML5-Benachrichtigung',
 		),
 		'show_nav_buttons' => 'Zeige Navigations-Buttons',
+		'show_fav_unread' => 'Zeige Favoriten als "Ungelesen"',
 		'theme' => 'Erscheinungsbild',
 		'title' => 'Anzeige',
 		'width' => array(

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -37,7 +37,6 @@ return array(
 			'timeout' => 'Zeitüberschreitung für HTML5-Benachrichtigung',
 		),
 		'show_nav_buttons' => 'Zeige Navigations-Buttons',
-		'show_fav_unread' => 'Immer Favoriten zeigen',
 		'theme' => 'Erscheinungsbild',
 		'title' => 'Anzeige',
 		'width' => array(
@@ -98,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Nach „Alle als gelesen markieren“,',
+		'always_show_favorites' => 'Immer Favoriten zeigen',
 		'articles_per_page' => 'Anzahl der Artikel pro Seite',
 		'auto_load_more' => 'Die nächsten Artikel am Seitenende laden',
 		'auto_remove_article' => 'Artikel nach dem Lesen verstecken',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -37,6 +37,7 @@ return array(
 			'timeout' => 'HTML5 notification timeout',
 		),
 		'show_nav_buttons' => 'Show the navigation buttons',
+		'show_fav_unread' => 'Show Favorites as "Unread"',
 		'theme' => 'Theme',
 		'title' => 'Display',
 		'width' => array(

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'After “mark all as read”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',
+		'always_show_favorites' => 'Show all articles in favorites by default',
 		'articles_per_page' => 'Number of articles per page',
 		'auto_load_more' => 'Load more articles at the page bottom',
 		'auto_remove_article' => 'Hide articles after reading',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -37,7 +37,6 @@ return array(
 			'timeout' => 'HTML5 notification timeout',
 		),
 		'show_nav_buttons' => 'Show the navigation buttons',
-		'show_fav_unread' => 'Always show favorites',
 		'theme' => 'Theme',
 		'title' => 'Display',
 		'width' => array(
@@ -98,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'After “mark all as read”,',
+		'always_show_favorites' => 'Always show favorites',
 		'articles_per_page' => 'Number of articles per page',
 		'auto_load_more' => 'Load more articles at the page bottom',
 		'auto_remove_article' => 'Hide articles after reading',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -37,7 +37,7 @@ return array(
 			'timeout' => 'HTML5 notification timeout',
 		),
 		'show_nav_buttons' => 'Show the navigation buttons',
-		'show_fav_unread' => 'Show Favorites as "Unread"',
+		'show_fav_unread' => 'Always show favorites',
 		'theme' => 'Theme',
 		'title' => 'Display',
 		'width' => array(

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'After “mark all as read”,',
-		'always_show_favorites' => 'Always show favorites',
+		'always_show_favorites' => 'Show by default all articles in favorites',
 		'articles_per_page' => 'Number of articles per page',
 		'auto_load_more' => 'Load more articles at the page bottom',
 		'auto_remove_article' => 'Hide articles after reading',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Tras “marcar todo como leído”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Número de artículos por página',
 		'auto_load_more' => 'Cargar más artículos al final de la página',
 		'auto_remove_article' => 'Ocultar artículos tras la lectura',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Tras “marcar todo como leído”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Número de artículos por página',
 		'auto_load_more' => 'Cargar más artículos al final de la página',
 		'auto_remove_article' => 'Ocultar artículos tras la lectura',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Tras “marcar todo como leído”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Número de artículos por página',
 		'auto_load_more' => 'Cargar más artículos al final de la página',
 		'auto_remove_article' => 'Ocultar artículos tras la lectura',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Après “marquer tout comme lu”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Afficher par défaut tous les articles dans les favoris',
 		'articles_per_page' => 'Nombre d’articles par page',
 		'auto_load_more' => 'Charger les articles suivants en bas de page',
 		'auto_remove_article' => 'Cacher les articles après lecture',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Après “marquer tout comme lu”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Nombre d’articles par page',
 		'auto_load_more' => 'Charger les articles suivants en bas de page',
 		'auto_remove_article' => 'Cacher les articles après lecture',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'לאחר “סימון הכל כנקרא”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'מספר המאמרים בעמוד',
 		'auto_load_more' => 'טעינת המאמר הבא סוף העמוד',
 		'auto_remove_article' => 'Hide articles after reading',	// TODO - Translation

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'לאחר “סימון הכל כנקרא”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'מספר המאמרים בעמוד',
 		'auto_load_more' => 'טעינת המאמר הבא סוף העמוד',
 		'auto_remove_article' => 'Hide articles after reading',	// TODO - Translation

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'לאחר “סימון הכל כנקרא”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'מספר המאמרים בעמוד',
 		'auto_load_more' => 'טעינת המאמר הבא סוף העמוד',
 		'auto_remove_article' => 'Hide articles after reading',	// TODO - Translation

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Dopo “segna tutto come letto”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Numero di articoli per pagina',
 		'auto_load_more' => 'Carica articoli successivi a fondo pagina',
 		'auto_remove_article' => 'Nascondi articoli dopo la lettura',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Dopo “segna tutto come letto”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Numero di articoli per pagina',
 		'auto_load_more' => 'Carica articoli successivi a fondo pagina',
 		'auto_remove_article' => 'Nascondi articoli dopo la lettura',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Dopo “segna tutto come letto”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Numero di articoli per pagina',
 		'auto_load_more' => 'Carica articoli successivi a fondo pagina',
 		'auto_remove_article' => 'Nascondi articoli dopo la lettura',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '“모두 읽음으로 표시” 후,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => '페이지당 글 수',
 		'auto_load_more' => '페이지 하단에 다다르면 글 더 불러오기',
 		'auto_remove_article' => '글을 읽은 후 숨기기',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '“모두 읽음으로 표시” 후,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => '페이지당 글 수',
 		'auto_load_more' => '페이지 하단에 다다르면 글 더 불러오기',
 		'auto_remove_article' => '글을 읽은 후 숨기기',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '“모두 읽음으로 표시” 후,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => '페이지당 글 수',
 		'auto_load_more' => '페이지 하단에 다다르면 글 더 불러오기',
 		'auto_remove_article' => '글을 읽은 후 숨기기',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Na “markeer alles als gelezen”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Aantal artikelen per pagina',
 		'auto_load_more' => 'Laad volgende artikel onderaan de pagina',
 		'auto_remove_article' => 'Verberg artikel na lezen',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Na “markeer alles als gelezen”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Aantal artikelen per pagina',
 		'auto_load_more' => 'Laad volgende artikel onderaan de pagina',
 		'auto_remove_article' => 'Verberg artikel na lezen',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Na “markeer alles als gelezen”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Aantal artikelen per pagina',
 		'auto_load_more' => 'Laad volgende artikel onderaan de pagina',
 		'auto_remove_article' => 'Verberg artikel na lezen',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Aprèp « marcar coma legit »,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Nombre d’articles per pagina',
 		'auto_load_more' => 'Cargar los articles seguents enbàs de la pagina',
 		'auto_remove_article' => 'Rescondre los articles aprèp lectura',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Aprèp « marcar coma legit »,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Nombre d’articles per pagina',
 		'auto_load_more' => 'Cargar los articles seguents enbàs de la pagina',
 		'auto_remove_article' => 'Rescondre los articles aprèp lectura',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Aprèp « marcar coma legit »,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Nombre d’articles per pagina',
 		'auto_load_more' => 'Cargar los articles seguents enbàs de la pagina',
 		'auto_remove_article' => 'Rescondre los articles aprèp lectura',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Depois de "marcar todos como lido",',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Número de artigos por página',
 		'auto_load_more' => 'Carregar mais artigos no final da página',
 		'auto_remove_article' => 'Esconder artigos depois de lidos',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Depois de "marcar todos como lido",',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Número de artigos por página',
 		'auto_load_more' => 'Carregar mais artigos no final da página',
 		'auto_remove_article' => 'Esconder artigos depois de lidos',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Depois de "marcar todos como lido",',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Número de artigos por página',
 		'auto_load_more' => 'Carregar mais artigos no final da página',
 		'auto_remove_article' => 'Esconder artigos depois de lidos',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'After “mark all as read”,',	// TODO - Translation
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Number of articles per page',	// TODO - Translation
 		'auto_load_more' => 'Load next articles at the page bottom',
 		'auto_remove_article' => 'Hide articles after reading',	// TODO - Translation

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'After “mark all as read”,',	// TODO - Translation
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Number of articles per page',	// TODO - Translation
 		'auto_load_more' => 'Load next articles at the page bottom',
 		'auto_remove_article' => 'Hide articles after reading',	// TODO - Translation

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'After “mark all as read”,',	// TODO - Translation
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Number of articles per page',	// TODO - Translation
 		'auto_load_more' => 'Load next articles at the page bottom',
 		'auto_remove_article' => 'Hide articles after reading',	// TODO - Translation

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Po “Označiť všetko ako prečítané”,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Počet článkov na jednu stranu',
 		'auto_load_more' => 'Načítať ďalšie články dolu na stránke',
 		'auto_remove_article' => 'Skryť články po prečítaní',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Po “Označiť všetko ako prečítané”,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Počet článkov na jednu stranu',
 		'auto_load_more' => 'Načítať ďalšie články dolu na stránke',
 		'auto_remove_article' => 'Skryť články po prečítaní',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => 'Po “Označiť všetko ako prečítané”,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Počet článkov na jednu stranu',
 		'auto_load_more' => 'Načítať ďalšie články dolu na stránke',
 		'auto_remove_article' => 'Skryť články po prečítaní',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '"Hepsini okundu say" dedinten sonra,',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => 'Sayfa başına makale sayısı',
 		'auto_load_more' => 'Sayfa sonunda yeni makaleleri yükle',
 		'auto_remove_article' => 'Okuduktan sonra makaleleri gizle',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '"Hepsini okundu say" dedinten sonra,',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => 'Sayfa başına makale sayısı',
 		'auto_load_more' => 'Sayfa sonunda yeni makaleleri yükle',
 		'auto_remove_article' => 'Okuduktan sonra makaleleri gizle',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '"Hepsini okundu say" dedinten sonra,',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => 'Sayfa başına makale sayısı',
 		'auto_load_more' => 'Sayfa sonunda yeni makaleleri yükle',
 		'auto_remove_article' => 'Okuduktan sonra makaleleri gizle',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '「全部标记为已读」后',
-		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show all articles in favorites by default',	// TODO - Translation
 		'articles_per_page' => '每页文章数',
 		'auto_load_more' => '在页面底部载入下一篇文章',
 		'auto_remove_article' => '阅读后隐藏文章',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -97,6 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '「全部标记为已读」后',
+		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
 		'articles_per_page' => '每页文章数',
 		'auto_load_more' => '在页面底部载入下一篇文章',
 		'auto_remove_article' => '阅读后隐藏文章',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -97,7 +97,7 @@ return array(
 	),
 	'reading' => array(
 		'after_onread' => '「全部标记为已读」后',
-		'always_show_favorites' => 'Always show favorites',	// TODO - Translation
+		'always_show_favorites' => 'Show by default all articles in favorites',	// TODO - Translation
 		'articles_per_page' => '每页文章数',
 		'auto_load_more' => '在页面底部载入下一篇文章',
 		'auto_remove_article' => '阅读后隐藏文章',

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -31,7 +31,16 @@
 
 		<li class="tree-folder category favorites<?= FreshRSS_Context::isCurrentGet('s') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
-				<?= _i('bookmark') ?> <a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's'); if (FreshRSS_Context::$user_conf->show_fav_unread) echo("&state=3"); ?>"><?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?></a>
+				<?php
+					$url_starred = _url('index', $actual_view, 'get', 's');
+					if (FreshRSS_Context::$user_conf->show_fav_unread) {
+						$url_starred = $url_starred . '&state=3';
+					}
+				?>
+				<?= _i('bookmark') ?>
+				<a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= $url_starred ?>">
+					<?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?>
+				</a>
 			</div>
 		</li>
 

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -31,7 +31,7 @@
 
 		<li class="tree-folder category favorites<?= FreshRSS_Context::isCurrentGet('s') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
-				<?= _i('bookmark') ?> <a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') ?>"><?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?></a>
+				<?= _i('bookmark') ?> <a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's'); if (FreshRSS_Context::$user_conf->show_fav_unread) echo("&state=3"); ?>"><?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?></a>
 			</div>
 		</li>
 

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -124,12 +124,6 @@
 					<?= _t('conf.display.show_nav_buttons') ?>
 				</label>
 			</div>
-			<div class="group-controls">
-				<label class="checkbox" for="show_fav_unread">
-					<input type="checkbox" name="show_fav_unread" id="show_fav_unread" value="1"<?= FreshRSS_Context::$user_conf->show_fav_unread ? ' checked="checked"' : '' ?> data-leave-validation="<?= FreshRSS_Context::$user_conf->show_fav_unread ?>"/>
-					<?= _t('conf.display.show_fav_unread') ?>
-				</label>
-			</div>
 		</div>
 
 		<div class="form-group form-actions">

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -124,6 +124,12 @@
 					<?= _t('conf.display.show_nav_buttons') ?>
 				</label>
 			</div>
+			<div class="group-controls">
+				<label class="checkbox" for="show_fav_unread">
+					<input type="checkbox" name="show_fav_unread" id="show_fav_unread" value="1"<?= FreshRSS_Context::$user_conf->show_fav_unread ? ' checked="checked"' : '' ?> data-leave-validation="<?= FreshRSS_Context::$user_conf->show_fav_unread ?>"/>
+					<?= _t('conf.display.show_fav_unread') ?>
+				</label>
+			</div>
 		</div>
 
 		<div class="form-group form-actions">

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -49,6 +49,15 @@
 
 		<div class="form-group">
 			<div class="group-controls">
+				<label class="checkbox" for="show_fav_unread">
+					<input type="checkbox" name="show_fav_unread" id="show_fav_unread" value="1"<?= FreshRSS_Context::$user_conf->show_fav_unread ? ' checked="checked"' : '' ?> data-leave-validation="<?= FreshRSS_Context::$user_conf->show_fav_unread ?>"/>
+					<?= _t('conf.display.show_fav_unread') ?>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<div class="group-controls">
 				<label class="checkbox" for="hide_read_feeds">
 					<input type="checkbox" name="hide_read_feeds" id="hide_read_feeds" value="1"<?= FreshRSS_Context::$user_conf->hide_read_feeds ? ' checked="checked"' : '' ?> data-leave-validation="<?= FreshRSS_Context::$user_conf->hide_read_feeds ?>"/>
 					<?= _t('conf.reading.hide_read_feeds') ?>

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -51,7 +51,7 @@
 			<div class="group-controls">
 				<label class="checkbox" for="show_fav_unread">
 					<input type="checkbox" name="show_fav_unread" id="show_fav_unread" value="1"<?= FreshRSS_Context::$user_conf->show_fav_unread ? ' checked="checked"' : '' ?> data-leave-validation="<?= FreshRSS_Context::$user_conf->show_fav_unread ?>"/>
-					<?= _t('conf.display.show_fav_unread') ?>
+					<?= _t('conf.reading.always_show_favorites') ?>
 				</label>
 			</div>
 		</div>

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -29,6 +29,7 @@ return array (
 	'view_mode' => 'normal',
 	'default_view' => 'adaptive',
 	'default_state' => FreshRSS_Entry::STATE_NOT_READ,
+	'show_fav_unread' => false,
 	'auto_load_more' => true,
 	'display_posts' => false,
 	'display_categories' => false,


### PR DESCRIPTION
Closes #2434

**Changes proposed in this pull request:**
- added a setting in "display" to show starred/favorites as unread

**How to test the feature manually:**
1. got to settings > display
2. a new checkbox is available: Show Favorites as "Unread" 
3. enable the checkbox
4. click on favorites/starred > url parameter state=3 is added to the link
5. if you click the favorites > read and unread articles in favorites are displayed

**Pull request checklist:**
- [ x ] code manually tested

**Question:**
Anyway, what does "show as unread" mean, with the unread background color or something?

**Answer:**
Color isn't changed for the articles. All will stay the same. But currently, if you click Favorites/Starred, only unread articles are displayed. In my workflow, when i star/favorite a article, it will be marked as read. Clicking now Favorite/Starred will not show that article, unless i also enable "unread" from the toolbar. This save that step and displays favorites/starred with state=3 as default. If the option is unchecked, the current behavior is used.

_Hopefully, this time i get it right :-) It's a bit frickely to do that only in the WebGUI, but i didn't have my PC at hand with git installed_ 
