### PR TITLE
Add the ability to customize greader by extension

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -14,6 +14,7 @@ class FreshRSS_Entry extends Minz_Model {
 	private $content;
 	private $link;
 	private $date;
+	private $date_added = 0; //In microseconds
 	private $hash = null;
 	private $is_read;	//Nullable boolean
 	private $is_favorite;
@@ -68,11 +69,15 @@ class FreshRSS_Entry extends Minz_Model {
 			return timestamptodate($this->date);
 		}
 	}
-	public function dateAdded($raw = false) {
-		$date = intval(substr($this->id, 0, -6));
+	public function dateAdded($raw = false, $microsecond = false) {
 		if ($raw) {
-			return $date;
+			if ($microsecond) {
+				return $this->date_added;
+			} else {
+				return intval(substr($this->id, 0, -6));
+			}
 		} else {
+			$date = intval(substr($this->id, 0, -6));
 			return timestamptodate($date);
 		}
 	}
@@ -119,6 +124,9 @@ class FreshRSS_Entry extends Minz_Model {
 
 	public function _id($value) {
 		$this->id = $value;
+		if ($this->date_added == 0) {
+			$this->date_added = $value;
+		}
 	}
 	public function _guid($value) {
 		if ($value == '') {
@@ -160,6 +168,13 @@ class FreshRSS_Entry extends Minz_Model {
 		$this->hash = null;
 		$value = intval($value);
 		$this->date = $value > 1 ? $value : time();
+	}
+	public function _dateAdded($value, $microsecond = false) {
+		if ($microsecond) {
+			$this->date_added = $value;
+		} else {
+			$this->date_added = $value * 1000000;
+		}
 	}
 	public function _isRead($value) {
 		$this->is_read = $value === null ? null : (bool)$value;

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -496,8 +496,8 @@ function entriesToArray($entries) {
 		}
 		$item = array(
 			'id' => 'tag:google.com,2005:reader/item/' . dec2hex($entry->id()),	//64-bit hexa http://code.google.com/p/google-reader-api/wiki/ItemId
-			'crawlTimeMsec' => substr($entry->id(), 0, -3),
-			'timestampUsec' => '' . $entry->id(),	//EasyRSS
+			'crawlTimeMsec' => substr($entry->dateAdded(true, true), 0, -3),
+			'timestampUsec' => '' . $entry->dateAdded(true, true), //EasyRSS & Reeder
 			'published' => $entry->date(true),
 			'title' => escapeToUnicodeAlternative($entry->title(), false),
 			'summary' => array('content' => $entry->content()),


### PR DESCRIPTION
Closes #2759 (take 2)

Changes proposed in this pull request:

- Use `dateAdded()` in greader API to forge the `crawlTimeMsec` & `timestampUsec` field, so it enforces the fact it's a timestamp + make the ability to change the value independently of the id.
- Add the ability to change the `dateAdded` of a `FreshRSS_Entry`, so an extension can change it in an extension hook (`entry_before_display` by example).

Can be used, by example, to exchange the `crawlTimeMsec` & `timestampUsec`, to workaround some RSS client usage of this field (like Reeder or EasyRSS - see the long ticket discussion…).

How to test the feature manually:

1. The best is probably to do an extension like I plan to add on my instance, which is basically:
```
public function init() {
		$this->registerHook('entry_before_display', array($this, 'handle_entry'));
	}
	public function handle_entry($entry) {
		if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '/api/greader.php') !== FALSE) {
			$entry->_dateAdded($entry->date(true));
		}
		return $entry;
	}
```

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
