### PR TITLE
[fix] Correct default view for label

### DIFF
--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -37,7 +37,7 @@
 		</div>
 
 		<div class="form-group">
-			<label class="group-name" for="view_mode"><?= _t('conf.reading.show') ?></label>
+			<label class="group-name" for="default_view"><?= _t('conf.reading.show') ?></label>
 			<div class="group-controls">
 				<select name="default_view" id="default_view" data-leave-validation="<?= FreshRSS_Context::$user_conf->default_view ?>">
 					<option value="adaptive"<?= FreshRSS_Context::$user_conf->default_view === 'adaptive' ? ' selected="selected"' : '' ?>><?= _t('conf.reading.show.adaptive') ?></option>


### PR DESCRIPTION
While testing <https://github.com/FreshRSS/FreshRSS/pull/2766> I noticed that clicking the label activated the wrong dropdown.

How to test the feature manually:

1. Open settings → Reading
2. Click `Articles to display` label
3. It activates the dropdown right next to it, rather than the previous one

### Before
![Screenshot_2020-01-13_11-42-49](https://user-images.githubusercontent.com/202757/72249537-e5fe5280-35f9-11ea-9814-0b3a44a9a52b.png)
### After
![Screenshot_2020-01-13_11-43-01](https://user-images.githubusercontent.com/202757/72249539-e5fe5280-35f9-11ea-98a5-5a2ce7fcfea5.png)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/freshrss/freshrss/2767)
<!-- Reviewable:end -->
