### PR TITLE
gitattributes: Enforce Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
https://www.git-scm.com/docs/gitattributes
Disable automatic end-of-line conversion from Unix to Windows, and enforces LF (Unix line endings).
We do not have any file type in the project that requires Windows line endings (e.g. PHP works fine on Windows with Linux line endings), but the automatic conversion makes it annoying to work on the same git local repository from different systems (e.g. hybrid Linux / Windows development)