### PR TITLE
Add a way to disable shortcuts

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -174,7 +174,11 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 		$this->view->list_keys = SHORTCUT_KEYS;
 
 		if (Minz_Request::isPost()) {
-			FreshRSS_Context::$user_conf->shortcuts = validateShortcutList(Minz_Request::param('shortcuts'));
+			$shortcuts = Minz_Request::param('shortcuts');
+			if (false !== Minz_Request::param('load_default_shortcuts')) {
+				$shortcuts = array_filter($shortcuts);
+			}
+			FreshRSS_Context::$user_conf->shortcuts = validateShortcutList($shortcuts);
 			FreshRSS_Context::$user_conf->save();
 			invalidateHttpCache();
 

--- a/app/i18n/cz/gen.php
+++ b/app/i18n/cz/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Export',	// TODO - Translation
 		'filter' => 'Filtrovat',
 		'import' => 'Import',	// TODO - Translation
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Spravovat',
 		'mark_favorite' => 'Označit jako oblíbené',
 		'mark_read' => 'Označit jako přečtené',

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exportieren',
 		'filter' => 'Filtern',
 		'import' => 'Importieren',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Verwalten',
 		'mark_favorite' => 'Als Favorit markieren',
 		'mark_read' => 'Als gelesen markieren',

--- a/app/i18n/en-us/gen.php
+++ b/app/i18n/en-us/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Export',
 		'filter' => 'Filter',
 		'import' => 'Import',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Manage',
 		'mark_favorite' => 'Mark as favorite',
 		'mark_read' => 'Mark as read',

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Export',
 		'filter' => 'Filter',
 		'import' => 'Import',
+		'load_default_shortcuts' => 'Load default shortcuts',
 		'manage' => 'Manage',
 		'mark_favorite' => 'Mark as favourite',
 		'mark_read' => 'Mark as read',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exportar',
 		'filter' => 'Filtrar',
 		'import' => 'Importar',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Administrar',
 		'mark_favorite' => 'Marcar como favorita',
 		'mark_read' => 'Marcar como leído',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exporter',
 		'filter' => 'Filtrer',
 		'import' => 'Importer',
+		'load_default_shortcuts' => 'Utiliser les raccourcis par défaut',
 		'manage' => 'Gérer',
 		'mark_favorite' => 'Mettre en favori',
 		'mark_read' => 'Marquer comme lu',

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'ייצוא',
 		'filter' => 'מסנן',
 		'import' => 'ייבוא',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'ניהול',
 		'mark_favorite' => 'סימון כמועדף',
 		'mark_read' => 'סימון כנקרא',

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Esporta',
 		'filter' => 'Filtra',
 		'import' => 'Importa',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Gestisci',
 		'mark_favorite' => 'Segna come preferito',
 		'mark_read' => 'Segna come letto',

--- a/app/i18n/kr/gen.php
+++ b/app/i18n/kr/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => '내보내기',
 		'filter' => '해당하는 글 보기',
 		'import' => '불러오기',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => '관리',
 		'mark_favorite' => '즐겨찾기에 등록',
 		'mark_read' => '읽음으로 표시',

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exporteren',
 		'filter' => 'Filteren',
 		'import' => 'Importeren',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Beheren',
 		'mark_favorite' => 'Markeer als favoriet',
 		'mark_read' => 'Markeer als gelezen',

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exportar',
 		'filter' => 'Filtre',
 		'import' => 'Importar',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Gerir',
 		'mark_favorite' => 'Ajustar als favorits',
 		'mark_read' => 'Marcar coma legit',

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exportar',
 		'filter' => 'Filtrar',
 		'import' => 'Importar',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Gerenciar',
 		'mark_favorite' => 'Marcar como favorito',
 		'mark_read' => 'Marcar como lido',

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Export',	// TODO - Translation
 		'filter' => 'Filter',	// TODO - Translation
 		'import' => 'Import',	// TODO - Translation
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Manage',	// TODO - Translation
 		'mark_favorite' => 'Mark as favourite',	// TODO - Translation
 		'mark_read' => 'Mark as read',	// TODO - Translation

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Exportovať',
 		'filter' => 'Filtrovať',
 		'import' => 'Importovať',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Spravovať',
 		'mark_favorite' => 'Označiť ako obľúbené',
 		'mark_read' => 'Označiť ako prečítané',

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => 'Dışa Aktar',
 		'filter' => 'Filtrele',
 		'import' => 'İçe Aktar',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => 'Yönet',
 		'mark_favorite' => 'Favoriye ekle',
 		'mark_read' => 'Okundu olarak işaretle',

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -15,6 +15,7 @@ return array(
 		'export' => '导出',
 		'filter' => '过滤',
 		'import' => '导入',
+		'load_default_shortcuts' => 'Load default shortcuts',	// TODO - Translation
 		'manage' => '管理',
 		'mark_favorite' => '标记收藏',
 		'mark_read' => '标记已读',

--- a/app/views/configure/shortcut.phtml
+++ b/app/views/configure/shortcut.phtml
@@ -184,6 +184,7 @@
 		<div class="form-group form-actions">
 			<div class="group-controls">
 				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-important" name="load_default_shortcuts"><?= _t('gen.action.load_default_shortcuts') ?></button>
 				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 			</div>
 		</div>

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -540,7 +540,9 @@ function validateShortcutList($shortcuts) {
 	$shortcuts_ok = array();
 
 	foreach ($shortcuts as $key => $value) {
-		if (in_array($value, SHORTCUT_KEYS)) {
+		if ('' === $value) {
+			$shortcuts_ok[$key] = $value;
+		} elseif (in_array($value, SHORTCUT_KEYS)) {
 			$shortcuts_ok[$key] = $value;
 		} elseif (isset($legacy[$value])) {
 			$shortcuts_ok[$key] = $legacy[$value];


### PR DESCRIPTION
Closes #3110

Changes proposed in this pull request:

- Add a way to disable shortcuts

How to test the feature manually:

1. Change a shortcut value to an empty value and save.
2. Try to use the shortcut.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

When the user do not want to use a shortcut, he can let the shortcut value
empty. This will save an empty configuration thus disabling the shortcut.
The load default action allows to use default shortcut only for disabled
shortcuts.