### PR TITLE
Return the correct Content-Type for SVG favicons

### DIFF
--- a/p/f.php
+++ b/p/f.php
@@ -48,5 +48,13 @@ if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (mt
 header('Content-Disposition: inline; filename="' . $id . '.ico"');
 
 if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
-	readfile($ico);
+
+    // In case the favicon is a svg file, replace the Content-Type header
+    $ico_content = file_get_contents($ico);
+    if (substr($ico_content, 0, 4) === '<svg') {
+            header('Content-Type: image/svg+xml');
+    }
+
+    echo $ico_content;
+
 }

--- a/p/f.php
+++ b/p/f.php
@@ -5,6 +5,7 @@ require(LIB_PATH . '/favicons.php');
 require(LIB_PATH . '/http-conditional.php');
 
 function show_default_favicon($cacheSeconds = 3600) {
+	header('Content-Type: image/x-icon');
 	header('Content-Disposition: inline; filename="default_favicon.ico"');
 
 	$default_mtime = @filemtime(DEFAULT_FAVICON);

--- a/p/f.php
+++ b/p/f.php
@@ -50,11 +50,11 @@ header('Content-Disposition: inline; filename="' . $id . '.ico"');
 if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
 
     // In case the favicon is a svg file, replace the Content-Type header
-    $ico_content = file_get_contents($ico);
-    if (substr($ico_content, 0, 4) === '<svg') {
-            header('Content-Type: image/svg+xml');
-    }
+	$ico_content_type = mime_content_type($ico);
+	if ($ico_content_type === 'image/svg') {
+		header('Content-Type: image/svg+xml');
+	}
 
-    echo $ico_content;
+	readfile($ico);
 
 }

--- a/p/f.php
+++ b/p/f.php
@@ -49,7 +49,7 @@ header('Content-Disposition: inline; filename="' . $id . '.ico"');
 
 if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
 
-    // In case the favicon is a svg file, replace the Content-Type header
+	// In case the favicon is a svg file, replace the Content-Type header
 	$ico_content_type = mime_content_type($ico);
 	if ($ico_content_type === 'image/svg') {
 		header('Content-Type: image/svg+xml');

--- a/p/f.php
+++ b/p/f.php
@@ -5,11 +5,10 @@ require(LIB_PATH . '/favicons.php');
 require(LIB_PATH . '/http-conditional.php');
 
 function show_default_favicon($cacheSeconds = 3600) {
-	header('Content-Type: image/x-icon');
-	header('Content-Disposition: inline; filename="default_favicon.ico"');
-
 	$default_mtime = @filemtime(DEFAULT_FAVICON);
 	if (!httpConditional($default_mtime, $cacheSeconds, 2)) {
+		header('Content-Type: image/x-icon');
+		header('Content-Disposition: inline; filename="default_favicon.ico"');
 		readfile(DEFAULT_FAVICON);
 	}
 }

--- a/p/f.php
+++ b/p/f.php
@@ -24,8 +24,6 @@ $ico = FAVICONS_DIR . $id . '.ico';
 $ico_mtime = @filemtime($ico);
 $txt_mtime = @filemtime($txt);
 
-header('Content-Type: image/x-icon');
-
 if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (mt_rand(15, 20) * 86400))) {
 	if ($txt_mtime == false) {
 		show_default_favicon(1800);
@@ -45,14 +43,17 @@ if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (mt
 	}
 }
 
-header('Content-Disposition: inline; filename="' . $id . '.ico"');
-
 if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
-	// In case the favicon is a svg file, replace the Content-Type header
-	$ico_content_type = mime_content_type($ico);
-	if ($ico_content_type === 'image/svg') {
-		header('Content-Type: image/svg+xml');
+	$ico_content_type = 'image/x-icon';
+	if (function_exists('mime_content_type')) {
+		$ico_content_type = mime_content_type($ico);
 	}
-
+	switch ($ico_content_type) {
+		case 'image/svg':
+			$ico_content_type = 'image/svg+xml';
+			break;
+	}
+	header('Content-Type: ' . $ico_content_type);
+	header('Content-Disposition: inline; filename="' . $id . '.ico"');
 	readfile($ico);
 }

--- a/p/f.php
+++ b/p/f.php
@@ -48,7 +48,6 @@ if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (mt
 header('Content-Disposition: inline; filename="' . $id . '.ico"');
 
 if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
-
 	// In case the favicon is a svg file, replace the Content-Type header
 	$ico_content_type = mime_content_type($ico);
 	if ($ico_content_type === 'image/svg') {
@@ -56,5 +55,4 @@ if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
 	}
 
 	readfile($ico);
-
 }


### PR DESCRIPTION
Closes #2572

Changes proposed in this pull request:

- Before displaying the favicon, check if the file type is "image/svg" using `mime_content_type`.
- If so, change the returned Content-Type HTTP header to "image/svg+xml".

How to test the feature manually:

1. Add a feed with a SVG favicon, such as https://github.com/FreshRSS/FreshRSS/releases
2. Before the fix, SVG favicons show up as the default favicon. After the fix, they should appear as the actual favicon.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
