### PR TITLE
Turn off autocaptialization on the username field to improve mobile UX.

### DIFF
--- a/app/views/auth/formLogin.phtml
+++ b/app/views/auth/formLogin.phtml
@@ -10,7 +10,7 @@
 
 		<div class="form-group">
 			<label for="username"><?= _t('gen.auth.username') ?></label>
-			<input type="text" id="username" name="username" autocomplete="username" size="16" required="required" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autofocus="autofocus" autocaptialize=off/>
+			<input type="text" id="username" name="username" autocomplete="username" size="16" required="required" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autofocus="autofocus" autocapitalize="off" />
 		</div>
 
 		<div class="form-group">

--- a/app/views/auth/formLogin.phtml
+++ b/app/views/auth/formLogin.phtml
@@ -10,7 +10,7 @@
 
 		<div class="form-group">
 			<label for="username"><?= _t('gen.auth.username') ?></label>
-			<input type="text" id="username" name="username" autocomplete="username" size="16" required="required" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autofocus="autofocus" />
+			<input type="text" id="username" name="username" autocomplete="username" size="16" required="required" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autofocus="autofocus" autocaptialize=off/>
 		</div>
 
 		<div class="form-group">

--- a/app/views/auth/register.phtml
+++ b/app/views/auth/register.phtml
@@ -6,7 +6,7 @@
 
 		<div class="form-group">
 			<label for="new_user_name"><?= _t('gen.auth.username'), '<br />', _i('help'), ' ', _t('gen.auth.username.format') ?></label>
-			<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autocaptialize=off />
+			<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autocapitalize="off" />
 		</div>
 
 		<?php if ($this->show_email_field) { ?>

--- a/app/views/auth/register.phtml
+++ b/app/views/auth/register.phtml
@@ -6,7 +6,7 @@
 
 		<div class="form-group">
 			<label for="new_user_name"><?= _t('gen.auth.username'), '<br />', _i('help'), ' ', _t('gen.auth.username.format') ?></label>
-			<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" />
+			<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autocaptialize=off />
 		</div>
 
 		<?php if ($this->show_email_field) { ?>


### PR DESCRIPTION
Closes #2384

Changes proposed in this pull request:

- Add autocaptialize=off to the username <input> tag so mobile browsers will not autocap usernames 

How to test the feature manually:

1. Log out
2. Log in with mobile browser
3. Profit. 

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
