### PR TITLE
Dropdown menu max-height

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -304,7 +304,7 @@ a.btn {
 }
 
 .dropdown-menu-scrollable {
-	max-height: 75vh;
+	max-height: min(75vh, 50em);
 	overflow-x: hidden;
 	overflow-y: auto;
 }

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -304,7 +304,7 @@ a.btn {
 }
 
 .dropdown-menu-scrollable {
-	max-height: 75vh;
+	max-height: min(75vh, 50em);
 	overflow-x: hidden;
 	overflow-y: auto;
 }


### PR DESCRIPTION
On big screens, I find the drop-down menus too high, so this patch limits to 50em in addition of the existing limit of 75vh.

https://caniuse.com/#feat=minmaxwh

Before:

![image](https://user-images.githubusercontent.com/1008324/87221738-99a88b00-c36e-11ea-9320-714c0563f218.png)

After:

![image](https://user-images.githubusercontent.com/1008324/87221740-9f05d580-c36e-11ea-9b72-9d2074ce6222.png)
