### PR TITLE
Fix memory leak when using lib_phpQuery

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -408,7 +408,9 @@ class FreshRSS_Entry extends Minz_Model {
 			}
 
 			$content = $doc->find($path);
-			return trim(sanitizeHTML($content->__toString(), $url));
+			$html = trim(sanitizeHTML($content->__toString(), $url));
+			phpQuery::unloadDocuments();
+			return $html;
 		} else {
 			throw new Exception();
 		}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -401,6 +401,7 @@ class FreshRSS_Entry extends Minz_Model {
 						$refresh = preg_replace('/^[0-9.; ]*\s*(url\s*=)?\s*/i', '', trim($meta->getAttribute('content')));
 						$refresh = SimplePie_Misc::absolutize_url($refresh, $url);
 						if ($refresh != false && $refresh !== $url) {
+							phpQuery::unloadDocuments();
 							return self::getContentByParsing($refresh, $path, $attributes, $maxRedirs - 1);
 						}
 					}


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/2952
This library keeps documents in static class, so it requires a special call to clean them.