### PR TITLE
Fix JS for statistics repartition select form

### DIFF
--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -163,9 +163,11 @@ function init_select_observers() {
 					const opt = s.options[s.selectedIndex],
 						url = opt.getAttribute('data-url');
 					if (url) {
-						s.form.querySelectorAll('[type=submit]').forEach(function (b) {
-								b.disabled = true;
-							});
+						s.disabled = true;
+						s.value = '';
+						if (s.form) {
+							s.form.querySelectorAll('[type=submit]').forEach(function (b) { b.disabled = true; });
+						}
 						location.href = url;
 					}
 				};

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -166,7 +166,9 @@ function init_select_observers() {
 						s.disabled = true;
 						s.value = '';
 						if (s.form) {
-							s.form.querySelectorAll('[type=submit]').forEach(function (b) { b.disabled = true; });
+							s.form.querySelectorAll('[type=submit]').forEach(function (b) {
+									b.disabled = true;
+								});
 						}
 						location.href = url;
 					}


### PR DESCRIPTION
Error was: `s.form is null in extra.js:166:7`
At the same time, disable the form and clears the value while waiting for the next page to load, to better understand what is happening.