### PR TITLE
Reset scroll

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1542,6 +1542,7 @@ function init_normal() {
 }
 
 function init_beforeDOM() {
+	document.scrollingElement.scrollTop = 0;
 	if (['normal', 'reader', 'global'].indexOf(context.current_view) >= 0) {
 		init_normal();
 	}


### PR DESCRIPTION
Address some of https://github.com/FreshRSS/FreshRSS/issues/2836
This patch resets the scrollbar to the top when a FreshRSS page is
initialised.
Makes sure that when a FreshRSS page is restored in a Web browser
session, we do not hit the problematic situation when the content is
refreshed but the scrollbar moved back to where it was, potentially
erroneously marking as read many as read, of landing on the wrong focus.