### PR TITLE
Fix fetch content for complex HEAD

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -753,14 +753,20 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		//Check Feed ID validity.
 		$entryDAO = FreshRSS_Factory::createEntryDao();
 		$entries = $entryDAO->listWhere('f', $feed_id);
+		$entry = null;
 
-		if (empty($entries)) {
+		//Get first entry (syntax robust for Generator or Array)
+		foreach ($entries as $myEntry) {
+			$entry = $myEntry;
+			break;
+		}
+
+		if ($entry == null) {
 			$this->view->fatalError = _t('feedback.sub.feed.selector_preview.no_entries');
 			return;
 		}
 
-		//Get feed & entry.
-		$entry = $entries[0];
+		//Get feed.
 		$feed = $entry->feed(true);
 
 		if (!$feed) {

--- a/lib/lib_phpQuery.php
+++ b/lib/lib_phpQuery.php
@@ -501,9 +501,10 @@ class DOMDocumentWrapper {
 		$metaContentType = $matches[0][0];
 		$markup = substr($markup, 0, $matches[0][1])
 			.substr($markup, $matches[0][1]+strlen($metaContentType));
-		$headStart = stripos($markup, '<head>');
-		$markup = substr($markup, 0, $headStart+6).$metaContentType
-			.substr($markup, $headStart+6);
+		$headStart = stripos($markup, '<head');
+		$headStop = stripos($markup, '>', $headStart);
+		$markup = substr($markup, 0, $headStop+1).$metaContentType
+			.substr($markup, $headStop+1);
 		return $markup;
 	}
 	protected function charsetAppendToHTML($html, $charset, $xhtml = false) {
@@ -4206,7 +4207,7 @@ class phpQueryObject
 					.($node->getAttribute('id')
 						? '#'.$node->getAttribute('id'):'')
 					.($node->getAttribute('class')
-						? '.'.join('.', split(' ', $node->getAttribute('class'))):'')
+						? '.'.join('.', explode(' ', $node->getAttribute('class'))):'')
 					.($node->getAttribute('name')
 						? '[name="'.$node->getAttribute('name').'"]':'')
 					.($node->getAttribute('value') && strpos($node->getAttribute('value'), '<'.'?php') === false


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/2864

*  Fix `contentSelectorPreviewAction()` https://github.com/FreshRSS/FreshRSS/pull/2778 , which was not compatible with `yield` #2588
* Fix lib_phpQuery:
  * Replace `split()` by `explode()` for PHP7 compatibility https://php.net/str-split
  * Fix for documents with a `<head>` tag more complicated, like `<head profile="http://www.w3.org/1999/xhtml/vocab">`