### PR TITLE
Fix CSS Edge glitch in archiving options

### DIFF
--- a/p/scripts/category.js
+++ b/p/scripts/category.js
@@ -143,6 +143,7 @@ function archiving() {
 		if (e.target.id === 'use_default_purge_options') {
 			slider.querySelectorAll('.archiving').forEach(function (element) {
 				element.hidden = e.target.checked;
+				if (!e.target.checked) element.style.visibility = 'visible'; 	//Help for Edge 44
 			});
 		}
 	});


### PR DESCRIPTION
With Edge, only setting `.hidden = false` does not make the element and sub-elements properly visible.
Should not make any difference for other browsers.

## Example of glitch in Edge
![image](https://user-images.githubusercontent.com/1008324/79618043-475a2400-8109-11ea-91c8-de2b9a3f26ed.png)

## Fixed
![image](https://user-images.githubusercontent.com/1008324/79618079-63f65c00-8109-11ea-85d1-05cf29c6cf89.png)
