### PR TITLE
2914 show last login date

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -616,6 +616,7 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 			'language' => $userConfiguration->language,
 			'mail_login' => $userConfiguration->mail_login,
 			'is_admin' => $userConfiguration->is_admin,
+			'last_login' => $userConfiguration->last_login ? date('c', $userConfiguration->last_login) : null,
 		);
 	}
 }

--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -81,7 +81,10 @@ class FreshRSS_Auth {
 	 */
 	public static function giveAccess() {
 		$current_user = Minz_Session::param('currentUser');
+		/** @var Minz_Configuration $user_conf */
 		$user_conf = get_user_configuration($current_user);
+		$user_conf->last_login = time();
+		$user_conf->save();
 		if ($user_conf == null) {
 			self::$login_ok = false;
 			return false;

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -204,5 +204,7 @@ return array(
 		'username' => 'Username',
 		'users' => 'Users',
 		'user_list' => 'List of users',
+		'last_login' => 'Last login',
+		'never_loggedin' => 'Never logged in'
 	),
 );

--- a/app/views/user/details.phtml
+++ b/app/views/user/details.phtml
@@ -45,6 +45,13 @@
         </div>
 
         <div class="form-group">
+            <label class="group-name"><?= _t('admin.user.last_login') ?></label>
+            <div class="group-controls">
+                <?= $this->details['last_login'] ? $this->details['last_login'] : _t('admin.user.never_loggedin') ?>
+            </div>
+        </div>
+
+        <div class="form-group">
             <label class="group-name" for="newPasswordPlain"><?= _t('admin.user.password_form') ?></label>
             <div class="group-controls">
                 <div class="stick">

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -77,6 +77,7 @@
 				<th><?= _t('admin.user.feed_count') ?></th>
 				<th><?= _t('admin.user.article_count') ?></th>
 				<th><?= _t('admin.user.database_size') ?></th>
+                <th><?= _t('admin.user.last_login') ?></th>
 				<th>&nbsp;</th>
 			</tr>
 		</thead>
@@ -90,6 +91,7 @@
 					<td><?= format_number($values['feed_count']) ?></td>
 					<td><?= format_number($values['article_count']) ?></td>
 					<td><?= format_bytes($values['database_size']) ?></td>
+                    <td><?= $values['last_login'] ? $values['last_login'] : _t('admin.user.never_loggedin') ?></td>
 					<td><a href="<?= _url('user', 'details', 'username', $username) ?>">Details</a></td>
 				</tr>
 			<?php endforeach ?>

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -77,7 +77,7 @@
 				<th><?= _t('admin.user.feed_count') ?></th>
 				<th><?= _t('admin.user.article_count') ?></th>
 				<th><?= _t('admin.user.database_size') ?></th>
-                <th><?= _t('admin.user.last_login') ?></th>
+				<th><?= _t('admin.user.last_login') ?></th>
 				<th>&nbsp;</th>
 			</tr>
 		</thead>
@@ -91,7 +91,7 @@
 					<td><?= format_number($values['feed_count']) ?></td>
 					<td><?= format_number($values['article_count']) ?></td>
 					<td><?= format_bytes($values['database_size']) ?></td>
-                    <td><?= $values['last_login'] ? $values['last_login'] : _t('admin.user.never_loggedin') ?></td>
+					<td><?= $values['last_login'] ? $values['last_login'] : _t('admin.user.never_loggedin') ?></td>
 					<td><a href="<?= _url('user', 'details', 'username', $username) ?>">Details</a></td>
 				</tr>
 			<?php endforeach ?>

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -95,4 +95,5 @@ return array (
 	'html5_notif_timeout' => 0,
 	'show_nav_buttons' => true,
 	'extensions_enabled' => array(),
+	'last_login' => null,
 );


### PR DESCRIPTION
Closes #2914

Changes proposed in this pull request:

- Adds last login date to default user configuration file
- Displays last login date on manage users and user detail screen
- Writes current timestamp to user configuration when user logs in.

How to test the feature manually:

1. Create user.
2. Confirm 'Last Login' column on manage users screen and detail screen is 'Never Logged In'
3. Login as new user
4. Confirm 'Last Login' displays correct timesamp.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

I was wondering about time formatting. I have stuck with the basic ISO 8601 format, but it isn't the most user friendly display. How are dates handled generally within the project?

![Screenshot from 2020-04-30 10-33-28](https://user-images.githubusercontent.com/5101742/80695751-41cbe900-8ace-11ea-968d-fcf2f560e340.png)

![Screenshot from 2020-04-30 10-33-52](https://user-images.githubusercontent.com/5101742/80695758-442e4300-8ace-11ea-8799-5703893301be.png)

