### PR TITLE
Fix form layout

### DIFF
--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -15,14 +15,6 @@ a, button.as-link {
 	outline: none;
 }
 
-/*=== Forms */
-.form-group {
-	display: inline-block;
-	float: left;
-	width: 100%;
-	height: auto;
-}
-
 legend {
 	margin: 20px 0 5px;
 	padding: 5px 0;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -15,14 +15,6 @@ a, button.as-link {
 	outline: none;
 }
 
-/*=== Forms */
-.form-group {
-	display: inline-block;
-	float: left;
-	width: 100%;
-	height: auto;
-}
-
 legend {
 	margin: 20px 0 5px;
 	padding: 5px 0;


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix login form layout when using BlueLagoon or Screwdriver themes.

How to test the feature manually:

1. Select one of the aforementioned themes.
2. Display some form to see that everything is in order.
3. Logout to see the 'about' link below the form.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

The login form layout was broken for BlueLagoon and Screwdriver themes. The 'about' link was
displayed next to the form since the later didn't have a height. I removed completely the
rule since it seems that it has no effect, except the one aforementioned.
