### PR TITLE
fix: Fix .stick class for older Webkit versions

### DIFF
--- a/p/themes/Alternative-Dark/template.css
+++ b/p/themes/Alternative-Dark/template.css
@@ -220,6 +220,11 @@ td.numeric {
 	white-space: nowrap;
 }
 
+.stick > input {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .stick > input.long {
 	flex-shrink: 1;
 }

--- a/p/themes/Alternative-Dark/template.rtl.css
+++ b/p/themes/Alternative-Dark/template.rtl.css
@@ -220,6 +220,11 @@ td.numeric {
 	white-space: nowrap;
 }
 
+.stick > input {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .stick > input.long {
 	flex-shrink: 1;
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -225,6 +225,11 @@ td.numeric {
 	white-space: nowrap;
 }
 
+.stick > input {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .stick > input.long {
 	flex-shrink: 1;
 }

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -225,6 +225,11 @@ td.numeric {
 	white-space: nowrap;
 }
 
+.stick > input {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .stick > input.long {
 	flex-shrink: 1;
 }


### PR DESCRIPTION
See https://github.com/FreshRSS/FreshRSS/pull/2938#issuecomment-632429861

Changes proposed in this pull request:

Remove the top and bottom margins on `.stick .input`s for older versions of the Webkit engine. 

How to test the feature manually:

1. Open the main view with Safari or Gnome Web and check the search input is aligned with its submit button

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) (N/A)
- [x] documentation updated (N/A)

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
