### PR TITLE
Add controls on media

### DIFF
--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Zkratky',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Aplikovat uživatelské filtry',
 		'user_filter_help' => 'Je-li nastaven pouze jeden filtr, bude použit. Další filtry jsou dostupné pomocí jejich čísla.',
 		'views' => 'Views',	// TODO - Translation

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Nächsten markieren ohne zu öffnen',
 		'skip_previous_article' => 'Vorherigen markieren ohne zu öffnen',
 		'title' => 'Tastenkombination',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Auf Benutzerfilter zugreifen',
 		'user_filter_help' => 'Wenn es nur einen Benutzerfilter gibt, wird dieser verwendet. Ansonsten sind die Filter über ihre Nummer erreichbar.',
 		'views' => 'Ansichten',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',
 		'skip_previous_article' => 'Focus previous without opening',
 		'title' => 'Shortcuts',
+		'toggle_media' => 'Play/pause media',
 		'user_filter' => 'Access user queries',
 		'user_filter_help' => 'If there is only one user query, it is used. Otherwise, queries are accessible by their number.',
 		'views' => 'Views',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Atajos de teclado',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Acceso a filtros de usuario',
 		'user_filter_help' => 'Si solo hay un filtro de usuario, ese será el que se use. En caso contrario, los filtros están accesibles por su númeración.',
 		'views' => 'Views',	// TODO - Translation

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Passer au suivant sans ouvrir',
 		'skip_previous_article' => 'Passer au précédent sans ouvrir',
 		'title' => 'Raccourcis',
+		'toggle_media' => 'Lire/arrêter le média',
 		'user_filter' => 'Accéder aux filtres utilisateur',
 		'user_filter_help' => 'S’il n’y a qu’un filtre utilisateur, celui-ci est utilisé automatiquement. Sinon ils sont accessibles par leur numéro.',
 		'views' => 'Vues',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'קיצורי דרך',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'גישה למססנים',
 		'user_filter_help' => 'אם יש רק מזנן אחד הוא יהיה בשימוש. אחרת המסננים ישמשו על בסיס המספר שלהם.',
 		'views' => 'Views',	// TODO - Translation

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Comandi da tastiera',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Accedi alle ricerche personali',
 		'user_filter_help' => 'Se è presente una sola ricerca personale verrà usata quella, altrimenti usare anche il numero associato.',
 		'views' => 'Views',	// TODO - Translation

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => '다음 글로 커서 이동',
 		'skip_previous_article' => '이전 글로 커서 이동',
 		'title' => '단축키',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => '사용자 필터 사용하기',
 		'user_filter_help' => '사용자 필터가 하나만 설정되어 있다면 해당 필터를 사용하고, 그렇지 않다면 필터를 번호로 선택할 수 있습니다.',
 		'views' => '표시',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Volgend artikel focusen zonder openen',
 		'skip_previous_article' => 'Vorig artikel focusen zonder openen',
 		'title' => 'Verwijzingen',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Toegang gebruikers filters',
 		'user_filter_help' => 'Als er slechts één gebruikersfilter is, dan wordt die gebruikt. Anders zijn ze toegankelijk met hun nummer.',
 		'views' => 'Aanzichten',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Centrar sul seguent sens lo dobrir',
 		'skip_previous_article' => 'Centrar sul precedent sens lo dobrir',
 		'title' => 'Acorchis',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Accedir als filtres utilizaire',
 		'user_filter_help' => 'S’i a pas qu’un filtre utilizaire, aquel serà utilizat. Autrament los filtres son accessibles per lor numèro.',
 		'views' => 'Vistas',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focar o próximo sem abri-lo',
 		'skip_previous_article' => 'Focar o anterior sem abri-lo',
 		'title' => 'Atalhos',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Acesse filtros de usuário',
 		'user_filter_help' => 'Se há apenas um filtro, ele é utilizado. Caso contrário, os filtros serão acessíveis pelos seus números.',
 		'views' => 'Visualizações',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Shortcuts',	// TODO - Translation
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Access user filters',
 		'user_filter_help' => 'If there is only one user filter, it is used. Else filters are accessible by their number.',
 		'views' => 'Views',	// TODO - Translation

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Prejde na ďalší bez otvorenia',
 		'skip_previous_article' => 'Prejde na predošlý bez otvorenia',
 		'title' => 'Skratky',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Použiť používateľské filtre',
 		'user_filter_help' => 'Ak je nastavený iba jeden spôsob zdieľania, použije sa. Inak si spôsoby zdieľania vyberá používateľ podľa čísla.',
 		'views' => 'Zobrazenia',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => 'Focus next without opening',	// TODO - Translation
 		'skip_previous_article' => 'Focus previous without opening',	// TODO - Translation
 		'title' => 'Kısayollar',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => 'Kullanıcı filtrelerine eriş',
 		'user_filter_help' => 'Eğer tek filtre varsa o kullanılır. Yoksa filtrelerin kendi numaralarıyla kullanılır.',
 		'views' => 'Views',	// TODO - Translation

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -188,6 +188,7 @@ return array(
 		'skip_next_article' => '跳转到下一篇文章而不打开',
 		'skip_previous_article' => '跳转到上一篇文章而不打开',
 		'title' => '快捷键',
+		'toggle_media' => 'Play/pause media',	// TODO - Translation
 		'user_filter' => '显示自定义查询',
 		'user_filter_help' => '如果有多个自定义过滤器，则会按照它们的序号依次访问。',
 		'views' => '视图',

--- a/app/views/configure/shortcut.phtml
+++ b/app/views/configure/shortcut.phtml
@@ -136,6 +136,13 @@
 			</div>
 		</div>
 
+		<div class="form-group">
+			<label class="group-name" for="toggle_media"><?= _t('conf.shortcut.toggle_media') ?></label>
+			<div class="group-controls">
+				<input type="text" id="toggle_media" name="shortcuts[toggle_media]" list="keys" value="<?= $s['toggle_media'] ?>" data-leave-validation="<?= $s['toggle_media'] ?>"/>
+			</div>
+		</div>
+
 		<legend><?= _t('conf.shortcut.other_action') ?></legend>
 
 		<div class="form-group">

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -41,6 +41,7 @@ echo htmlspecialchars(json_encode(array(
 		'global_view' => @$s['global_view'],
 		'reading_view' => @$s['reading_view'],
 		'rss_view' => @$s['rss_view'],
+		'toggle_media' => @$s['toggle_media'],
 	),
 	'urls' => array(
 		'index' => _url('index', 'index'),

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -75,6 +75,7 @@ return array (
 		'global_view' => '2',
 		'reading_view' => '3',
 		'rss_view' => '4',
+		'toggle_media' => 'v',
 	),
 	'show_favicons' => true,
 	'topline_read' => true,

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -581,6 +581,18 @@ function collapse_entry() {
 	toggleContent(flux_current, flux_current, false);
 }
 
+function toggle_media() {
+	const media = document.querySelector('.flux.current video,.flux.current audio');
+	if (media === null) {
+		return;
+	}
+	if (media.paused) {
+		media.play();
+	} else {
+		media.pause();
+	}
+}
+
 function user_filter(key) {
 	const filter = document.getElementById('dropdown-query'),
 		filters = filter.parentElement.querySelectorAll('.dropdown-menu > .query > a');
@@ -861,6 +873,7 @@ function init_shortcuts() {
 			if (k === s.reading_view) { delayedClick(document.querySelector('#nav_menu_views .view-reader')); return false; }
 			if (k === s.global_view) { delayedClick(document.querySelector('#nav_menu_views .view-global')); return false; }
 			if (k === s.rss_view) { delayedClick(document.querySelector('#nav_menu_views .view-rss')); return false; }
+			if (k === s.toggle_media) { toggle_media(); return false;}
 			return true;
 		};
 }


### PR DESCRIPTION
Closes #1952

Changes proposed in this pull request:

- Add a shortcut to control media (audio/video) from an entry

How to test the feature manually:

1. configure properly the shortcut to your liking
2. open a feed with a media
3. try to play and stop the media by hitting the shortcut key

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
