### PR TITLE
API discard common API URL errors

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -912,6 +912,7 @@ function markAllAsRead($streamId, $olderThanId) {
 }
 
 $pathInfo = empty($_SERVER['PATH_INFO']) ? '' : urldecode($_SERVER['PATH_INFO']);
+$pathInfo = preg_replace('%^(/api)?(/greader\.php)?%', '', $pathInfo);	//Discard common errors
 if ($pathInfo == '') {
 	exit('OK');
 }


### PR DESCRIPTION
Some apps auto-complete `/api/greader.php` while others do not.
Discard common errors instead of failing, to be more user-friendly.
E.g. if the user types the full API URL in Readrops https://github.com/FreshRSS/FreshRSS/issues/3059#issuecomment-644149548 it currently fails, but will succeed with this patch