### PR TITLE
fix: #2701 Fix look of authors

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -28,9 +28,9 @@
 		}
 	}
 	?><li class="item website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>"><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" /> <span><?= $this->feed->name() ?></span></a></li>
-	<li class="item title" dir="auto"><a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>"><?= $this->entry->title() ?></a><?php
+	<li class="item title" dir="auto"><a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>"><?= $this->entry->title() ?><?php
 		if ($topline_display_authors):
-			?><div class="item author"><?php
+			?><span class="author"><?php
 			$authors = $this->entry->authors();
 			if (is_array($authors)) {
 				$first = true;
@@ -39,9 +39,9 @@
 					$first = false;
 				}
 			}
-			?></div><?php
+			?></span><?php
 		endif;
-	?></li>
+	?></a></li>
 	<?php if ($topline_date) { ?><li class="item date"><?= $this->entry->date() ?> </li><?php } ?>
 	<?php if ($topline_link) { ?><li class="item link"><a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>"><?= _i('link') ?></a></li><?php } ?>
 </ul>

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -667,11 +667,11 @@ a.btn {
 	text-decoration: none;
 }
 
-.flux .item.author {
+.flux .item.title .author {
+	padding-left: 1rem;
 	color: #555;
-	font-size: .7rem;
+	font-size: .9rem;
 	font-weight: normal;
-	white-space: normal;
 }
 
 .flux .item.date {


### PR DESCRIPTION
Closes #2701

Changes proposed in this pull request:

- Place "author" element in the "title" block of entries

This fix makes the authors part of the "title item", so it's not
considered as another block. This is not perfect since authors will
disappear on small screens, but we can discuss of putting titles on
multi-lines (see https://github.com/FreshRSS/FreshRSS/issues/2344).

How to test the feature manually:

1. Enable "author" display
2. Disable the multiline CSS fix :stuck_out_tongue: 
3. Check the author element is placed next to the title (and not under)

![Capture d’écran de 2020-01-16 16-58-38](https://user-images.githubusercontent.com/1436309/72541248-78b12280-3882-11ea-957c-c479c2161229.png)

![Capture d’écran - 2020-01-16 à 16 58 56](https://user-images.githubusercontent.com/1436309/72541257-7d75d680-3882-11ea-9edc-1b8bc51d9367.png)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
