### PR TITLE
Implement negation for searching by date intervals

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -720,6 +720,38 @@ SQL;
 					$values[] = $filter->getMaxPubdate();
 				}
 
+				//Negation of date intervals must be combined by OR
+				if ($filter->getNotMinDate() || $filter->getNotMaxDate()) {
+					$sub_search .= 'AND (';
+					if ($filter->getNotMinDate()) {
+						$sub_search .= $alias . 'id < ?';
+						$values[] = "{$filter->getNotMinDate()}000000";
+						if ($filter->getNotMaxDate()) {
+							$sub_search .= ' OR ';
+						}
+					}
+					if ($filter->getNotMaxDate()) {
+						$sub_search .= $alias . 'id > ?';
+						$values[] = "{$filter->getNotMaxDate()}000000";
+					}
+					$sub_search .= ') ';
+				}
+				if ($filter->getNotMinPubdate() || $filter->getNotMaxPubdate()) {
+					$sub_search .= 'AND (';
+					if ($filter->getNotMinPubdate()) {
+						$sub_search .= $alias . 'date < ?';
+						$values[] = $filter->getNotMinPubdate();
+						if ($filter->getNotMaxPubdate()) {
+							$sub_search .= ' OR ';
+						}
+					}
+					if ($filter->getNotMaxPubdate()) {
+						$sub_search .= $alias . 'date > ?';
+						$values[] = $filter->getNotMaxPubdate();
+					}
+					$sub_search .= ') ';
+				}
+
 				if ($filter->getAuthor()) {
 					foreach ($filter->getAuthor() as $author) {
 						$sub_search .= 'AND ' . $alias . 'author LIKE ? ';

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -24,6 +24,10 @@ class FreshRSS_Search {
 	private $search;
 
 	private $not_intitle;
+	private $not_min_date;
+	private $not_max_date;
+	private $not_min_pubdate;
+	private $not_max_pubdate;
 	private $not_inurl;
 	private $not_author;
 	private $not_tags;
@@ -75,7 +79,9 @@ class FreshRSS_Search {
 	public function getMinDate() {
 		return $this->min_date;
 	}
-
+	public function getNotMinDate() {
+		return $this->not_min_date;
+	}
 	public function setMinDate($value) {
 		return $this->min_date = $value;
 	}
@@ -83,7 +89,9 @@ class FreshRSS_Search {
 	public function getMaxDate() {
 		return $this->max_date;
 	}
-
+	public function getNotMaxDate() {
+		return $this->not_max_date;
+	}
 	public function setMaxDate($value) {
 		return $this->max_date = $value;
 	}
@@ -91,9 +99,15 @@ class FreshRSS_Search {
 	public function getMinPubdate() {
 		return $this->min_pubdate;
 	}
+	public function getNotMinPubdate() {
+		return $this->not_min_pubdate;
+	}
 
 	public function getMaxPubdate() {
 		return $this->max_pubdate;
+	}
+	public function getNotMaxPubdate() {
+		return $this->not_max_pubdate;
 	}
 
 	public function getInurl() {
@@ -265,8 +279,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
-				list($this->max_date, $this->min_date) = parseDateInterval($dates[0]);
-				syslog(LOG_DEBUG, __method__ . date('c', $this->min_date) . ' / ' . date('c', $this->max_date));
+				list($this->not_min_date, $this->not_max_date) = parseDateInterval($dates[0]);
 			}
 		}
 		return $input;
@@ -297,7 +310,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
-				list($this->max_pubdate, $this->min_pubdate) = parseDateInterval($dates[0]);
+				list($this->not_min_pubdate, $this->not_max_pubdate) = parseDateInterval($dates[0]);
 			}
 		}
 		return $input;

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -37,6 +37,9 @@ class FreshRSS_Search {
 
 		$input = preg_replace('/:&quot;(.*?)&quot;/', ':"\1"', $input);
 
+		$input = $this->parseNotPubdateSearch($input);
+		$input = $this->parseNotDateSearch($input);
+
 		$input = $this->parseNotIntitleSearch($input);
 		$input = $this->parseNotAuthorSearch($input);
 		$input = $this->parseNotInurlSearch($input);
@@ -257,6 +260,19 @@ class FreshRSS_Search {
 		return $input;
 	}
 
+	private function parseNotDateSearch($input) {
+		if (preg_match_all('/[!-]date:(?P<search>[^\s]*)/', $input, $matches)) {
+			$input = str_replace($matches[0], '', $input);
+			$dates = self::removeEmptyValues($matches['search']);
+			if (!empty($dates[0])) {
+				list($this->max_date, $this->min_date) = parseDateInterval($dates[0]);
+				syslog(LOG_DEBUG, __method__ . date('c', $this->min_date) . ' / ' . date('c', $this->max_date));
+			}
+		}
+		return $input;
+	}
+
+
 	/**
 	 * Parse the search string to find pubdate keyword and the search related
 	 * to it.
@@ -271,6 +287,17 @@ class FreshRSS_Search {
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
 				list($this->min_pubdate, $this->max_pubdate) = parseDateInterval($dates[0]);
+			}
+		}
+		return $input;
+	}
+
+	private function parseNotPubdateSearch($input) {
+		if (preg_match_all('/[!-]pubdate:(?P<search>[^\s]*)/', $input, $matches)) {
+			$input = str_replace($matches[0], '', $input);
+			$dates = self::removeEmptyValues($matches['search']);
+			if (!empty($dates[0])) {
+				list($this->max_pubdate, $this->min_pubdate) = parseDateInterval($dates[0]);
 			}
 		}
 		return $input;

--- a/docs/en/users/03_Main_view.md
+++ b/docs/en/users/03_Main_view.md
@@ -200,7 +200,7 @@ You can use the search field to further refine results:
 Be careful not to enter a space between the operator and the search value.
 
 Some operators can be used negatively, to exclude articles, with the same syntax as above, but prefixed by a `!` or `-`:
-`-author:name`, `-intitle:keyword`, `-inurl:keyword`, `-#tag`, `!keyword`.
+`-author:name`, `-intitle:keyword`, `-inurl:keyword`, `-#tag`, `!keyword`, `!date:2019`, `!date:P1W`, `!pubdate:P3d/`.
 
 It is also possible to combine keywords to create a more precise filter. For example, you can enter multiple instances of `author:`, `intitle:`, `inurl:`, `#`, and free-text.
 

--- a/docs/fr/users/03_Main_view.md
+++ b/docs/fr/users/03_Main_view.md
@@ -251,7 +251,7 @@ recherchée.
 
 Certains opérateurs peuvent être utilisé négativement, pour exclure des
 articles, avec la même syntaxe que ci-dessus, mais préfixé par `!` ou `-`
-:`-author:nom`, `-intitle:mot`, `-inurl:mot`, `-#tag`, `!mot`.
+:`-author:nom`, `-intitle:mot`, `-inurl:mot`, `-#tag`, `!mot`, `!date:2019`, `!date:P1W`, `!pubdate:P3d/`.
 
 Il est également possible de combiner les mots-clefs pour faire un filtrage
 encore plus précis, et il est autorisé d’avoir plusieurs instances de :

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -150,6 +150,7 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	public function provideDateSearch() {
 		return array(
 			array('date:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1172754000', '1210519800'),
+			array('!date:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1210519800', '1172754000'),
 			array('date:2007-03-01T13:00:00Z/P1Y2M10DT2H30M', '1172754000', '1210519799'),
 			array('date:P1Y2M10DT2H30M/2008-05-11T15:30:00Z', '1172754001', '1210519800'),
 			array('date:2007-03-01/2008-05-11', strtotime('2007-03-01'), strtotime('2008-05-12') - 1),
@@ -176,6 +177,7 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	public function providePubdateSearch() {
 		return array(
 			array('pubdate:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1172754000', '1210519800'),
+			array('!pubdate:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1210519800', '1172754000'),
 			array('pubdate:2007-03-01T13:00:00Z/P1Y2M10DT2H30M', '1172754000', '1210519799'),
 			array('pubdate:P1Y2M10DT2H30M/2008-05-11T15:30:00Z', '1172754001', '1210519800'),
 			array('pubdate:2007-03-01/2008-05-11', strtotime('2007-03-01'), strtotime('2008-05-12') - 1),

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -150,7 +150,6 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	public function provideDateSearch() {
 		return array(
 			array('date:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1172754000', '1210519800'),
-			array('!date:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1210519800', '1172754000'),
 			array('date:2007-03-01T13:00:00Z/P1Y2M10DT2H30M', '1172754000', '1210519799'),
 			array('date:P1Y2M10DT2H30M/2008-05-11T15:30:00Z', '1172754001', '1210519800'),
 			array('date:2007-03-01/2008-05-11', strtotime('2007-03-01'), strtotime('2008-05-12') - 1),
@@ -177,7 +176,6 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	public function providePubdateSearch() {
 		return array(
 			array('pubdate:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1172754000', '1210519800'),
-			array('!pubdate:2007-03-01T13:00:00Z/2008-05-11T15:30:00Z', '1210519800', '1172754000'),
 			array('pubdate:2007-03-01T13:00:00Z/P1Y2M10DT2H30M', '1172754000', '1210519799'),
 			array('pubdate:P1Y2M10DT2H30M/2008-05-11T15:30:00Z', '1172754001', '1210519800'),
 			array('pubdate:2007-03-01/2008-05-11', strtotime('2007-03-01'), strtotime('2008-05-12') - 1),


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/2866
Allow searching for e.g. `!date:P1W` to exlude all articles newer than one week.
More generally, allows exclusion of any date interval, such as `!pubdate:2019`, `-date:2020-01-01/P5d`, etc.
Can also be combined, e.g. `pubdate:2020-03 !pubdate:2020-03-15`