### PR TITLE
Fix wget in linux update guide

### DIFF
--- a/docs/en/admins/07_LinuxUpdate.md
+++ b/docs/en/admins/07_LinuxUpdate.md
@@ -67,7 +67,7 @@ cd /usr/share/FreshRSS/
 
 3. Download and unzip the update file
 ```
-curl -L -o freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip
+wget -O freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip
 unzip freshrss.zip
 ```
 

--- a/docs/en/admins/07_LinuxUpdate.md
+++ b/docs/en/admins/07_LinuxUpdate.md
@@ -67,7 +67,7 @@ cd /usr/share/FreshRSS/
 
 3. Download and unzip the update file
 ```
-wget -o freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip
+curl -L -o freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip
 unzip freshrss.zip
 ```
 


### PR DESCRIPTION
Closes #2857

Changes proposed in this pull request:

- change link from `wget` to curl in `linux` update guide

How to test the feature manually:

1. run `wget -O freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip` and make sure it works.
2. run `wget -o freshrss.zip https://github.com/FreshRSS/FreshRSS/archive/1.15.3.zip` and make sure it doesn't work ;)

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [] unit tests written (optional if too hard) 
- [X] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
