### PR TITLE
API relaxed detection of short/long item ID forms

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -731,10 +731,10 @@ function streamContentsItems($e_ids, $order) {
 	header('Content-Type: application/json; charset=UTF-8');
 
 	foreach ($e_ids as $i => $e_id) {
-		if (strpos($e_id, '/') !== false) {
-			$e_id = hex2dec(basename($e_id));	//Strip prefix 'tag:google.com,2005:reader/item/'
+		// https://feedhq.readthedocs.io/en/latest/api/terminology.html#items
+		if (!ctype_digit($e_id) || $e_id[0] === '0') {
+			$e_ids[$i] = hex2dec(basename($e_id));	//Strip prefix 'tag:google.com,2005:reader/item/'
 		}
-		$e_ids[$i] = $e_id;
 	}
 
 	$entryDAO = FreshRSS_Factory::createEntryDao();
@@ -755,10 +755,9 @@ function streamContentsItems($e_ids, $order) {
 
 function editTag($e_ids, $a, $r) {
 	foreach ($e_ids as $i => $e_id) {
-		if (strpos($e_id, '/') !== false) {
-			$e_id = hex2dec(basename($e_id));	//Strip prefix 'tag:google.com,2005:reader/item/'
+		if (!ctype_digit($e_id) || $e_id[0] === '0') {
+			$e_ids[$i] = hex2dec(basename($e_id));	//Strip prefix 'tag:google.com,2005:reader/item/'
 		}
-		$e_ids[$i] = $e_id;
 	}
 
 	$entryDAO = FreshRSS_Factory::createEntryDao();


### PR DESCRIPTION
#Fix https://github.com/FreshRSS/FreshRSS/issues/2956
Bug/feature introduced by https://github.com/FreshRSS/FreshRSS/pull/2947 (which was following the specification better)

The original code `strpos($e_id, '/') !== null` was wrong (it can never be null, only false or integer), but the idea was to check whether the client was sending a short form (decimal) or long form of the ID (hexadecimal with prefixes including slashes). Since it has not given problem until my recent typo fix, this means that the short form is apparently not used by the clients we tested. But now that we are back to following the specification better, it looks like a client such as Reeder 4 is sending an hexadecimal form without a prefix, which breaks the detection.

This patch changes the detection, which should work in all known cases AND comply with the specification

https://feedhq.readthedocs.io/en/latest/api/terminology.html#items