### PR TITLE
Change how updating a key works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,7 @@ endif
 ifndef value
 	$(error To update a key, you need to provide its value in the "value" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a delete -k $(key)
-	@$(PHP) ./cli/manipulate.translation.php -a add -k $(key) -v "$(value)"
+	@$(PHP) ./cli/manipulate.translation.php -a add -k $(key) -v "$(value)" -l en
 	@echo Key updated.
 
 .PHONY: i18n-ignore-key

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -182,7 +182,16 @@ class I18nData {
 		    !array_key_exists($key, $this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)])) {
 			throw new Exception('The selected key does not exist for the selected language.');
 		}
-		$this->data[$language][$this->getFilenamePrefix($key)][$key] = $value;
+		if (static::REFERENCE_LANGUAGE === $language) {
+			$previousValue = $this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)][$key];
+			foreach ($this->getAvailableLanguages() as $lang) {
+				if ($this->data[$lang][$this->getFilenamePrefix($key)][$key] === $previousValue) {
+					$this->data[$lang][$this->getFilenamePrefix($key)][$key] = $value;
+				}
+			}
+		} else {
+			$this->data[$language][$this->getFilenamePrefix($key)][$key] = $value;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Changes proposed in this pull request:

- Update referential i18n values without losing translations

How to test the feature manually:

1. change a value in the referential with the make rule
2. see it changed in all untranslated files
3. see it stay unchanged in all translated files

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, to update a key from the reference language (en), the key was deleted
then created. This way was unproductive for all keys already translated.
Now, the key is updated in all untranslated languages.

See https://github.com/FreshRSS/FreshRSS/pull/3068#issuecomment-646868894
