### PR TITLE
Fix warning with FeedReader

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -32,6 +32,7 @@ if (PHP_INT_SIZE < 8) {	//32-bit
 		return str_pad(gmp_strval(gmp_init($dec, 10), 16), 16, '0', STR_PAD_LEFT);
 	}
 	function hex2dec($hex) {
+		if (!ctype_xdigit($hex)) return 0;
 		return gmp_strval(gmp_init($hex, 16), 10);
 	}
 } else {	//64-bit
@@ -39,6 +40,7 @@ if (PHP_INT_SIZE < 8) {	//32-bit
 		return str_pad(dechex($dec), 16, '0', STR_PAD_LEFT);
 	}
 	function hex2dec($hex) {
+		if (!ctype_xdigit($hex)) return 0;
 		return hexdec($hex);
 	}
 }
@@ -729,7 +731,7 @@ function streamContentsItems($e_ids, $order) {
 	header('Content-Type: application/json; charset=UTF-8');
 
 	foreach ($e_ids as $i => $e_id) {
-		if (strpos($e_id, '/') !== null) {
+		if (strpos($e_id, '/') !== false) {
 			$e_id = hex2dec(basename($e_id));	//Strip prefix 'tag:google.com,2005:reader/item/'
 		}
 		$e_ids[$i] = $e_id;
@@ -753,7 +755,7 @@ function streamContentsItems($e_ids, $order) {
 
 function editTag($e_ids, $a, $r) {
 	foreach ($e_ids as $i => $e_id) {
-		if (strpos($e_id, '/') !== null) {
+		if (strpos($e_id, '/') !== false) {
 			$e_id = hex2dec(basename($e_id));	//Strip prefix 'tag:google.com,2005:reader/item/'
 		}
 		$e_ids[$i] = $e_id;


### PR DESCRIPTION
FeedReader 2.10.0 sends something like
`T=c.......5cZZZZZZZZZZZZZZZZZ&r=user/-/state/com.google/read&i=-/tag%3Agoogle.com&i=-/2005%3Areader/item/0005a4b97779db22`
to `/api/greader.php/reader/api/0/edit-tag`

The first `i=-/tag/google.com` is wrong and cannot be converted to an
entry ID.
This resulted in:

> PHP Warning:  gmp_init(): Unable to convert variable to GMP - string
is not an integer in /var/www/FreshRSS/p/api/greader.php on line 35