### PR TITLE
Fix null array index bug for PHP 7.4

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -372,7 +372,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 		$feedsDao = array();
 		$feedDao = FreshRSS_Factory::createFeedDAO();
 		foreach ($listDAO as $line) {
-			if ($previousLine['c_id'] != null && $line['c_id'] !== $previousLine['c_id']) {
+			if (!empty($previousLine['c_id']) && $line['c_id'] !== $previousLine['c_id']) {
 				// End of the current category, we add it to the $list
 				$cat = new FreshRSS_Category(
 					$previousLine['c_name'],


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/issues/2775
Especially for PHP 7.4+ "Array-style access of non-arrays"
https://php.net/migration74.incompatible

Closes https://github.com/FreshRSS/FreshRSS/issues/2775

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated