### PR TITLE
fix: Test setupMigrations doesn't return false

### DIFF
--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -127,5 +127,5 @@ function setupMigrations() {
 
 	$migrator = new Minz_Migrator($migrations_path);
 	$versions = implode("\n", $migrator->versions());
-	return @file_put_contents($migrations_version_path, $versions);
+	return @file_put_contents($migrations_version_path, $versions) !== false;
 }


### PR DESCRIPTION
Closes #3104

Changes proposed in this pull request:

`file_put_contents` can return 0 if there’s nothing to write in the
`applied_migrations.txt` file, which is equivalent to `false`. Since
there are no migrations yet, this is what happens. Because this value
(i.e. `0`) is tested next in the `app/install.php` file, the install
script was failing.

How to test the feature manually:

1. create a `data/do-install.txt` file and delete `data/applied_migrations.txt`
2. reinstall FRSS, following the normal workflow
3. the installation should succeed, `data/do-install.txt` should be removed and `data/applied_migrations.txt` created (empty)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) N/A
- [x] documentation updated N/A

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
