### PR TITLE
getContentByParsing follow HTML redirections

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -398,7 +398,7 @@ class FreshRSS_Entry extends Minz_Model {
 				$metas = $doc->find('meta[http-equiv][content]');
 				foreach ($metas as $meta) {
 					if (strtolower($meta->getAttribute('http-equiv')) === 'refresh') {
-						$refresh = preg_replace('/^.*?\bhttp/i', 'http', $meta->getAttribute('content'));
+						$refresh = preg_replace('/^[0-9.; ]*\s*(url\s*=)?\s*/i', '', trim($meta->getAttribute('content')));
 						$refresh = SimplePie_Misc::absolutize_url($refresh, $url);
 						if ($refresh != false && $refresh !== $url) {
 							return self::getContentByParsing($refresh, $path, $attributes, $maxRedirs - 1);

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -397,7 +397,7 @@ class FreshRSS_Entry extends Minz_Model {
 				//Follow any HTML redirection
 				$metas = $doc->find('meta[http-equiv][content]');
 				foreach ($metas as $meta) {
-					if (strtolower($meta->getAttribute('http-equiv')) === 'refresh') {
+					if (strtolower(trim($meta->getAttribute('http-equiv'))) === 'refresh') {
 						$refresh = preg_replace('/^[0-9.; ]*\s*(url\s*=)?\s*/i', '', trim($meta->getAttribute('content')));
 						$refresh = SimplePie_Misc::absolutize_url($refresh, $url);
 						if ($refresh != false && $refresh !== $url) {


### PR DESCRIPTION
Add the ability to follow HTML redirections in getContentByParsing:

```html
<meta http-equiv="Refresh" content="1; url=https://example.net/article123.html" />
```

Example of feed: `http://rss.careerjet.dk/rss?s=Elev&l=Danmark`
It contains article URLs that have an HTML redirection.
Example of CSS selector: `.advertise_compact`