### PR TITLE
Delay the feeds actualization start notice

### DIFF
--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -22,7 +22,6 @@ ob_start();
 echo 'Results: ', "\n";	//Buffered
 
 $begin_date = date_create('now');
-notice('FreshRSS starts feeds actualization at ' . $begin_date->format('c'));
 
 // Set the header params ($_GET) to call the FRSS application.
 $_GET['c'] = 'feed';
@@ -36,6 +35,8 @@ $app = new FreshRSS();
 $system_conf = Minz_Configuration::get('system');
 $system_conf->auth_type = 'none';  // avoid necessity to be logged in (not saved!)
 define('SIMPLEPIE_SYSLOG_ENABLED', $system_conf->simplepie_syslog_enabled);
+
+notice('FreshRSS starts feeds actualization at ' . $begin_date->format('c'));
 
 // make sure the PHP setup of the CLI environment is compatible with FreshRSS as well
 performRequirementCheck($system_conf->db['type']);

--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -36,7 +36,7 @@ $system_conf = Minz_Configuration::get('system');
 $system_conf->auth_type = 'none';  // avoid necessity to be logged in (not saved!)
 define('SIMPLEPIE_SYSLOG_ENABLED', $system_conf->simplepie_syslog_enabled);
 
-notice('FreshRSS starts feeds actualization at ' . $begin_date->format('c'));
+notice('FreshRSS starting feeds actualization at ' . $begin_date->format('c'));
 
 // make sure the PHP setup of the CLI environment is compatible with FreshRSS as well
 performRequirementCheck($system_conf->db['type']);


### PR DESCRIPTION
Move the actualization start notice until after SIMPLEPIE_SYSLOG_ENABLED is defined.

Closes #2973


Changes proposed in this pull request:

- Move the actualization start notice until after SIMPLEPIE_SYSLOG_ENABLED is defined.
-
-

How to test the feature manually:

1. Run feed actualizer
2. Notice that the no warning is logged

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
