### PR TITLE
Edit mapco.css

### DIFF
--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1105,7 +1105,6 @@ form th {
 .content code, .content.thin code {
   padding: 2px 5px;
   background: #f9fafb;
-  color: #eff0f2;
   border: 1px solid #eff0f2;
   border-radius: 3px;
 }


### PR DESCRIPTION
Otherwise end up with (almost) white-on-white

Closes #3047

Changes proposed in this pull request:

- Remove single line of css that specifies the inordinately light coloured text
-
-

How to test the feature manually:

1. use mapco theme
2. open a feed that uses code tags outside of the context of a pre tag
3. code should be legible

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
