### PR TITLE
Fix display_categories upgrade from 1.16.0 again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2020-XX-XX FreshRSS 1.16.2-dev
 
 * Bug fixing
-	* Fix migration of the preference *Show categories unfolded by default* (from ≤ 1.16.0) to the new *Categories to unfold* [#3018](https://github.com/FreshRSS/FreshRSS/pull/3018)
+	* Fix migration of the preference *Show categories unfolded by default* (from ≤ 1.16.0) to the new *Categories to unfold* [#3019](https://github.com/FreshRSS/FreshRSS/pull/3019)
 
 
 ## 2020-05-30 FreshRSS 1.16.1

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -69,6 +69,11 @@ class FreshRSS_Context {
 			}
 			FreshRSS_Context::$user_conf->archiving = $archiving;
 		}
+
+		//Legacy < 1.16.1
+		if (!in_array(FreshRSS_Context::$user_conf->display_categories, [ 'active', 'all', 'none' ], true)) {
+			FreshRSS_Context::$user_conf->display_categories = FreshRSS_Context::$user_conf->display_categories === true ? 'all' : 'active';
+		}
 	}
 
 	/**


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3017
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/3018
There were two bugs. I forgot that `ConfigurationSetter.php` is not called when reading `config.php`