### PR TITLE
Change add feed action

### DIFF
--- a/app/Controllers/categoryController.php
+++ b/app/Controllers/categoryController.php
@@ -28,7 +28,7 @@ class FreshRSS_category_Controller extends Minz_ActionController {
 	 */
 	public function createAction() {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
-		$url_redirect = array('c' => 'subscription', 'a' => 'index');
+		$url_redirect = array('c' => 'subscription', 'a' => 'add');
 
 		$limits = FreshRSS_Context::$system_conf->limits;
 		$this->view->categories = $catDAO->listCategories(false);
@@ -58,6 +58,7 @@ class FreshRSS_category_Controller extends Minz_ActionController {
 			);
 
 			if ($catDAO->addCategory($values)) {
+				$url_redirect['a'] = 'index';
 				Minz_Request::good(_t('feedback.sub.category.created', $cat->name()), $url_redirect);
 			} else {
 				Minz_Request::bad(_t('feedback.sub.category.error'), $url_redirect);

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -67,6 +67,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		$cat_id = $cat == null ? FreshRSS_CategoryDAO::DEFAULTCATEGORYID : $cat->id();
 
 		$feed = new FreshRSS_Feed($url);	//Throws FreshRSS_BadUrl_Exception
+		$feed->_attributes('', $attributes);
 		$feed->_httpAuth($http_auth);
 		$feed->load(true);	//Throws FreshRSS_Feed_Exception, Minz_FileNotExistException
 		$feed->_category($cat_id);
@@ -90,7 +91,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 			'description' => $feed->description(),
 			'lastUpdate' => time(),
 			'httpAuth' => $feed->httpAuth(),
-			'attributes' => $attributes,
+			'attributes' => $feed->attributes(),
 		);
 
 		$id = $feedDAO->addFeed($values);

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -241,4 +241,11 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 	public function bookmarkletAction() {
 		Minz_View::prependTitle(_t('sub.title.subscription_tools') . ' . ');
 	}
+
+	/**
+	 * This action displays the page to add a new feed
+	 */
+	public function addAction() {
+		Minz_View::prependTitle(_t('sub.title.add') . ' . ');
+	}
 }

--- a/app/Models/Themes.php
+++ b/app/Models/Themes.php
@@ -71,6 +71,7 @@ class FreshRSS_Themes extends Minz_Model {
 	public static function alt($name) {
 		static $alts = array(
 			'add' => '✚',
+			'add-white' => '✚',
 			'all' => '☰',
 			'bookmark' => '★',
 			'bookmark-add' => '✚',

--- a/app/i18n/cz/gen.php
+++ b/app/i18n/cz/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Aktualizovat',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← Zpět na seznam RSS kanálů',
 		'cancel' => 'Zrušit',

--- a/app/i18n/cz/sub.php
+++ b/app/i18n/cz/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',	// TODO - Translation
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archivace',
 		'empty' => 'Vyprázdit kategorii',
 		'information' => 'Informace',
-		'new' => 'Nová kategorie',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'Název',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Import / export',	// TODO - Translation
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Přihlásit (FreshRSS bookmark)',
 		'import_export' => 'Import / export',	// TODO - Translation
 		'subscription_management' => 'Správa subskripcí',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Správa subskripcí',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Správa RSS kanálů',
 		'subscription_tools' => 'Subscription tools',	// TODO - Translation
 	),

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Aktualisieren',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Zurück',
 		'back_to_rss_feeds' => '← Zurück zu Ihren RSS-Feeds gehen',
 		'cancel' => 'Abbrechen',

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Kopieren Sie die folgende URL, um sie in einem externen Tool zu verwenden.',
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archivierung',
 		'empty' => 'Leere Kategorie',
 		'information' => 'Information',	// TODO - Translation
-		'new' => 'Neue Kategorie',
 		'position' => 'Reihenfolge',
 		'position_help' => 'Steuert die Kategoriesortierung',
 		'title' => 'Titel',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importieren / Exportieren',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Abonnieren (FreshRSS-Lesezeichen)',
 		'import_export' => 'Importieren / Exportieren',
 		'subscription_management' => 'Abonnementverwaltung',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Abonnementverwaltung',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Verwaltung der RSS-Feeds',
 		'subscription_tools' => 'Abonnement-Tools',
 	),

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Actualize',
+		'add' => 'Add',
 		'back' => '← Go back',
 		'back_to_rss_feeds' => '← Go back to your RSS feeds',
 		'cancel' => 'Cancel',

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archiving',
 		'empty' => 'Empty category',
 		'information' => 'Information',
-		'new' => 'New category',
 		'position' => 'Display position',
 		'position_help' => 'To control category sort order',
 		'title' => 'Title',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Import / export',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',
+		'add_feed' => 'Add a feed',
 		'bookmark' => 'Subscribe (FreshRSS bookmark)',
 		'import_export' => 'Import / export',
 		'subscription_management' => 'Subscriptions management',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Subscriptions management',
+		'add' => 'Add a feed/a category',
+		'add_category' => 'Add a category',
+		'add_feed' => 'Add a feed',
 		'feed_management' => 'RSS feeds management',
 		'subscription_tools' => 'Subscription tools',
 	),

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Actualizar',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Volver',
 		'back_to_rss_feeds' => '← regresar a tus fuentes RSS',
 		'cancel' => 'Cancelar',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',	// TODO - Translation
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archivo',
 		'empty' => 'Vaciar categoría',
 		'information' => 'Información',
-		'new' => 'Nueva categoría',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'Título',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importar / exportar',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Suscribirse (favorito FreshRSS)',
 		'import_export' => 'Importar / exportar',
 		'subscription_management' => 'Administración de suscripciones',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Administración de suscripciones',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Administración de fuentes RSS',
 		'subscription_tools' => 'Subscription tools',	// TODO - Translation
 	),

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Actualiser',
+		'add' => 'Ajouter',
 		'back' => '← Retour',
 		'back_to_rss_feeds' => '← Retour à vos flux RSS',
 		'cancel' => 'Annuler',

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'L\'ajout de flux et de catégories se fait désormais <a href=\'%s\'>ici</a>. Il est possible d\'y accéder depuis le menu de gauche ou depuis l\'icône ✚ présente sur la page principale.',
 	'api' => array(
 		'documentation' => 'Copier l’URL suivante dans l’outil qui utilisera l’API.',
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archivage',
 		'empty' => 'Catégorie vide',
 		'information' => 'Informations',
-		'new' => 'Nouvelle catégorie',
 		'position' => 'Position d’affichage',
 		'position_help' => 'Pour contrôler l’ordre de tri des catégories',
 		'title' => 'Titre',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importer / exporter',
 	),
 	'menu' => array(
+		'add' => 'Ajouter un flux/une catégorie',
+		'add_feed' => 'Ajouter un flux',
 		'bookmark' => 'S’abonner (bookmark FreshRSS)',
 		'import_export' => 'Importer / exporter',
 		'subscription_management' => 'Gestion des abonnements',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Gestion des abonnements',
+		'add' => 'Ajouter un flux/une catégorie',
+		'add_category' => 'Ajouter une catégorie',
+		'add_feed' => 'Ajouter un flux',
 		'feed_management' => 'Gestion des flux RSS',
 		'subscription_tools' => 'Outils d’abonnement',
 	),

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'מימוש',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← חזרה להזנות הRSS שלך',
 		'cancel' => 'ביטול',

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',	// TODO - Translation
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'ארכוב',
 		'empty' => 'Empty category',	// TODO - Translation
 		'information' => 'מידע',
-		'new' => 'קטגוריה חדשה',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'כותרת',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'יבוא / יצוא ',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'הרשמה (FreshRSS סימניית)',
 		'import_export' => 'יבוא / יצוא ',
 		'subscription_management' => 'ניהול הרשמות',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'ניהול הרשמות',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'ניהול הזנות RSS',
 		'subscription_tools' => 'Subscription tools',	// TODO - Translation
 	),

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Aggiorna',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← Indietro',
 		'cancel' => 'Annulla',

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',	// TODO - Translation
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archiviazione',
 		'empty' => 'Categoria vuota',
 		'information' => 'Informazioni',
-		'new' => 'Nuova categoria',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'Titolo',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importa / esporta',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Bookmark (trascina nei preferiti)',
 		'import_export' => 'Importa / esporta',
 		'subscription_management' => 'Gestione sottoscrizioni',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Gestione sottoscrizioni',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Gestione RSS feeds',
 		'subscription_tools' => 'Subscription tools',	// TODO - Translation
 	),

--- a/app/i18n/kr/gen.php
+++ b/app/i18n/kr/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => '새 글 가져오기',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← RSS 피드로 돌아가기',
 		'cancel' => '취소',

--- a/app/i18n/kr/sub.php
+++ b/app/i18n/kr/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => '외부 도구에서 API를 사용하기 위해서 아래 URL을 사용하세요.',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => '보관',
 		'empty' => '빈 카테고리',
 		'information' => '정보',
-		'new' => '새 카테고리',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => '제목',
@@ -102,6 +102,8 @@ return array(
 		'title' => '불러오기 / 내보내기',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => '구독하기 (FreshRSS 북마클릿)',
 		'import_export' => '불러오기 / 내보내기',
 		'subscription_management' => '구독 관리',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => '구독 관리',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'RSS 피드 관리',
 		'subscription_tools' => '구독 도구',
 	),

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Actualiseren',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Terug',
 		'back_to_rss_feeds' => '← Ga terug naar je RSS feeds',
 		'cancel' => 'Annuleren',

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Kopieer de volgende URL om deze in een externe toepassing te gebruiken.',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archiveren',
 		'empty' => 'Lege categorie',
 		'information' => 'Informatie',
-		'new' => 'Nieuwe categorie',
 		'position' => 'Weergavepositie',
 		'position_help' => 'Om de categorieweergave-sorteervolgorde te controleren',
 		'title' => 'Titel',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importeren / exporteren',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Abonneer (FreshRSS bladwijzer)',
 		'import_export' => 'Importeer / exporteer',
 		'subscription_management' => 'Abonnementenbeheer',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Abonnementenbeheer',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'RSS-feedbeheer',
 		'subscription_tools' => 'Hulpmiddelen voor abonnementen',
 	),

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Actualizar',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Tornar',
 		'back_to_rss_feeds' => '← Tornar a vòstres fluxes RSS',
 		'cancel' => 'Anullar',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copiatz l’URL seguenta per l’utilizaire dins d’una aisina extèrna.',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archivar',
 		'empty' => 'Categoria voida',
 		'information' => 'Informacions',
-		'new' => 'Nòva categoria',
 		'position' => 'Mostrar la posicion',
 		'position_help' => 'Per contrarotlar l’òrdre de tria de la categoria',
 		'title' => 'Títol',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importar / Exportar',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Sabonar (marcapagina FreshRSS)',
 		'import_export' => 'Importar / Exportar',
 		'subscription_management' => 'Gestion dels abonaments',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Gestion dels abonaments',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Gestion dels fluxes RSS',
 		'subscription_tools' => 'Aisinas d’abonament',
 	),

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Atualizar',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Voltar',
 		'back_to_rss_feeds' => '← Volte para o seu feeds RSS',
 		'cancel' => 'Cancelar',

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copie a seguinte URL para utilizar com uma ferramenta externa',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Arquivar',
 		'empty' => 'Categoria vazia',
 		'information' => 'Informações',
-		'new' => 'Nova categoria',
 		'position' => 'Posição de exibição',
 		'position_help' => 'Para controlar a ordem de exibição',
 		'title' => 'Título',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Importar / exportar',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Inscreva-se (FreshRSS favoritos)',
 		'import_export' => 'Importar / exportar',
 		'subscription_management' => 'Gerenciamento de inscrições',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Gerenciamento de inscrições',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Gerenciamento dos RSS feeds',
 		'subscription_tools' => 'Ferramentas de inscrição',
 	),

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Actualize',	// TODO - Translation
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← Go back to your RSS feeds',	// TODO - Translation
 		'cancel' => 'Cancel',	// TODO - Translation

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',	// TODO - Translation
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archivage',
 		'empty' => 'Empty category',	// TODO - Translation
 		'information' => 'Information',	// TODO - Translation
-		'new' => 'New category',	// TODO - Translation
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'Title',	// TODO - Translation
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Import / export',	// TODO - Translation
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Subscribe (FreshRSS bookmark)',	// TODO - Translation
 		'import_export' => 'Import / export',	// TODO - Translation
 		'subscription_management' => 'Subscriptions management',	// TODO - Translation
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Subscriptions management',	// TODO - Translation
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'RSS feeds management',	// TODO - Translation
 		'subscription_tools' => 'Subscription tools',	// TODO - Translation
 	),

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Aktualizovať',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← Späť na vaše RSS kanály',
 		'cancel' => 'Zrušiť',

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Skopírujte tento odkaz a použite ho v inom programe.',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Archiving',	// TODO - Translation
 		'empty' => 'Prázdna kategória',
 		'information' => 'Informácia',
-		'new' => 'Nová kategória',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'Názov',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'Import / export',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Odoberať (záložka FreshRSS)',
 		'import_export' => 'Import / export',
 		'subscription_management' => 'Správa odoberaných kanálov',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Správa odoberaných kanálov',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'Správa RSS kanálov',
 		'subscription_tools' => 'Nástroje na odoberanie kanálov',
 	),

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => 'Yenile',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← Go back',	// TODO - Translation
 		'back_to_rss_feeds' => '← RSS akışlarınız için geri gidin',
 		'cancel' => 'İptal',

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => 'Copy the following URL to use it within an external tool.',	// TODO - Translation
 		'title' => 'API',	// TODO - Translation
@@ -16,7 +17,6 @@ return array(
 		'archiving' => 'Arşiv',
 		'empty' => 'Boş kategori',
 		'information' => 'Bilgi',
-		'new' => 'Yeni kategori',
 		'position' => 'Display position',	// TODO - Translation
 		'position_help' => 'To control category sort order',	// TODO - Translation
 		'title' => 'Başlık',
@@ -102,6 +102,8 @@ return array(
 		'title' => 'İçe / dışa aktar',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => 'Abonelik (FreshRSS yer imleri)',
 		'import_export' => 'İçe / dışa aktar',
 		'subscription_management' => 'Abonelik yönetimi',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => 'Abonelik yönetimi',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => 'RSS akış yönetimi',
 		'subscription_tools' => 'Subscription tools',	// TODO - Translation
 	),

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -3,6 +3,7 @@
 return array(
 	'action' => array(
 		'actualize' => '获取',
+		'add' => 'Add',	// TODO - Translation
 		'back' => '← 返回',
 		'back_to_rss_feeds' => '← 返回订阅源',
 		'cancel' => '取消',

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -1,6 +1,7 @@
 <?php
 
 return array(
+	'add' => 'Feed and category creation has been moved <a href=\'%s\'>here</a>. It is also accessible from the menu on the left and from the ✚ icon available on the main page.',	// TODO - Translation
 	'api' => array(
 		'documentation' => '复制以下地址，以供外部工具使用',
 		'title' => 'API',
@@ -16,7 +17,6 @@ return array(
 		'archiving' => '归档',
 		'empty' => '空分类',
 		'information' => '信息',
-		'new' => '新分类',
 		'position' => '显示位置',
 		'position_help' => '控制分类排列顺序',
 		'title' => '标题',
@@ -102,6 +102,8 @@ return array(
 		'title' => '导入/导出',
 	),
 	'menu' => array(
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'bookmark' => '订阅（FreshRSS 书签）',
 		'import_export' => '导入/导出',
 		'subscription_management' => '订阅管理',
@@ -109,6 +111,9 @@ return array(
 	),
 	'title' => array(
 		'_' => '订阅管理',
+		'add' => 'Add a feed/a category',	// TODO - Translation
+		'add_category' => 'Add a category',	// TODO - Translation
+		'add_feed' => 'Add a feed',	// TODO - Translation
 		'feed_management' => '订阅源管理',
 		'subscription_tools' => '订阅工具',
 	),

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -14,7 +14,7 @@
 	<?php if (FreshRSS_Auth::hasAccess()) { ?>
 	<div class="stick configure-feeds">
 		<a id="btn-subscription" class="btn btn-important" href="<?= _url('subscription', 'index') ?>"><?= _t('index.menu.subscription') ?></a>
-		<a id="btn-importExport" class="btn btn-important" href="<?= _url('importExport', 'index') ?>"><?= _i('import') ?></a>
+		<a id="btn-add" class="btn btn-important" href="<?= _url('subscription', 'add') ?>"><?= _i('add-white') ?></a>
 	</div>
 	<?php } elseif (FreshRSS_Auth::accessNeedsLogin()) { ?>
 	<a href="<?= _url('index', 'about') ?>"><?= _t('index.menu.about') ?></a>

--- a/app/layout/aside_subscription.phtml
+++ b/app/layout/aside_subscription.phtml
@@ -1,7 +1,11 @@
 <ul class="nav nav-list aside">
 	<li class="nav-header"><?= _t('sub.menu.subscription_management') ?></li>
 
-	<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() !== 'bookmarklet' ? ' active' : '' ?>">
+	<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'add' ? ' active' : '' ?>">
+		<a href="<?= _url('subscription', 'add') ?>"><?= _t('sub.menu.add') ?></a>
+	</li>
+
+	<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
 		<a href="<?= _url('subscription', 'index') ?>"><?= _t('sub.menu.subscription_management') ?></a>
 	</li>
 

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -10,7 +10,7 @@
 		<div class="form-group">
 			<label class="group-name" for="url_rss"><?= _t('sub.feed.url') ?></label>
 			<div class="group-controls">
-				<input id="url_rss" name="url_rss" type="url" required="required" autocomplete="off"/>
+				<input id="url_rss" name="url_rss" type="url" required="required" autocomplete="off" class="long"/>
 			</div>
 		</div>
 

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -1,0 +1,91 @@
+<?php $this->partial('aside_subscription'); ?>
+
+<div class="post drop-section">
+    <a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
+
+	<h2><?= _t('sub.title.add_feed') ?></h2>
+    <form id="add_rss" method="post" action="<?= _url('feed', 'add') ?>" autocomplete="off">
+		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+
+		<div class="form-group">
+			<label class="group-name" for="url_rss"><?= _t('sub.feed.url') ?></label>
+			<div class="group-controls">
+				<input id="url_rss" name="url_rss" type="url" required="required" autocomplete="off"/>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label class="group-name" for="category"><?= _t('sub.category') ?></label>
+			<div class="group-controls">
+                <select name="category" id="category">
+                <?php foreach ($this->categories as $cat) { ?>
+                <option value="<?= $cat->id() ?>"<?= $cat->id() == 1 ? ' selected="selected"' : '' ?>>
+                    <?= $cat->name() ?>
+                </option>
+                <?php } ?>
+                </select>
+			</div>
+		</div>
+
+        <legend><?= _t('sub.feed.auth.configuration') ?></legend>
+		<div class="form-group">
+			<label class="group-name" for="http_user_feed"><?= _t('sub.feed.auth.username') ?></label>
+			<div class="group-controls">
+				<input id="http_user_feed" name="http_user_feed" type="text" autocomplete="off"/>
+			</div>
+		</div>
+
+		<div class="form-group">
+        <label class="group-name" for="http_pass_feed"><?= _t('sub.feed.auth.password') ?></label>
+			<div class="group-controls">
+				<input id="http_pass_feed" name="http_pass_feed" type="text" value=" " autocomplete="new-password"/>
+			</div>
+		</div>
+
+		<?php if (FreshRSS_Auth::hasAccess('admin')) { ?>
+		<legend><?= _t('sub.feed.advanced') ?></legend>
+		<div class="form-group">
+			<label class="group-name" for="timeout"><?= _t('sub.feed.timeout') ?></label>
+			<div class="group-controls">
+				<input type="number" name="timeout" id="timeout" min="3" max="120" value="" placeholder="<?= _t('gen.short.by_default') ?>" />
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label class="group-name" for="ssl_verify"><?= _t('sub.feed.ssl_verify') ?></label>
+			<div class="group-controls">
+				<label class="checkbox" for="ssl_verify">
+					<select name="ssl_verify" id="ssl_verify">
+						<option value=""><?= _t('gen.short.by_default') ?></option>
+						<option value="0"><?= _t('gen.short.no') ?></option>
+						<option value="1"><?= _t('gen.short.yes') ?></option>
+					</select>
+				</label>
+			</div>
+		</div>
+		<?php } ?>
+
+		<div class="form-group form-actions">
+			<div class="group-controls">
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.add') ?></button>
+			</div>
+		</div>
+	</form>
+
+	<h2><?= _t('sub.title.add_category') ?></h2>
+	<form action="<?= _url('category', 'create') ?>" method="post">
+		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+		<div class="form-group">
+			<label class="group-name" for="new-category"><?= _t('sub.category') ?></label>
+			<div class="group-controls">
+				<input id="new-category" name="new-category" type="text" autocomplete="off"/>
+			</div>
+		</div>
+
+		<div class="form-group form-actions">
+			<div class="group-controls">
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.add') ?></button>
+			</div>
+		</div>
+	</form>
+</div>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -5,51 +5,12 @@
 
 	<h2><?= _t('sub.title') ?></h2>
 
-	<form id="add_rss" method="post" action="<?= _url('feed', 'add') ?>" autocomplete="off">
-		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
-		<div class="stick">
-			<input type="url" name="url_rss" class="long" placeholder="<?= _t('sub.feed.add') ?>" />
-			<div class="dropdown">
-				<div id="dropdown-cat" class="dropdown-target"></div>
-
-				<a class="dropdown-toggle btn" href="#dropdown-cat"><?= _i('down') ?></a>
-				<ul class="dropdown-menu">
-					<li class="dropdown-close"><a href="#close">❌</a></li>
-
-					<li class="dropdown-header"><?= _t('sub.category') ?></li>
-
-					<li class="input">
-						<select name="category" id="category">
-						<?php foreach ($this->categories as $cat) { ?>
-						<option value="<?= $cat->id() ?>"<?= $cat->id() == 1 ? ' selected="selected"' : '' ?>>
-							<?= $cat->name() ?>
-						</option>
-						<?php } ?>
-						<option value="nc"><?= _t('sub.category.new') ?></option>
-						</select>
-					</li>
-
-					<li class="input" aria-hidden="true">
-						<input type="text" name="new_category[name]" id="new_category_name" autocomplete="off" placeholder="<?= _t('sub.category.new') ?>" />
-					</li>
-
-					<li class="separator"></li>
-
-					<li class="dropdown-header"><?= _t('sub.feed.auth.http') ?></li>
-					<li class="input">
-						<input type="text" name="http_user" id="http_user_feed" value=" " autocomplete="off" placeholder="<?= _t('sub.feed.auth.username') ?>" />
-					</li>
-					<li class="input">
-						<input type="password" name="http_pass" id="http_pass_feed" autocomplete="new-password" placeholder="<?= _t('sub.feed.auth.password') ?>" />
-					</li>
-				</ul>
-			</div>
-			<button class="btn" type="submit"><?= _i('add') ?></button>
-		</div>
-	</form>
-
 	<p class="alert alert-warn">
 		<?= _t('sub.feed.moved_category_deleted', $this->default_category->name()) ?>
+	</p>
+
+	<p class="alert alert-warn">
+		<?= _t('sub.add', _url('subscription', 'add')) ?>
 	</p>
 
 	<?php if ($this->onlyFeedsWithError): ?>
@@ -57,18 +18,6 @@
 		<?= _t('sub.feed.showing.error') ?>
 	</p>
 	<?php endif; ?>
-
-	<div class="box">
-		<div class="box-title"><label for="new-category"><?= _t('sub.category.add') ?></label></div>
-
-		<ul class="box-content box-content-centered">
-			<form action="<?= _url('category', 'create') ?>" method="post">
-				<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
-				<li class="item"><input type="text" id="new-category" name="new-category" placeholder="<?= _t('sub.category.new') ?>" /></li>
-				<li class="item"><button class="btn btn-important" type="submit"><?= _t('gen.action.submit') ?></button></li>
-			</form>
-		</ul>
-	</div>
 
 	<form id="controller-category" method="post" aria-hidden="true">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -125,21 +125,6 @@ function init_remove_observers() {
 		});
 }
 
-function init_feed_observers() {
-	const s = document.getElementById('category');
-	if (s && s.matches('select')) {
-		s.onchange = function (ev) {
-				const detail = document.getElementById('new_category_name').parentElement;
-				if (this.value === 'nc') {
-					detail.setAttribute('aria-hidden', 'false');
-					detail.querySelector('input').focus();
-				} else {
-					detail.setAttribute('aria-hidden', 'true');
-				}
-			};
-	}
-}
-
 function init_password_observers() {
 	document.querySelectorAll('.toggle-password').forEach(function (a) {
 			a.onmousedown = function (ev) {
@@ -257,7 +242,6 @@ function init_extra() {
 	init_crypto_form();
 	init_share_observers();
 	init_remove_observers();
-	init_feed_observers();
 	init_password_observers();
 	init_select_observers();
 	init_slider_observers();

--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -310,6 +310,6 @@
 	border-radius: 3px;
 }
 
-.aside_feed .stick #btn-importExport {
+.aside_feed .stick #btn-add {
 	border-left-color: $sid-bg;
 }

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -795,7 +795,7 @@ form th {
   border-radius: 3px;
 }
 
-.aside_feed .stick #btn-importExport {
+.aside_feed .stick #btn-add {
   border-left-color: #fbf9f6;
 }
 

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -795,7 +795,7 @@ form th {
   border-radius: 3px;
 }
 
-.aside_feed .stick #btn-importExport {
+.aside_feed .stick #btn-add {
   border-right-color: #fbf9f6;
 }
 

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -308,6 +308,6 @@
 	border-radius: 3px;
 }
 
-.aside_feed .stick #btn-importExport {
+.aside_feed .stick #btn-add {
 	border-left-color: $sid-bg;
 }

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -798,7 +798,7 @@ form th {
   border-radius: 3px;
 }
 
-.aside_feed .stick #btn-importExport {
+.aside_feed .stick #btn-add {
   border-left-color: #303136;
 }
 

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -798,7 +798,7 @@ form th {
   border-radius: 3px;
 }
 
-.aside_feed .stick #btn-importExport {
+.aside_feed .stick #btn-add {
   border-right-color: #303136;
 }
 

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -63,7 +63,7 @@ a.btn:hover {
 a#btn-subscription {
   width: 76%;
 }
-a#btn-importExport {
+a#btn-add {
   width: 5%;
 }
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -63,7 +63,7 @@ a.btn:hover {
 a#btn-subscription {
   width: 76%;
 }
-a#btn-importExport {
+a#btn-add {
   width: 5%;
 }
 

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -78,7 +78,7 @@ a {
 		width: 76%;
 	}
 
-	&#btn-importExport {
+	&#btn-add {
 		width: 5%;
 	}
 }

--- a/p/themes/icons/add-white.svg
+++ b/p/themes/icons/add-white.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16">
+<g transform="translate(-60.0002,-726)">
+<path style="color:#fff;" fill="#fff" d="m67,729,0,4-4,0,0,2,4,0,0,4,2,0,0-4,4,0,0-2-4,0,0-4-2,0z"/>
+</g>
+</svg>


### PR DESCRIPTION
Closes #777

Changes proposed in this pull request:

- Add a dedicated page to add a feed to avoid multiple clicks.
- Change the subscription page by removing the add feed action and reducing the size of the add category action.
- Change main page to add direct access to the add feed action.

How to test the feature manually:

1. Add a simple feed
2. Add a category
3. Add a feed with a new category
4. Add a feed with HTTP authentication

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

To ease the use of this feature, there is a new dedicated page to avoid numerous clicks.
Especially for switching categories or using HTTP authentication. The underlying actions
remain identical but the interface is simplified.