### PR TITLE
Change feed order in a category

### DIFF
--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -357,14 +357,18 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 	}
 
 	public function listByCategory($cat) {
-		$sql = 'SELECT * FROM `_feed` WHERE category=? ORDER BY name';
+		$sql = 'SELECT * FROM `_feed` WHERE category=?';
 		$stm = $this->pdo->prepare($sql);
 
-		$values = array($cat);
+		$stm->execute(array($cat));
 
-		$stm->execute($values);
+		$feeds = self::daoToFeed($stm->fetchAll(PDO::FETCH_ASSOC));
 
-		return self::daoToFeed($stm->fetchAll(PDO::FETCH_ASSOC));
+		usort($feeds, function ($a, $b) {
+			return strnatcasecmp($a->name(), $b->name());
+		});
+
+		return $feeds;
 	}
 
 	public function countEntries($id) {


### PR DESCRIPTION
Closes #3128

Changes proposed in this pull request:

- Change feed order in a category

How to test the feature manually:

1. Open the feed subscription page
2. Feeds must be ordered
3. Change the case of a feed name
4. The order must stay identical

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, the sorting was not human readable. Lower-cased feed names were
displayed after upper-cased feed names.
Now, the sorting is human readable. The sorting is done without taking into
account the name case.