### PR TITLE
Fix bad relogging clients

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -934,10 +934,11 @@ FreshRSS_Context::$user_conf = null;
 if ($user !== '') {
 	FreshRSS_Context::$user_conf = get_user_configuration($user);
 	Minz_ExtensionManager::init();
-	Minz_Translate::init(FreshRSS_Context::$user_conf->language);
-
 	if (FreshRSS_Context::$user_conf != null) {
+		Minz_Translate::init(FreshRSS_Context::$user_conf->language);
 		Minz_ExtensionManager::enableByList(FreshRSS_Context::$user_conf->extensions_enabled);
+	} else {
+		Minz_Translate::init();
 	}
 } else {
 	Minz_Translate::init();

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -929,7 +929,7 @@ ini_set('session.use_cookies', '0');
 register_shutdown_function('session_destroy');
 Minz_Session::init('FreshRSS');
 
-$user = $pathInfos[1] === 'accounts' ? null : authorizationToUser();
+$user = $pathInfos[1] === 'accounts' ? '' : authorizationToUser();
 FreshRSS_Context::$user_conf = null;
 if ($user !== '') {
 	FreshRSS_Context::$user_conf = get_user_configuration($user);

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -929,7 +929,7 @@ ini_set('session.use_cookies', '0');
 register_shutdown_function('session_destroy');
 Minz_Session::init('FreshRSS');
 
-$user = authorizationToUser();
+$user = $pathInfos[1] === 'accounts' ? null : authorizationToUser();
 FreshRSS_Context::$user_conf = null;
 if ($user !== '') {
 	FreshRSS_Context::$user_conf = get_user_configuration($user);


### PR DESCRIPTION
Some clients (like EasyRSS) are still using the old HTTP Authorization
header after having logged to log in with another user.
We should not attempt to process Authorization headers during a login
request