### PR TITLE
Fix PostgreSQL database auto-create with limited rights

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -21,7 +21,7 @@ class FreshRSS_DatabaseDAO extends Minz_ModelPdo {
 		try {
 			$sql = sprintf($SQL_CREATE_DB, empty($db['base']) ? '' : $db['base']);
 			return $this->pdo->exec($sql) !== false;
-		} catch (PDOException $e) {
+		} catch (Exception $e) {
 			$_SESSION['bd_error'] = $e->getMessage();
 			syslog(LOG_DEBUG, __method__ . ' warning: ' . $e->getMessage());
 			return false;
@@ -34,7 +34,7 @@ class FreshRSS_DatabaseDAO extends Minz_ModelPdo {
 			$stm = $this->pdo->query($sql);
 			$res = $stm->fetchAll(PDO::FETCH_COLUMN, 0);
 			return $res != false;
-		} catch (PDOException $e) {
+		} catch (Exception $e) {
 			$_SESSION['bd_error'] = $e->getMessage();
 			syslog(LOG_DEBUG, __method__ . ' warning: ' . $e->getMessage());
 			return false;

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -97,7 +97,7 @@ function initDb() {
 		try {
 			//First connection without database name to create the database
 			$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
-		} catch (PDOException $ex) {
+		} catch (Exception $ex) {
 			$databaseDAO = null;
 		}
 		//Restore final database parameters for auto-creation and for future connections

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -94,13 +94,19 @@ function initDb() {
 		//For first connection, use default database for PostgreSQL, empty database for MySQL / MariaDB:
 		$db['base'] = $db['type'] === 'pgsql' ? 'postgres' : '';
 		$conf->db = $db;
-		//First connection without database name to create the database
-		$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+		try {
+			//First connection without database name to create the database
+			$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+		} catch (PDOException $ex) {
+			$databaseDAO = null;
+		}
 		//Restore final database parameters for auto-creation and for future connections
 		$db['base'] = $dbBase;
 		$conf->db = $db;
-		//Perfom database auto-creation
-		$databaseDAO->create();
+		if ($databaseDAO != null) {
+			//Perfom database auto-creation
+			$databaseDAO->create();
+		}
 	}
 
 	//New connection with the database name


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3009
Install would fail if the user is not even allowed to connect to the default `postgres` database, because this is what is done to attempt to auto-create the FreshRSS database, so we need to catch this error.