### PR TITLE
Enhance the way help elements are displayed

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -621,7 +621,7 @@ function printStep3() {
 					<input type="password" id="passwordPlain" name="passwordPlain" pattern=".{7,}" autocomplete="off" <?= $auth_type === 'form' ? ' required="required"' : '' ?> tabindex="5" />
 					<a class="btn toggle-password" data-toggle="passwordPlain"><?= FreshRSS_Themes::icon('key') ?></a>
 				</div>
-				<?= _i('help') ?> <?= _t('install.auth.password_format') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('install.auth.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>
 			</div>
 		</div>

--- a/app/views/auth/register.phtml
+++ b/app/views/auth/register.phtml
@@ -5,8 +5,9 @@
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 
 		<div class="form-group">
-			<label for="new_user_name"><?= _t('gen.auth.username'), '<br />', _i('help'), ' ', _t('gen.auth.username.format') ?></label>
+			<label for="new_user_name"><?= _t('gen.auth.username') ?></label>
 			<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autocapitalize="off" />
+			<p class="help"><?= _i('help') ?> <?= _t('gen.auth.username.format') ?></p>
 		</div>
 
 		<?php if ($this->show_email_field) { ?>
@@ -19,12 +20,14 @@
 		<?php } ?>
 
 		<div class="form-group">
-			<label for="new_user_passwordPlain"><?= _t('gen.auth.password'), '<br />', _i('help'), ' ', _t('gen.auth.password.format') ?></label>
+			<label for="new_user_passwordPlain"><?= _t('gen.auth.password') ?></label>
 			<div class="stick">
 				<input type="password" id="new_user_passwordPlain" name="new_user_passwordPlain" required="required" autocomplete="new-password" pattern=".{7,}" />
 				<a class="btn toggle-password" data-toggle="new_user_passwordPlain"><?= _i('key') ?></a>
 			</div>
 			<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>
+			<p class="help"><?= _i('help') ?> <?= _t('gen.auth.password.format') ?></p>
+
 		</div>
 
 		<?php if ($this->show_tos_checkbox) { ?>

--- a/app/views/configure/archiving.phtml
+++ b/app/views/configure/archiving.phtml
@@ -6,7 +6,7 @@
 	<form method="post" action="<?= _url('configure', 'archiving') ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<legend><?= _t('conf.archiving') ?></legend>
-		<p><?= _i('help') ?> <?= _t('conf.archiving.help') ?></p>
+		<p class="help"><?= _i('help') ?> <?= _t('conf.archiving.help') ?></p>
 
 		<div class="form-group">
 			<label class="group-name" for="ttl_default"><?= _t('conf.archiving.ttl') ?></label>
@@ -132,7 +132,7 @@
 			<div class="group-controls">
 				<input type="hidden" name="optimiseDatabase" value="1" />
 				<button type="submit" class="btn btn-important"><?= _t('conf.archiving.optimize') ?></button>
-				<?= _i('help') ?> <?= _t('conf.archiving.optimize_help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('conf.archiving.optimize_help') ?></p>
 			</div>
 		</div>
 	</form>

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -11,7 +11,7 @@
 			<label class="group-name" for="posts_per_page"><?= _t('conf.reading.articles_per_page') ?></label>
 			<div class="group-controls">
 				<input type="number" id="posts_per_page" name="posts_per_page" value="<?= FreshRSS_Context::$user_conf->posts_per_page ?>" min="5" max="500" data-leave-validation="<?= FreshRSS_Context::$user_conf->posts_per_page ?>"/>
-				<?= _i('help') ?> <?= _t('conf.reading.number_divided_when_reader') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('conf.reading.number_divided_when_reader') ?></p>
 			</div>
 		</div>
 

--- a/app/views/configure/system.phtml
+++ b/app/views/configure/system.phtml
@@ -25,7 +25,7 @@
 			<label class="group-name" for="max-registrations"><?= _t('admin.system.registration.number') ?></label>
 			<div class="group-controls">
 				<input type="number" id="max-registrations" name="max-registrations" value="<?= FreshRSS_Context::$system_conf->limits['max_registrations'] ?>" min="0" data-leave-validation="<?= FreshRSS_Context::$system_conf->limits['max_registrations'] ?>"/>
-				<?= _i('help') ?> <?= _t('admin.system.registration.help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('admin.system.registration.help') ?></p>
 			</div>
 		</div>
 
@@ -74,7 +74,7 @@
 			<label class="group-name" for="cookie-duration"><?= _t('admin.system.cookie-duration.number') ?></label>
 			<div class="group-controls">
 				<input type="number" id="cookie-duration" name="cookie-duration" value="<?= FreshRSS_Context::$system_conf->limits['cookie_duration'] ?>" min="0" data-leave-validation="<?= FreshRSS_Context::$system_conf->limits['cookie_duration'] ?>"/>
-				<?= _i('help') ?> <?= _t('admin.system.cookie-duration.help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('admin.system.cookie-duration.help') ?></p>
 			</div>
 		</div>
 

--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -69,15 +69,12 @@
 			<label class="group-name" for="http_user"><?= _t('sub.feed.auth.username') ?></label>
 			<div class="group-controls">
 				<input type="text" name="http_user" id="http_user" class="extend" value="<?= empty($auth['username']) ? ' ' : $auth['username'] ?>" autocomplete="off" />
+				<p class="help"><?= _i('help') ?> <?= _t('sub.feed.auth.help') ?></p>
 			</div>
 
 			<label class="group-name" for="http_pass"><?= _t('sub.feed.auth.password') ?></label>
 			<div class="group-controls">
 				<input type="password" name="http_pass" id="http_pass" class="extend" value="<?= $auth['password'] ?>" autocomplete="new-password" />
-			</div>
-
-			<div class="group-controls">
-				<?= _i('help') ?> <?= _t('sub.feed.auth.help') ?>
 			</div>
 		</div>
 

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -21,7 +21,7 @@
 			<label class="group-name" for="position"><?= _t('sub.category.position') ?></label>
 			<div class="group-controls">
 				<input type="number" name="position" id="position" min="1" value="<?= $this->category->attributes('position') ?>" />
-				<?= _i('help') ?> <?= _t('sub.category.position_help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('sub.category.position_help') ?></p>
 			</div>
 		</div>
 

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -254,7 +254,7 @@
 			<label class="group-name" for="http_user_feed<?= $this->feed->id() ?>"><?= _t('sub.feed.auth.username') ?></label>
 			<div class="group-controls">
 				<input type="text" name="http_user_feed<?= $this->feed->id() ?>" id="http_user_feed<?= $this->feed->id() ?>" class="extend" value="<?= empty($auth['username']) ? ' ' : $auth['username'] ?>" autocomplete="off" />
-				<?= _i('help') ?> <?= _t('sub.feed.auth.help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('sub.feed.auth.help') ?></p>
 			</div>
 
 			<label class="group-name" for="http_pass_feed<?= $this->feed->id() ?>"><?= _t('sub.feed.auth.password') ?></label>
@@ -278,7 +278,7 @@
 					<input type="text" name="path_entries" id="path_entries" class="extend" value="<?= $this->feed->pathEntries() ?>" placeholder="<?= _t('gen.short.blank_to_disable') ?>" />
 					<a id="popup-preview-selector" class="btn" href="<?= _url('feed', 'contentSelectorPreview', 'id', $this->feed->id(), 'selector', 'selector-token') ?>"><?= _i('look') ?></a>
 				</div>
-				<?= _i('help') ?> <?= _t('sub.feed.css_help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('sub.feed.css_help') ?></p>
 			</div>
 		</div>
 
@@ -347,7 +347,7 @@
 						echo htmlspecialchars($filterRead->getRawInput(), ENT_NOQUOTES, 'UTF-8'), PHP_EOL;
 					}
 				?></textarea>
-				<?= _i('help') ?> <?= _t('sub.feed.filteractions.help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('sub.feed.filteractions.help') ?></p>
 			</div>
 		</div>
 
@@ -364,13 +364,13 @@
 				<a class="btn btn-important" href="<?= _url('feed', 'clearCache', 'id', $this->feed->id()) ?>">
 					<?= _t('sub.feed.maintenance.clear_cache') ?>
 				</a>
-				<?= _i('help') ?> <?= _t('sub.feed.maintenance.clear_cache_help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('sub.feed.maintenance.clear_cache_help') ?></p>
 			</div>
 			<div class="group-controls">
 				<a class="btn btn-important" href="<?= _url('feed', 'reload', 'id', $this->feed->id()) ?>">
 					<?= _t('sub.feed.maintenance.reload_articles') ?>
 				</a>
-				<?= _i('help') ?> <?= _t('sub.feed.maintenance.reload_articles_help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('sub.feed.maintenance.reload_articles_help') ?></p>
 			</div>
 		</div>
 	</form>

--- a/app/views/user/details.phtml
+++ b/app/views/user/details.phtml
@@ -51,7 +51,7 @@
                     <input type="password" id="newPasswordPlain" name="newPasswordPlain" autocomplete="new-password" pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
                     <a class="btn toggle-password" data-toggle="password-<?= $this->username; ?>"><?= _i('key') ?></a>
                 </div>
-                <?= _i('help'); ?> <?= _t('admin.user.password_format') ?>
+                <p class="help"><?= _i('help'); ?> <?= _t('admin.user.password_format') ?></p>
             </div>
         </div>
 

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -53,7 +53,7 @@
 					<input type="password" id="new_user_passwordPlain" name="new_user_passwordPlain" autocomplete="new-password" pattern=".{7,}" />
 					<a class="btn toggle-password" data-toggle="new_user_passwordPlain"><?= _i('key') ?></a>
 				</div>
-				<?= _i('help') ?> <?= _t('admin.user.password_format') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('admin.user.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>
 			</div>
 		</div>

--- a/app/views/user/profile.phtml
+++ b/app/views/user/profile.phtml
@@ -43,7 +43,7 @@
 					<input type="password" id="newPasswordPlain" name="newPasswordPlain" autocomplete="new-password" pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
 					<a class="btn toggle-password" data-toggle="newPasswordPlain"><?= _i('key') ?></a>
 				</div>
-				<?= _i('help') ?> <?= _t('conf.profile.password_format') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('conf.profile.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>
 			</div>
 		</div>
@@ -55,7 +55,7 @@
 			<div class="group-controls">
 				<input type="text" id="token" name="token" value="<?= $token ?>" placeholder="<?= _t('gen.short.blank_to_disable') ?>"<?php
 					echo FreshRSS_Auth::accessNeedsAction() ? '' : ' disabled="disabled"'; ?> data-leave-validation="<?= $token ?>"/>
-				<?= _i('help') ?> <?= _t('admin.auth.token_help') ?>
+				<p class="help"><?= _i('help') ?> <?= _t('admin.auth.token_help') ?></p>
 				<kbd><?= Minz_Url::display(array('a' => 'rss', 'params' => array('user' => Minz_Session::param('currentUser'), 'token' => $token, 'hours' => FreshRSS_Context::$user_conf->since_hours_posts_per_rss)), 'html', true) ?></kbd>
 			</div>
 		</div>
@@ -81,7 +81,7 @@
 						<input type="password" id="apiPasswordPlain" name="apiPasswordPlain" autocomplete="new-password" pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
 						<a class="btn toggle-password" data-toggle="apiPasswordPlain"><?= _i('key') ?></a>
 					</div>
-					<?= _i('help') ?> <kbd><a href="../api/"><?= Minz_Url::display('/api/', 'html', true) ?></a></kbd>
+					<p class="help"><?= _i('help') ?> <kbd><a href="../api/"><?= Minz_Url::display('/api/', 'html', true) ?></a></kbd></p>
 				</div>
 			</div>
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -59,6 +59,10 @@ p {
 	font-size: 1em;
 }
 
+p.help {
+	margin: 5px 0 0.5em !important;
+}
+
 sup {
 	line-height: 25px;
 	position: relative;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -59,8 +59,8 @@ p {
 	font-size: 1em;
 }
 
-p.help {
-	margin: 5px 0 0.5em !important;
+p.help, .prompt p.help {
+	margin: 5px 0 0.5em;
 }
 
 sup {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -59,6 +59,10 @@ p {
 	font-size: 1em;
 }
 
+p.help {
+	margin: 5px 0 0.5em !important;
+}
+
 sup {
 	line-height: 25px;
 	position: relative;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -59,8 +59,8 @@ p {
 	font-size: 1em;
 }
 
-p.help {
-	margin: 5px 0 0.5em !important;
+p.help, .prompt p.help {
+	margin: 5px 0 0.5em;
 }
 
 sup {


### PR DESCRIPTION
Closes https://github.com/FreshRSS/FreshRSS/issues/2886

Changes proposed in this pull request:

- Move help under elements instead of being at the right. I feel it's more elegant, specially for view very limited in size, like side panel.
- Homogenize some help placement in some views (register, add-feed-by-get…)

How to test the feature manually:

1. Just… go to the views. 

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

Here is some comparative screenshot (doesn't include all changes). I updated the whole UI, and not just the side panels. I felt it's more homogeneous this way (and, personally, I like the result), but I can limit this change only to side panels if wanted.

→ _app/views/helpers/feed/update.phtml_
- Before
<img width="622" alt="feed_update_before" src="https://user-images.githubusercontent.com/1971659/79699571-9aaaae80-8290-11ea-834d-309ece8f964a.png">
<img width="400" alt="feed_reload_before" src="https://user-images.githubusercontent.com/1971659/79699718-73a0ac80-8291-11ea-911a-f677b115c3e9.png">

- After
<img width="631" alt="feed_update_after" src="https://user-images.githubusercontent.com/1971659/79699574-9ed6cc00-8290-11ea-9b19-a91605c011e2.png">
<img width="427" alt="feed_reload_after" src="https://user-images.githubusercontent.com/1971659/79699722-7a2f2400-8291-11ea-952d-bb8633df038d.png">


→ _app/views/user/profile.phtml_ & _app/views/user/details.phtml_
- Before 
<img width="623" alt="user_before" src="https://user-images.githubusercontent.com/1971659/79699676-46ec9500-8291-11ea-82af-58913adb71f7.png">

- After
<img width="465" alt="user_after" src="https://user-images.githubusercontent.com/1971659/79699681-4e13a300-8291-11ea-87d3-b0fb34224aea.png">

→ _app/views/auth/register.phtml_
- Before
<img width="437" alt="register_before" src="https://user-images.githubusercontent.com/1971659/79699809-19ecb200-8292-11ea-8584-f254588a12f5.png">

- After
<img width="422" alt="register_after" src="https://user-images.githubusercontent.com/1971659/79699814-1eb16600-8292-11ea-88f5-26493e7e8b06.png">
