### PR TITLE
Add language detection when the user is not logged in

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -148,6 +148,8 @@ class FreshRSS_auth_Controller extends Minz_ActionController {
 					FreshRSS_FormAuth::deleteCookie();
 				}
 
+				Minz_Translate::init($conf->language);
+
 				// All is good, go back to the index.
 				Minz_Request::good(_t('feedback.auth.login.success'),
 				                   array('c' => 'index', 'a' => 'index'));
@@ -191,6 +193,8 @@ class FreshRSS_auth_Controller extends Minz_ActionController {
 				Minz_Session::_param('csrf');
 				FreshRSS_Auth::giveAccess();
 
+				Minz_Translate::init($conf->language);
+
 				Minz_Request::good(_t('feedback.auth.login.success'),
 				                   array('c' => 'index', 'a' => 'index'));
 			} else {
@@ -231,6 +235,7 @@ class FreshRSS_auth_Controller extends Minz_ActionController {
 
 		$this->view->show_tos_checkbox = file_exists(join_path(DATA_PATH, 'tos.html'));
 		$this->view->show_email_field = FreshRSS_Context::$system_conf->force_email_validation;
+		$this->view->preferred_language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
 		Minz_View::prependTitle(_t('gen.auth.registration.title') . ' · ');
 	}
 }

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -68,7 +68,7 @@ class FreshRSS extends Minz_FrontController {
 				// Basic protection against XSRF attacks
 				FreshRSS_Auth::removeAccess();
 				$http_referer = empty($_SERVER['HTTP_REFERER']) ? '' : $_SERVER['HTTP_REFERER'];
-				Minz_Translate::init('en');	//TODO: Better choice of fallback language
+				self::initI18n();
 				Minz_Error::error(403, array('error' => array(
 						_t('feedback.access.denied'),
 						' [HTTP_REFERER=' . htmlspecialchars($http_referer, ENT_NOQUOTES, 'UTF-8') . ']'
@@ -80,7 +80,7 @@ class FreshRSS extends Minz_FrontController {
 					!FreshRSS_Auth::hasAccess('admin'))
 				)) {
 				// Token-based protection against XSRF attacks, except for the login or self-create user forms
-				Minz_Translate::init('en');	//TODO: Better choice of fallback language
+				self::initI18n();
 				Minz_Error::error(403, array('error' => array(
 						_t('feedback.access.denied'),
 						' [CSRF]'
@@ -90,8 +90,11 @@ class FreshRSS extends Minz_FrontController {
 	}
 
 	private static function initI18n() {
-		Minz_Session::_param('language', FreshRSS_Context::$user_conf->language);
-		Minz_Translate::init(FreshRSS_Context::$user_conf->language);
+		$selected_language = FreshRSS_Auth::hasAccess() ? FreshRSS_Context::$user_conf->language : null;
+		$language = Minz_Translate::getLanguage($selected_language, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
+
+		Minz_Session::_param('language', $language);
+		Minz_Translate::init($language);
 	}
 
 	public static function loadStylesAndScripts() {

--- a/app/views/auth/register.phtml
+++ b/app/views/auth/register.phtml
@@ -5,6 +5,16 @@
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 
 		<div class="form-group">
+			<label for="new_user_language"><?= _t('admin.user.language') ?></label>
+			<select name="new_user_language" id="new_user_language">
+			<?php $languages = Minz_Translate::availableLanguages(); ?>
+			<?php foreach ($languages as $lang) { ?>
+			<option value="<?= $lang ?>"<?= $this->preferred_language === $lang ? ' selected="selected"' : '' ?>><?= _t('gen.lang.' . $lang) ?></option>
+			<?php } ?>
+			</select>
+		</div>
+
+		<div class="form-group">
 			<label for="new_user_name"><?= _t('gen.auth.username') ?></label>
 			<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off" pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" autocapitalize="off" />
 			<p class="help"><?= _i('help') ?> <?= _t('gen.auth.username.format') ?></p>

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -395,7 +395,7 @@ class Minz_Request {
 	/**
 	 * @return array
 	 */
-	public static function getPreferredLanguage() {
+	public static function getPreferredLanguages() {
 		if (preg_match_all('/(^|,)\s*(?P<lang>[^;,]+)/', static::getHeader('HTTP_ACCEPT_LANGUAGE'), $matches)) {
 			return $matches['lang'];
 		}

--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -63,6 +63,8 @@ class Minz_Translate {
 	public static function availableLanguages() {
 		$list_langs = array();
 
+		self::registerPath(APP_PATH . '/i18n');
+
 		foreach (self::$path_list as $path) {
 			$scan = scandir($path);
 			if (is_array($scan)) {
@@ -77,6 +79,31 @@ class Minz_Translate {
 		}
 
 		return array_unique($list_langs);
+	}
+
+	/**
+	 * Return the language to use in the application.
+	 * It returns the connected language if it exists then returns the first match from the
+	 * preferred languages then returns the default language
+	 * @param $user the connected user language (nullable)
+	 * @param $preferred an array of the preferred languages
+	 * @param $default the preferred language to use
+	 * @return a string containing the language to use
+	 */
+	public static function getLanguage($user, $preferred, $default) {
+		if (null !== $user) {
+			return $user;
+		}
+
+		$languages = Minz_Translate::availableLanguages();
+		foreach ($preferred as $language) {
+			$language = strtolower($language);
+			if (in_array($language, $languages, true)) {
+				return $language;
+			}
+		}
+
+		return $default;
 	}
 
 	/**


### PR DESCRIPTION
Changes proposed in this pull request:

- Add language detection from request headers when the user is not logged in
- Add language selection in the register form
- Fix notification language after successful login

How to test the feature manually:

1. Install 'Modify Header Value' extension on Firefox
2. Display FRSS page
3. Change 'Accept-Language' header value with the Firefox extension
4. Display FRSS page and check if the content is translated according to the header value

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] ~unit tests written (optional if too hard)~
- [ ] ~documentation updated~

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
