### PR TITLE
No pre for enclosure-description

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -401,7 +401,7 @@ class FreshRSS_Feed extends Minz_Model {
 						$content .= $enclosureContent;
 
 						if ($enclosure->get_description() != '') {
-							$content .= '<pre class="enclosure-description">' . $enclosure->get_description() . '</pre>';
+							$content .= '<p class="enclosure-description">' . $enclosure->get_description() . '</p>';
 						}
 						$content .= "</div>\n";
 					}

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1135,7 +1135,7 @@ input:checked + .slide-container .properties {
 	margin-left: .8em;
 }
 
-pre.enclosure-description {
+.enclosure-description {
 	white-space: pre-line;
 }
 


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/2807
In browsers, the styling `white-space:pre-line` will be applied by CSS,
but no styling will be done for clients via API.