### PR TITLE
Fix wrong foreach in applyFilterActions

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -295,7 +295,7 @@ class FreshRSS_Entry extends Minz_Model {
 			}
 			foreach ($this->feed->filterActions() as $filterAction) {
 				if ($this->matches($filterAction->booleanSearch())) {
-					foreach ($filterAction->actions() as $action => $params) {
+					foreach ($filterAction->actions() as $action) {
 						switch ($action) {
 							case 'read':
 								$this->_isRead(true);


### PR DESCRIPTION
$filterAction->actions()  returns Array.

Current works fine because the php switch behavior.
See: https://stackoverflow.com/questions/2259266/0-in-switch-case