### PR TITLE
Always put checkbox labels on the right

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -232,14 +232,18 @@
 				</label>
 			</div>
 		</div>
-		<div class="form-group">
-			<label class="group-name" for="pubsubhubbub"><?= _t('sub.feed.websub') ?></label>
-			<div class="group-controls">
-				<label class="checkbox" for="pubsubhubbub">
-					<input type="checkbox" name="pubsubhubbub" id="pubsubhubbub" disabled="disabled" value="1"<?= $this->feed->pubSubHubbubEnabled() ? ' checked="checked"' : '' ?> />
-				</label>
+
+		<?php if ($this->feed->pubSubHubbubEnabled()) { ?>
+			<div class="form-group">
+				<div class="group-controls">
+					<label class="checkbox" for="pubsubhubbub">
+						<input type="checkbox" name="pubsubhubbub" id="pubsubhubbub" disabled="disabled" value="1" checked />
+						<?= _t('sub.feed.websub') ?>
+					</label>
+				</div>
 			</div>
-		</div>
+		<?php } ?>
+
 		<div class="form-group form-actions">
 			<div class="group-controls">
 				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
@@ -310,9 +314,11 @@
 		</div>
 
 		<div class="form-group">
-			<label class="group-name" for="clear_cache"><?= _t('sub.feed.clear_cache') ?></label>
 			<div class="group-controls">
-				<input type="checkbox" name="clear_cache" id="clear_cache" value="1"<?= $this->feed->attributes('clear_cache') ? ' checked="checked"' : '' ?> />
+				<label class="checkbox" for="clear_cache">
+					<input type="checkbox" name="clear_cache" id="clear_cache" value="1"<?= $this->feed->attributes('clear_cache') ? ' checked="checked"' : '' ?> />
+					<?= _t('sub.feed.clear_cache') ?>
+				</label>
 			</div>
 		</div>
 


### PR DESCRIPTION
Changes proposed in this pull request:

There were two checkboxes with labels set on the left: it was looking
weird and inconsistent with the rest of the application.

Also, since the Websub checkbox cannot be checked by the user (i.e. it
is entirely managed by the backend), I just hide the line when Websub is
disabled. It would be better to never show the checkbox and adapt the
label to say something like "Websub is enabled for this feed", but I
prefer to avoid changing all the locales.

Last point: an input should always have one and only one label. Websub
checkbox had two labels, which can be hardly supported by assistive
technologies.

Reference: https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form#Multiple_labels

How to test the feature manually:

1. Check Websub checkbox is hidden for feeds with Websub disabled
2. Check Websub label is on the right of the checkbox for feeds with Websub disabled
3. Check the "always empty cache" label is on the right of the checkbox

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
