### PR TITLE
Don't check email if feature disabled or for admin

### DIFF
--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -54,7 +54,9 @@ class FreshRSS extends Minz_FrontController {
 			Minz_ExtensionManager::enableByList($ext_list);
 		}
 
-		self::checkEmailValidated();
+		if ($system_conf->force_email_validation && !FreshRSS_Auth::hasAccess('admin')) {
+			self::checkEmailValidated();
+		}
 
 		Minz_ExtensionManager::callHook('freshrss_init');
 	}


### PR DESCRIPTION
Closes #2902

Changes proposed in this pull request:

- disable email validation if `force_email_validation` is false
- disable email validation for admins

How to test the feature manually:

1. set a `email_validation_token` token for your admin user and set `force_email_validation` to true
1. you should be able to access the main page
1. set a `email_validation_token` token on a non-admin user and set `force_email_validation` to false
1. you should be able to access the main page

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
