### PR TITLE
Fix inline code tag contrast in ansum.css

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -77,6 +77,7 @@ People are sorted by name so please keep this order.
 * [Paulius Šukys](https://github.com/psukys): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:psukys), [Web](http://sukys.eu)
 * [perrinjerome](https://github.com/perrinjerome): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:perrinjerome)
 * [Peter Stoinov](https://github.com/stoinov): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:stoinov), [Web](https://stoinov.com)
+* [Petra Lamborn](https://github.com/petraoleum): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:petraoleum), [Web](https://petras.space)
 * [Pim Snel](https://github.com/mipmip): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is%3Apr+author%3Amipmip), [Web](https://www.pimsnel.com)
 * [plopoyop](https://github.com/plopoyop): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=plopoyop)
 * [Pofilo](https://github.com/Pofilo): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Pofilo), [Web](https://www.pofilo.fr/)

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1099,7 +1099,6 @@ form th {
 .content code, .content.thin code {
   padding: 2px 5px;
   background: #fcfaf8;
-  color: #f5f0ec;
   border: 1px solid #f5f0ec;
   border-radius: 3px;
 }


### PR DESCRIPTION
As with #3048

Changes proposed in this pull request:

- Remove line in ansum.css that creates bad contrast
- Add to CREDITS.md
-

How to test the feature manually:

1. Use Ansum theme
2. Open feed that uses inline code tags
3. Should be legible

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
