### PR TITLE
Fix for "Flash Of Unstyled Content" and slow loading in the Firefox

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -9,6 +9,7 @@ if (_t('gen.dir') === 'rtl') {
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="initial-scale=1.0" />
 		<?= self::headStyle() ?>
+		<script>/* Firefox FOUC Fix */</script>
 		<script id="jsonVars" type="application/json">
 <?php $this->renderHelper('javascript_vars'); ?>
 		</script>


### PR DESCRIPTION
Closes #2912

Changes proposed in this pull request:

- Adds commented but otherwise empty <script> tag to layout.phtml HTML between styles and actual scripts. This stops Firefox to loading scripts first, fixes FOUC and improves performance.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
