### PR TITLE
API Compatibility Reeder

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -343,7 +343,7 @@ function subscriptionEdit($streamNames, $titles, $action, $add = '', $remove = '
 	for ($i = count($streamNames) - 1; $i >= 0; $i--) {
 		$streamUrl = $streamNames[$i];	//feed/http://example.net/sample.xml	;	feed/338
 		if (strpos($streamUrl, 'feed/') === 0) {
-			$streamUrl = substr($streamUrl, 5);
+			$streamUrl = preg_replace('%^(feed/)+%', '', $streamUrl);
 			$feedId = 0;
 			if (ctype_digit($streamUrl)) {
 				if ($action === 'subscribe') {


### PR DESCRIPTION
#fix
https://github.com/FreshRSS/FreshRSS/issues/3031#issuecomment-646973334
Reeder sends e.g. `feed/feed/247` instead of `feed/247`