### PR TITLE
Revert FOUC fix

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -9,7 +9,6 @@ if (_t('gen.dir') === 'rtl') {
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="initial-scale=1.0" />
 		<?= self::headStyle() ?>
-		<script>/* Firefox FOUC Fix */</script>
 		<script id="jsonVars" type="application/json">
 <?php $this->renderHelper('javascript_vars'); ?>
 		</script>


### PR DESCRIPTION
Revert https://github.com/FreshRSS/FreshRSS/pull/2913
I have not seen any difference with/without this fix, and it might be due to the fact that is is blocked by CSP.
At least in Chrome, it generates CSP warnings.
If it should be re-introduced, see warning suggestions:

> Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-gcoEgwf1rABkUXPaVY2M1RH34tUHWGDn9nAAn/kGYUE='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.