### PR TITLE
Change machine-readable date format

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -90,8 +90,11 @@ class FreshRSS_Entry extends Minz_Model {
 		}
 		return timestamptodate($this->date);
 	}
-	public function machineReadableDate() {
-		return @date (DATE_ATOM, $this->date);
+	public function machineReadableDate($utc = true) {
+		if (true === $utc) {
+			return @gmdate(DATE_ATOM, $this->date);
+		}
+		return @date(DATE_ATOM, $this->date);
 	}
 	public function dateAdded($raw = false, $microsecond = false) {
 		if ($raw) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Change machine-readable date format to UTC

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, the date was using the server timezone. This can be a problem
when using different timezones.
Now, the date is converted to UTC first. This way, we always have the
date in the same format no matter what the server configuration is.