### PR TITLE
Fix display_categories upgrade from 1.16.0

### DIFF
--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -183,7 +183,7 @@ class FreshRSS_ConfigurationSetter {
 	}
 
 	private function _display_categories(&$data, $value) {
-		if (!in_array($value, [ 'active', 'all', 'none' ])) {
+		if (!in_array($value, [ 'active', 'all', 'none' ], true)) { 
 			$value = $value === true ? 'all' : 'active';
 		}
 		$data['display_categories'] = $value;

--- a/app/Models/ConfigurationSetter.php
+++ b/app/Models/ConfigurationSetter.php
@@ -183,7 +183,7 @@ class FreshRSS_ConfigurationSetter {
 	}
 
 	private function _display_categories(&$data, $value) {
-		if (!in_array($value, [ 'active', 'all', 'none' ], true)) { 
+		if (!in_array($value, [ 'active', 'all', 'none' ], true)) {
 			$value = $value === true ? 'all' : 'active';
 		}
 		$data['display_categories'] = $value;


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3017
The property `'display_categories' => boolean,` in 1.16.0 is not properly converted to `'display_categories' => 'string',` in 1.16.1 due to a weak type comparison bug.