### PR TITLE
Add support for extensions in Docker environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,11 @@ build: ## Build a Docker image
 
 .PHONY: start
 start: ## Start the development environment (use Docker)
+	$(foreach extension,$(extensions),$(eval volumes=$(volumes) --volume $(extension):/var/www/FreshRSS/extensions/$(notdir $(extension)):z))
 	docker run \
 		--rm \
 		--volume $(shell pwd):/var/www/FreshRSS:z \
+		$(volumes) \
 		--publish $(PORT):80 \
 		--env FRESHRSS_ENV=development \
 		--name freshrss-dev \

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -216,6 +216,13 @@ Here we are! We've talked about the most useful features of Minz and how to run 
 
 An extension allows you to easily add functionality to FreshRSS without having to touch the core of the project directly.
 
+### Make it work in Docker
+
+When working on an extension, it's easier to see it working directly in its environment. With Docker, you can leverage the use of the ```volume``` option when starting the container. Hopefully, you can use it without Docker-related knowledge by using the Makefile rule:
+```
+make start extensions="/full/path/to/extension/1 /full/path/to/extension/2"
+```
+
 ### Basic files and folders
 
 The first thing to note is that **all** extensions **must** be located in the `extensions` directory, at the base of the FreshRSS tree.

--- a/docs/fr/developers/03_Backend/05_Extensions.md
+++ b/docs/fr/developers/03_Backend/05_Extensions.md
@@ -374,6 +374,13 @@ temps d'aborder les extensions en elles-même.
 Une extension permet donc d'ajouter des fonctionnalités facilement à
 FreshRSS sans avoir à toucher au cœur du projet directement.
 
+### Travailler dans Docker
+
+Quand on travaille sur une extension, c'est toujours plus facile de la travailler directement dans son environnement. Avec Docker, on peut exploiter l'option ```volume``` quand on démarre le conteneur. Heureusement, on peut l'utiliser sans avoir de connaissances particulières de Docker en utilisant la règle du Makefile :
+```
+make start extensions="/chemin/complet/de/l/extension/1 /chemin/complet/de/l/extension/2"
+```
+
 ### Les fichiers et répertoires de base
 
 La première chose à noter est que **toutes** les extensions **doivent** se


### PR DESCRIPTION
Changes proposed in this pull request:

- Add support for extensions in Docker environment

How to test the feature manually:

1. Start docker with extension with the Makefile rule ```make start extensions="/full/path/to/extension/1 /full/path/to/extension/2"```
2. Open the extension page
3. See that the extensions are loaded

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
