### PR TITLE
Allow feed to be actualized after being truncated

### DIFF
--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -407,7 +407,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		$affected = $stm->rowCount();
 
 		$sql = 'UPDATE `_feed` '
-			 . 'SET `cache_nbEntries`=0, `cache_nbUnreads`=0 WHERE id=:id';
+			 . 'SET `cache_nbEntries`=0, `cache_nbUnreads`=0, `lastUpdate`=0 WHERE id=:id';
 		$stm = $this->pdo->prepare($sql);
 		$stm->bindParam(':id', $id, PDO::PARAM_INT);
 		if (!($stm && $stm->execute())) {


### PR DESCRIPTION
Before, on had to wait for the cache to expire before being able to refresh a feed that had been truncated via the Web interface.
Now, one can "delete all articles" and hit "actualize" immediately after without problem.
Useful for testing filters, debugging e.g. https://github.com/FreshRSS/FreshRSS/issues/2806