### PR TITLE
#2671 Apache reverse proxy

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -354,24 +354,19 @@ server {
 ### Alternative reverse proxy using [apache 2.4](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)
 
 Here is an example of a configuration file for running FreshRSS behind an Apache reverse proxy (as a subdirectory).
-You need a working SSL configuration and the Apache modules `proxy` and `proxy_http` installed.
+You need a working SSL configuration and the Apache modules `proxy` and `proxy_http` installed (depends on your distribution) and enabled (```a2enmod proxy proxy_http```).
 
 ```
 ProxyPreserveHost On
-ProxyPass /freshrss http://127.0.0.1:8080
-ProxyPassReverse /freshrss http://127.0.0.1:8080
 
+<Location /freshrss/>
+  ProxyPass http://127.0.0.1:9797/
+  ProxyPassReverse http://127.0.0.1:9797/
+  RequestHeader set X-Forwarded-Prefix "/freshrss"
+  RequestHeader set X-Forwarded-Proto "https"
+  Require all granted
+  Options none
+</Location>
 
-
-<Proxy http://127.0.0.1:8080>
-
-    RequestHeader set X-Forwarded-Proto "https"
-    RequestHeader set X-Forwarded-Prefix "/freshrss"
-
-    Require all granted
-
-    Options none
-
-</Proxy>
 
 ```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -354,7 +354,7 @@ server {
 ### Alternative reverse proxy using [apache 2.4](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)
 
 Here is an example of a configuration file for running FreshRSS behind an Apache reverse proxy (as a subdirectory).
-You have to have a working SSL configuration and the apache modules proxy and proxy_http installed
+You need a working SSL configuration and the Apache modules `proxy` and `proxy_http` installed.
 
 ```
 ProxyPreserveHost On

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -353,7 +353,7 @@ server {
 ```
 ### Alternative reverse proxy using [apache 2.4](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)
 
-Here is an example of configuration to run FreshRSS behind an Apache reverse proxy (as subdirectory).
+Here is an example of a configuration file for running FreshRSS behind an Apache reverse proxy (as a subdirectory).
 You have to have a working SSL configuration and the apache modules proxy and proxy_http installed
 
 ```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -351,3 +351,27 @@ server {
 	}
 }
 ```
+### Alternative reverse proxy using [apache 2.4](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)
+
+Here is an example of configuration to run FreshRSS behind an Apache reverse proxy (as subdirectory).
+You have to have a working SSL configuration and the apache modules proxy and proxy_http installed
+
+```
+ProxyPreserveHost On
+ProxyPass /freshrss http://127.0.0.1:8080
+ProxyPassReverse /freshrss http://127.0.0.1:8080
+
+
+
+<Proxy http://127.0.0.1:8080>
+
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Prefix "/freshrss"
+
+    Require all granted
+
+    Options none
+
+</Proxy>
+
+```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -351,10 +351,10 @@ server {
 	}
 }
 ```
-### Alternative reverse proxy using [apache 2.4](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)
+### Alternative reverse proxy using [Apache 2.4](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)
 
 Here is an example of a configuration file for running FreshRSS behind an Apache reverse proxy (as a subdirectory).
-You need a working SSL configuration and the Apache modules `proxy` and `proxy_http` installed (depends on your distribution) and enabled (```a2enmod proxy proxy_http```).
+You need a working SSL configuration and the Apache modules `proxy`, `proxy_http` and and `headers`installed (depends on your distribution) and enabled (```a2enmod proxy proxy_http headers```).
 
 ```
 ProxyPreserveHost On
@@ -367,6 +367,4 @@ ProxyPreserveHost On
   Require all granted
   Options none
 </Location>
-
-
 ```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -360,8 +360,8 @@ You need a working SSL configuration and the Apache modules `proxy`, `proxy_http
 ProxyPreserveHost On
 
 <Location /freshrss/>
-  ProxyPass http://127.0.0.1:9797/
-  ProxyPassReverse http://127.0.0.1:9797/
+  ProxyPass http://127.0.0.1:8080/
+  ProxyPassReverse http://127.0.0.1:8080/
   RequestHeader set X-Forwarded-Prefix "/freshrss"
   RequestHeader set X-Forwarded-Proto "https"
   Require all granted


### PR DESCRIPTION
Adding sample configuration for using apache as a reverse proxy

Closes #2671

Changes proposed in this pull request:

- Adding a sample configuration to use apache as a reverse proxy



Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [X] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
