### PR TITLE
Swap shortcuts for mark all articles as read / mark previous articles as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,7 @@
 		* Improved buffering strategy accordingly, with a loading animation while waiting for the first articles to arrive (e.g. complex / slow search) [#2845](https://github.com/FreshRSS/FreshRSS/pull/2845)
 		* To benefit from it, requires that the full Web stack allow efficient streaming / flushing of data. Check our reference [Docker + Traefik documentation](./Docker/README.md).
 	* Support RTL (right-to-left) languages [#2776](https://github.com/FreshRSS/FreshRSS/pull/2776)
-	* New keyboard shortcut <kbd>⇧ Shift</kbd>+<kbd>R</kbd> to park *previous* articles as read [#2843](https://github.com/FreshRSS/FreshRSS/pull/2843)
-		* *Marking all articles as read* is now achieved by <kbd>Alt ⎇</kbd>+<kbd>r</kbd> instead
+	* New keyboard shortcut <kbd>Alt ⎇</kbd>+<kbd>r</kbd> to park *previous* articles as read [#2843](https://github.com/FreshRSS/FreshRSS/pull/2843)
 	* In the statistics page, show feeds inactive for 1, 2, 3, 5 years [#2827](https://github.com/FreshRSS/FreshRSS/issues/2827)
 	* Reset FreshRSS page scroll when restoring a browser session, to avoid inadvertently marking as read new articles [#2842](https://github.com/FreshRSS/FreshRSS/pull/2842)
 	* Fix scrolling of labels dropdown [#2727](https://github.com/FreshRSS/FreshRSS/pull/2727)

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',	// TODO - Translation
 		'rss_view' => 'Open RSS view in a new tab',	// TODO - Translation
 		'see_on_website' => 'Navštívit původní webovou stránku',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> označí vše jako přečtené',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> označí vše jako přečtené',	// TODO - Translation
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Zkratky',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Wechsle zur Lese-Ansicht',
 		'rss_view' => 'Öffne RSS Ansicht in neuem Tab',
 		'see_on_website' => 'Auf der Original-Webseite ansehen',
-		'shift_for_all_read' => '+ <kbd>⇧ Umschalttaste</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd>, um alle Artikel als gelesen zu markieren.',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Umschalttaste</kbd>, um alle Artikel als gelesen zu markieren.',	// TODO - Translation
 		'skip_next_article' => 'Nächsten markieren ohne zu öffnen',
 		'skip_previous_article' => 'Vorherigen markieren ohne zu öffnen',
 		'title' => 'Tastenkombination',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',
 		'rss_view' => 'Open RSS view in a new tab',
 		'see_on_website' => 'See on original website',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> to mark all articles as read',
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> to mark all articles as read',
 		'skip_next_article' => 'Focus next without opening',
 		'skip_previous_article' => 'Focus previous without opening',
 		'title' => 'Shortcuts',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',	// TODO - Translation
 		'rss_view' => 'Open RSS view in a new tab',	// TODO - Translation
 		'see_on_website' => 'Ver en la web original',
-		'shift_for_all_read' => '+ <kbd>⇧ Mayúsculas</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> para marcar todos los artículos como leídos',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Mayúsculas</kbd> para marcar todos los artículos como leídos',	// TODO - Translation
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Atajos de teclado',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Basculer vers la vue lecture',
 		'rss_view' => 'Ouvrir le flux RSS dans un nouvel onglet',
 		'see_on_website' => 'Voir sur le site d’origine',
-		'shift_for_all_read' => '+ <kbd>⇧ Maj</kbd> pour marquer les articles précédents comme lus<br />+ <kbd>Alt ⎇</kbd> pour marquer tous les articles comme lus',
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> pour marquer les articles précédents comme lus<br />+ <kbd>⇧ Maj</kbd> pour marquer tous les articles comme lus',
 		'skip_next_article' => 'Passer au suivant sans ouvrir',
 		'skip_previous_article' => 'Passer au précédent sans ouvrir',
 		'title' => 'Raccourcis',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',	// TODO - Translation
 		'rss_view' => 'Open RSS view in a new tab',	// TODO - Translation
 		'see_on_website' => 'ראו את המקור באתר',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> על מנת לסמן את כל המאמרים כנקראו',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> על מנת לסמן את כל המאמרים כנקראו',	// TODO - Translation
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'קיצורי דרך',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',	// TODO - Translation
 		'rss_view' => 'Open RSS view in a new tab',	// TODO - Translation
 		'see_on_website' => 'Vai al sito fonte',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> per segnare tutti gli articoli come letti',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> per segnare tutti gli articoli come letti',	// TODO - Translation
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Comandi da tastiera',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => '읽기 모드로 전환',
 		'rss_view' => '새 탭에서 RSS 피드 열기',
 		'see_on_website' => '글이 게재된 웹사이트에서 보기',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> 를 누른 상태에선 모두 읽음으로 표시',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> 를 누른 상태에선 모두 읽음으로 표시',	// TODO - Translation
 		'skip_next_article' => '다음 글로 커서 이동',
 		'skip_previous_article' => '이전 글로 커서 이동',
 		'title' => '단축키',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Schakel naar leesaanzicht',
 		'rss_view' => 'Open RSS-aanzicht in een nieuwe tab',
 		'see_on_website' => 'Bekijk op originale website',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> om voorgaande artikelen als gelezen te markeren<br />+ <kbd>Alt ⎇</kbd> om alle artikelen als gelezen te markeren',
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> om voorgaande artikelen als gelezen te markeren<br />+ <kbd>⇧ Shift</kbd> om alle artikelen als gelezen te markeren',
 		'skip_next_article' => 'Volgend artikel focusen zonder openen',
 		'skip_previous_article' => 'Vorig artikel focusen zonder openen',
 		'title' => 'Verwijzingen',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Passar a la vista lectura',
 		'rss_view' => 'Dobrir la vista RSS dins un onglet novèl',
 		'see_on_website' => 'Veire al site d’origina',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> per marcar l’article precedent coma legit<br />+ <kbd>Alt ⎇</kbd> per marcar los articles coma legits',
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> per marcar l’article precedent coma legit<br />+ <kbd>⇧ Shift</kbd> per marcar los articles coma legits',
 		'skip_next_article' => 'Centrar sul seguent sens lo dobrir',
 		'skip_previous_article' => 'Centrar sul precedent sens lo dobrir',
 		'title' => 'Acorchis',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Mudar para o modo de leitura',
 		'rss_view' => 'Abrir visualização de RSS em uma nova aba',
 		'see_on_website' => 'Visualize o site original',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> para marcar todos os artigos como lido',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> para marcar todos os artigos como lido',	// TODO - Translation
 		'skip_next_article' => 'Focar o próximo sem abri-lo',
 		'skip_previous_article' => 'Focar o anterior sem abri-lo',
 		'title' => 'Atalhos',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',	// TODO - Translation
 		'rss_view' => 'Open RSS view in a new tab',	// TODO - Translation
 		'see_on_website' => 'See on original website',	// TODO - Translation
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> to mark all articles as read',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> to mark all articles as read',	// TODO - Translation
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Shortcuts',	// TODO - Translation

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Prepne do zobrazenia na čítanie',
 		'rss_view' => 'Otvorí zobrazenie RSS v novej záložke',
 		'see_on_website' => 'Zobrazí na webovej stránke',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> na označenie všetkých článkov ako prečítaných',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> na označenie všetkých článkov ako prečítaných',	// TODO - Translation
 		'skip_next_article' => 'Prejde na ďalší bez otvorenia',
 		'skip_previous_article' => 'Prejde na predošlý bez otvorenia',
 		'title' => 'Skratky',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => 'Switch to reading view',	// TODO - Translation
 		'rss_view' => 'Open RSS view in a new tab',	// TODO - Translation
 		'see_on_website' => 'Orijinal sitede göster',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> tuşu ile tüm makaleler okundu olarak işaretlenir',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> tuşu ile tüm makaleler okundu olarak işaretlenir',	// TODO - Translation
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Kısayollar',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -180,7 +180,7 @@ return array(
 		'reading_view' => '切换到阅读视图',
 		'rss_view' => '在新标签中打开 RSS 视图',
 		'see_on_website' => '在原网站中查看',
-		'shift_for_all_read' => '+ <kbd>⇧ Shift</kbd> to mark previous articles as read<br />+ <kbd>Alt ⎇</kbd> 可以将全部文章设为已读',	// TODO - Translation
+		'shift_for_all_read' => '+ <kbd>Alt ⎇</kbd> to mark previous articles as read<br />+ <kbd>⇧ Shift</kbd> 可以将全部文章设为已读',	// TODO - Translation
 		'skip_next_article' => '跳转到下一篇文章而不打开',
 		'skip_previous_article' => '跳转到上一篇文章而不打开',
 		'title' => '快捷键',

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -793,9 +793,9 @@ function init_shortcuts() {
 			}
 			if (k === s.mark_read) {
 				if (ev.altKey) {
-					document.querySelector('.nav_menu .read_all').click();
-				} else if (ev.shiftKey) {
 					mark_previous_read(document.querySelector('.flux.current'));
+				} else if (ev.shiftKey) {
+					document.querySelector('.nav_menu .read_all').click();
 				} else {	// Toggle the read state
 					mark_read(document.querySelector('.flux.current'), false, false);
 				}


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/2865
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/2843
* <kbd>⇧ Shift</kbd>+<kbd>R</kbd> to mark all articles as read;
* <kbd>Alt ⎇</kbd>+<kbd>r</kbd> to mark previous articles as read.