### PR TITLE
Fix filenames for files exported with CLI

### DIFF
--- a/cli/export-opml-for-user.php
+++ b/cli/export-opml-for-user.php
@@ -19,7 +19,7 @@ fwrite(STDERR, 'FreshRSS exporting OPML for user “' . $username . "”…\n");
 $importController = new FreshRSS_importExport_Controller();
 
 $ok = false;
-$ok = $importController->exportFile(true, false, false, array(), 0, $username);
+$ok = $importController->exportFile($username, true, false, false, array(), 0);
 
 invalidateHttpCache($username);
 

--- a/cli/export-zip-for-user.php
+++ b/cli/export-zip-for-user.php
@@ -20,10 +20,9 @@ fwrite(STDERR, 'FreshRSS exporting ZIP for user “' . $username . "”…\n");
 $importController = new FreshRSS_importExport_Controller();
 
 $ok = false;
+$number_entries = empty($options['max-feed-entries']) ? 100 : intval($options['max-feed-entries']);
 try {
-	$ok = $importController->exportFile(true, true, true, true,
-		empty($options['max-feed-entries']) ? 100 : intval($options['max-feed-entries']),
-		$username);
+	$ok = $importController->exportFile($username, true, true, true, true, $number_entries);
 } catch (FreshRSS_ZipMissing_Exception $zme) {
 	fail('FreshRSS error: Lacking php-zip extension!');
 }


### PR DESCRIPTION
Changes proposed in this pull request:

Filenames were created with the username of the current user. However,
when we export the files with the CLI, the current user is "_".

This commit makes the username always required in the `exportFile`
method so we make sure to always manipulate a real value. Consequently,
the filenames can be formatted correctly.

Obviously, this has absolutely no impacts since the CLI doesn't consider
the HTTP headers. It just makes things a bit more clear. It's a first
step to remove the concept of "default user".

How to test the feature manually:

Just make sure the export feature still works both with the web interface and CLI.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
