### PR TITLE
WebSub move fixes

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -427,7 +427,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				$entryDAO->commit();
 			}
 
-			if ($pubSubHubbubEnabled && $feed->hubUrl() && $feed->selfUrl()) {	//selfUrl has priority for WebSub
+			if ($pubsubhubbubEnabledGeneral && $feed->hubUrl() && $feed->selfUrl()) {	//selfUrl has priority for WebSub
 				if ($feed->selfUrl() !== $url) {	// https://github.com/pubsubhubbub/PubSubHubbub/wiki/Moving-Feeds-or-changing-Hubs
 					$selfUrl = checkUrl($feed->selfUrl());
 					if ($selfUrl) {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -695,7 +695,11 @@ class FreshRSS_Feed extends Minz_Model {
 
 	//Parameter true to subscribe, false to unsubscribe.
 	public function pubSubHubbubSubscribe($state) {
-		$url = $this->selfUrl ? $this->selfUrl : $this->url;
+		if ($state) {
+			$url = $this->selfUrl ? $this->selfUrl : $this->url;
+		} else {
+			$url = $this->url;	//Always use current URL during unsubscribe
+		}
 		if ($url && (Minz_Request::serverIsPublic(FreshRSS_Context::$system_conf->base_url) || !$state)) {
 			$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
 			$hubFile = @file_get_contents($hubFilename);


### PR DESCRIPTION
Small fixes related to when WebSub changes address:
* When unsubscribing, one must use the current/old address, not the newly found selfUrl;
* This change https://github.com/FreshRSS/FreshRSS/pull/2659#discussion_r347263068 was wrong, so reverted to the first version. We must obey the rules also for feeds for which the initial WebSub enabling is not finished, otherwise we never have a chance to redirect the feed to the proper selfUrl.