### PR TITLE
fix: Make sure to have user conf in hasAccess

### DIFF
--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -116,14 +116,16 @@ class FreshRSS_Auth {
 	 */
 	public static function hasAccess($scope = 'general') {
 		$systemConfiguration = Minz_Configuration::get('system');
-		$userConfiguration = Minz_Configuration::get('user');
+		$currentUser = Minz_Session::param('currentUser');
+		$userConfiguration = get_user_configuration($currentUser);
+		$isAdmin = $userConfiguration && $userConfiguration->is_admin;
 		$default_user = $systemConfiguration->default_user;
 		$ok = self::$login_ok;
 		switch ($scope) {
 		case 'general':
 			break;
 		case 'admin':
-			$ok &= $default_user === Minz_Session::param('currentUser') || $userConfiguration->is_admin;
+			$ok &= $default_user === $currentUser || $isAdmin;
 			break;
 		default:
 			$ok = false;


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- Make sure to have user conf in hasAccess

The `FreshRSS_Auth::hasAccess` method is called during auth
initialization (`app/FreshRSS.php:78`), only for `user#create` action.
However, at this step, the `user` configuration namespace hasn't be
initialized yet, and so users weren't able to register because of the
exception... quite critical!

How to test the feature manually:

1. As an admin, make sure registrations are opened
2. Log out
3. Try to register a new user
4. It works! (it didn't before this patch)
5. As a new user, make sure you don't have administrator rights

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
