### PR TITLE
Reduce DB locks

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -462,7 +462,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				break;
 			}
 		}
-		if (!$noCommit) {
+		if (!$noCommit && ($nb_new_articles > 0 || $updated_feeds > 0)) {
 			if (!$entryDAO->inTransaction()) {
 				$entryDAO->beginTransaction();
 			}


### PR DESCRIPTION
Do not lock the DB to update it when there is nothing to commit.
This should reduce the risk of seeing some `database is locked` errors.