### PR TITLE
Fix makefile when no local php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@ ifndef TAG
 endif
 
 PORT ?= 8080
-PHP := $(shell sh -c 'which php')
 
 ifdef NO_DOCKER
-	PHP = php
+	PHP = $(shell which php)
 else
 	PHP = docker run \
 		--rm \


### PR DESCRIPTION
The makefile did not work when there was no local php.

~Closes #~

Changes proposed in this pull request:

- Fix the use of the makefile when there is no local php

How to test the feature manually:

1. Type ```make start``` without PHP. You should see the problem.
2. Switch to the PR and do it again. There shouldn't be a problem

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] ~documentation updated~

