### PR TITLE
volume names include redundant prefix

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,27 +1,30 @@
 version: "3"
 
 services:
-  freshrss_postgresql:
-    image: postgres
-    restart: unless-stopped
+  freshrss-db:
+    image: postgres:12-alpine
     container_name: freshrss-db
+    hostname: freshrss-db
+    restart: unless-stopped
     volumes:
-      - pgsql_data:/var/lib/postgresql/data
+      - db:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=freshrss
       - POSTGRES_PASSWORD=freshrss
       - POSTGRES_DB=freshrss
 
-  freshrss:
-    image: freshrss/freshrss
+  freshrss-app:
+    image: freshrss/freshrss:latest
+    container_name: freshrss-app
+    hostname: freshrss-app
     restart: unless-stopped
     ports:
       - "8080:80"
     depends_on:
-      - freshrss_postgresql
+      - freshrss-db
     volumes:
-      - freshrss_data:/var/www/FreshRSS/data
-      - freshrss_extensions:/var/www/FreshRSS/extensions
+      - data:/var/www/FreshRSS/data
+      - extensions:/var/www/FreshRSS/extensions
     environment:
       - CRON_MIN=*/20
       - TZ=Europe/Copenhagen
@@ -29,6 +32,6 @@ services:
       - "traefik.port=80"
 
 volumes:
-  pgsql_data:
-  freshrss_data:
-  freshrss_extensions:
+  db:
+  data:
+  extensions:


### PR DESCRIPTION
This proposed change includes tweaks to the names of the services and volumes, and adds an explicit label to the postgres and freshrss containers.

Using a more generic "freshrss-db" instead of "freshrss_postgresql" seems more standard among other docker projects and makes it a bit easier to switch databases later.

Removing the "freshrss_" prefix from the volume names solves a problem where the docker-compose automatically prepends a "project name" to volume names upon running "up".  So if your docker-compose.yml file is stored in a folder named "freshrss", you would end up with a redundant volume name of "freshrss_freshrss_data".

This also adds a restart policy to the db container.