### PR TITLE
Fix fetch preview

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -700,7 +700,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		//Extract all feed entries from database, load complete content and store them back in database.
 		$entries = $entryDAO->listWhere('f', $feed_id, FreshRSS_Entry::STATE_ALL, 'DESC', 0);
 
-		//We need another DB connexion in parallel
+		//We need another DB connection in parallel
 		Minz_ModelPdo::$usesSharedPdo = false;
 		$entryDAO2 = FreshRSS_Factory::createEntryDao();
 

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -755,8 +755,9 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 
 		//Get first entry (syntax robust for Generator or Array)
 		foreach ($entries as $myEntry) {
-			$entry = $myEntry;
-			break;
+			if ($entry == null) {
+				$entry = $myEntry;
+			}
 		}
 
 		if ($entry == null) {

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -258,12 +258,10 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 	}
 
 	public function searchById($id) {
-		$sql = 'SELECT * FROM `_feed` WHERE id=?';
+		$sql = 'SELECT * FROM `_feed` WHERE id=:id';
 		$stm = $this->pdo->prepare($sql);
-
-		$values = array($id);
-
-		$stm->execute($values);
+		$stm->bindParam(':id', $id, PDO::PARAM_INT);
+		$stm->execute();
 		$res = $stm->fetchAll(PDO::FETCH_ASSOC);
 		$feed = self::daoToFeed($res);
 


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/2923
In MariaDB / MySQL, we cannot start a new query if we have not consumed
the previous buffered query fully.