### PR TITLE
pause automatic updates during upgrade

### DIFF
--- a/docs/en/admins/07_LinuxUpdate.md
+++ b/docs/en/admins/07_LinuxUpdate.md
@@ -4,6 +4,22 @@ This tutorial demonstrates commands for updating FreshRSS. It assumes that your 
 
 **Note that FreshRSS contains a built-in update system.** It's easier to use if you don't understand the commands that follow. It's available through the web interface of your FreshRSS installation, Administration → Update.
 
+## Pausing automatic feed updates
+
+If [Automatic Feed Updating](08_FeedUpdates.md) has been configured, temporarily suspend the automatic feed updates during the upgrade process.
+
+Before performing the upgrade:
+
+1. cron method: run `sudo crontab -e` and comment out the task
+2. systemd method: run `sudo systemctl stop freshrss.timer`
+
+After performing the upgrade:
+
+1. cron method: run `sudo crontab -e` and uncomment the task
+2. systemd method: run `sudo systemctl start freshrss.timer`
+
+You may wish to run the cron task or systemd unit (`freshrss.service`) immediately after the upgrade to ensure the automatic feed updates are functioning correctly.
+
 ## Using git
 
 **You must have used git to install FreshRSS to use this update method.**


### PR DESCRIPTION
Closes # (N/A - generic doc update)

Changes proposed in this pull request:

- Enhance upgrade documentation; temporarily suspend automatic updates during code upgrade process

How to test the feature manually:

1. Visual via Github md parser: https://github.com/troyengel/FreshRSS/blob/lnxupdate/docs/en/admins/07_LinuxUpdate.md

Pull request checklist:

- [x] clear commit messages
- [n/a] code manually tested
- [n/a] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
