### PR TITLE
Expose podcast in API

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -75,11 +75,12 @@ class FreshRSS_Entry extends Minz_Model {
 					];
 				}
 			}
+			return $results;
 		} catch (Exception $ex) {
-			//Discard errors
+			return $results;
 		}
-		return $results;
 	}
+
 	public function link() {
 		return $this->link;
 	}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -76,6 +76,7 @@ class FreshRSS_Entry extends Minz_Model {
 				}
 			}
 		} catch (Exception $ex) {
+			//Discard errors
 		}
 		return $results;
 	}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -59,6 +59,26 @@ class FreshRSS_Entry extends Minz_Model {
 	public function content() {
 		return $this->content;
 	}
+	public function enclosures() {
+		$results = [];
+		try {
+			if ($this->content != '') {
+				$dom = new DOMDocument();
+				$dom->loadHTML($this->content, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
+				$xpath = new DOMXpath($dom);
+				$enclosures = $xpath->query('//div[@class="enclosure"]/p[@class="enclosure-content"]/*[@src]');
+				foreach ($enclosures as $enclosure) {
+					$results[] = [
+						'url' => $enclosure->getAttribute('src'),
+						'type' => $enclosure->getAttribute('data-type'),
+						'length' => $enclosure->getAttribute('data-length'),
+					];
+				}
+			}
+		} catch (Exception $ex) {
+		}
+		return $results;
+	}
 	public function link() {
 		return $this->link;
 	}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -62,7 +62,7 @@ class FreshRSS_Entry extends Minz_Model {
 	public function enclosures() {
 		$results = [];
 		try {
-			if ($this->content != '') {
+			if (strpos($this->content, '<p class="enclosure-content') !== false) {
 				$dom = new DOMDocument();
 				$dom->loadHTML($this->content, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
 				$xpath = new DOMXpath($dom);

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -373,13 +373,18 @@ class FreshRSS_Feed extends Minz_Model {
 						$elinks[$elink] = true;
 						$mime = strtolower($enclosure->get_type());
 						$medium = strtolower($enclosure->get_medium());
+						$length = $enclosure->get_length();
 						if ($medium === 'image' || strpos($mime, 'image/') === 0) {
 							$enclosureContent .= '<p class="enclosure-content"><img src="' . $elink . '" alt="" /></p>';
 						} elseif ($medium === 'audio' || strpos($mime, 'audio/') === 0) {
 							$enclosureContent .= '<p class="enclosure-content"><audio preload="none" src="' . $elink
+								. ($length == null ? '' : '" data-length="' . intval($length))
+								. '" data-type="' . htmlspecialchars($mime, ENT_COMPAT, 'UTF-8')
 								. '" controls="controls"></audio> <a download="" href="' . $elink . '">💾</a></p>';
 						} elseif ($medium === 'video' || strpos($mime, 'video/') === 0) {
 							$enclosureContent .= '<p class="enclosure-content"><video preload="none" src="' . $elink
+								. ($length == null ? '' : '" data-length="' . intval($length))
+								. '" data-type="' . htmlspecialchars($mime, ENT_COMPAT, 'UTF-8')
 								. '" controls="controls"></video> <a download="" href="' . $elink . '">💾</a></p>';
 						} elseif ($medium != '' || strpos($mime, 'application/') === 0 || strpos($mime, 'text/') === 0) {
 							$enclosureContent .= '<p class="enclosure-content"><a download="" href="' . $elink . '">💾</a></p>';

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -508,6 +508,18 @@ function entriesToArray($entries) {
 				//'htmlUrl' => $line['f_website'],
 			),
 		);
+		foreach ($entry->enclosures() as $enclosure) {
+			if (!empty($enclosure['url']) && !empty($enclosure['type'])) {
+				$media = [
+						'href' => $enclosure['url'],
+						'type' => $enclosure['type'],
+					];
+				if (!empty($enclosure['length'])) {
+					$media['length'] = intval($enclosure['length']);
+				}
+				$item['enclosure'][] = $media;
+			}
+		}
 		$author = $entry->authors(true);
 		$author = trim($author, '; ');
 		if ($author != '') {


### PR DESCRIPTION
Expose RSS enclosures in our API, e.g. for clients supporting podcasts:

```json
"enclosure": [
        {
          "href": "https://audio.ausha.co/omERrsrWzE1O.mp3?t=1585735204",
          "type": "audio/mpeg",
          "length": 13721712
        }
      ],
```

https://blog.martindoms.com/2009/10/16/using-the-google-reader-api-part-2

View in [News+](https://github.com/noinnion/newsplus)
![Screenshot_20200412-233915_News+](https://user-images.githubusercontent.com/1008324/79081145-eacac380-7d1a-11ea-9f32-09b0590342bf.jpg)

![Screenshot_20200412-222914_News+](https://user-images.githubusercontent.com/1008324/79081133-dab2e400-7d1a-11ea-9431-4b930c58d9fc.jpg)