### PR TITLE
Fix Docker FRESHRSS_ENV for cron

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -14,6 +14,7 @@ if [ -n "$CRON_MIN" ]; then
 		echo "export TZ=$TZ"
 		echo "export COPY_LOG_TO_SYSLOG=$COPY_LOG_TO_SYSLOG"
 		echo "export COPY_SYSLOG_TO_STDERR=$COPY_SYSLOG_TO_STDERR"
+		echo "export FRESHRSS_ENV=$FRESHRSS_ENV"
 	) >/var/www/FreshRSS/Docker/env.txt
 	crontab -l | sed -r "\\#FreshRSS#s#^[^ ]+ #$CRON_MIN #" | crontab -
 fi


### PR DESCRIPTION
cron job was not passed the environment variable FRESHRSS_ENV as it should
This resulted in messages during cron to not be logged according to FRESHRSS_ENV level