### PR TITLE
[i18n] Add a `make pot` command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ endif
 rtl: ## Generate RTL CSS files
 	rtlcss -d p/themes && find . -type f -name '*.rtl.rtl.css' -delete
 
+.PHONY: pot
+pot: ## Generate POT templates for docs
+	cd docs && ../cli/translation-update.sh
+
 ##########
 ## HELP ##
 ##########


### PR DESCRIPTION
By analogy with <https://github.com/FreshRSS/FreshRSS/pull/2996>.
How to test the feature manually:

1. Have po4a installed (preferably 0.56 or higher, but that's not necessary to test the make command).
2. Run `make pot`.
3. Enjoy the new POT files.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/freshrss/freshrss/3006)
<!-- Reviewable:end -->
