### PR TITLE
Docs: Add Fluent Reader to API Clients

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -73,6 +73,7 @@ People are sorted by name so please keep this order.
 * [Nicolas Elie](https://github.com/nicolaselie): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=nicolaselie)
 * [Nicolas Frandeboeuf](https://github.com/nicofrand): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=nicofrand), [Web](https://nicofrand.ey)
 * [Nicolas Lœuillet](https://github.com/nicosomb): [contributions](https://github.com/FreshRSS/documentation/commits?author=nicosomb), [Web](http://www.loeuillet.org/)
+* [No Name Pro](https://github.com/NoNamePro0): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=NoNamePro0)
 * [Offerel](https://github.com/Offerel): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Offerel)
 * [Olivier Dossmann](https://github.com/blankoworld): [contributions](https://github.com/FreshRSS/FreshRSS/commits?author=blankoworld), [Web](https://olivier.dossmann.net)
 * [Pablo Caro](https://github.com/pcaro90): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:pcaro90), [Web](https://pcaro.es/)

--- a/docs/en/users/06_Fever_API.md
+++ b/docs/en/users/06_Fever_API.md
@@ -30,7 +30,13 @@ Tested with:
 
 * MacOS
   * [ReadKit](https://apps.apple.com/app/readkit/id588726889) (Commercial)
+  * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
 
+* Windows
+  * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
+
+* Linux
+  * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
 
 ## Features
 

--- a/docs/en/users/06_Fever_API.md
+++ b/docs/en/users/06_Fever_API.md
@@ -30,12 +30,8 @@ Tested with:
 
 * MacOS
   * [ReadKit](https://apps.apple.com/app/readkit/id588726889) (Commercial)
-  * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
 
-* Windows
-  * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
-
-* Linux
+* Cross-Platform (Desktop: Windows, Linux and MacOS)
   * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
 
 ## Features

--- a/docs/en/users/06_Fever_API.md
+++ b/docs/en/users/06_Fever_API.md
@@ -18,14 +18,14 @@ Then point your mobile application to the `fever.php` address (e.g. `https://fre
 
 ## Compatible clients
 
-| App                                                                                | Platform            | Free Software                                            |
+| App                                                                                | Platform            | License                                            |
 |:----------------------------------------------------------------------------------:|:-------------------:|:--------------------------------------------------------:|
-|[Fluent Reader](https://hyliu.me/fluent-reader/)                                    |Windows, Linux, macOS|[Open Source](https://github.com/yang991178/fluent-reader)|
+|[Fluent Reader](https://hyliu.me/fluent-reader/)                                    |Windows, Linux, macOS|[BSD-3-Clause](https://github.com/yang991178/fluent-reader/blob/master/LICENSE)|
 |[Readably](https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably)|Android              |Closed Source                                             |
 |[Fiery Feeds](https://apps.apple.com/app/fiery-feeds-rss-reader/id1158763303)       |iOS                  |Closed Source                                             |
-|[Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153)                 |iOS                  |Commercial                                                |
-|[Reeder](https://www.reederapp.com/)                                                |iOS                  |Commercial                                                |
-|[ReadKit](https://apps.apple.com/app/readkit/id588726889)                           |macOS                |Commercial                                                |
+|[Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153)                 |iOS                  |Closed Source                                             |
+|[Reeder](https://www.reederapp.com/)                                                |iOS                  |Closed Source                                              |
+|[ReadKit](https://apps.apple.com/app/readkit/id588726889)                           |macOS                |Closed Source                                              |
 
 ## Features
 

--- a/docs/en/users/06_Fever_API.md
+++ b/docs/en/users/06_Fever_API.md
@@ -18,21 +18,14 @@ Then point your mobile application to the `fever.php` address (e.g. `https://fre
 
 ## Compatible clients
 
-Tested with:
-
-* Android
-  * [Readably](https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably) (Closed source)
-
-* iOS
-  * [Fiery Feeds](https://apps.apple.com/app/fiery-feeds-rss-reader/id1158763303) (Closed source)
-  * [Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153) (Commercial)
-  * [Reeder](https://www.reederapp.com/) (Commercial) (Use its Google Reader API / native FreshRSS option when possible)
-
-* MacOS
-  * [ReadKit](https://apps.apple.com/app/readkit/id588726889) (Commercial)
-
-* Cross-Platform (Desktop: Windows, Linux and MacOS)
-  * [Fluent Reader](https://hyliu.me/fluent-reader/) ([Open Source](https://github.com/yang991178/fluent-reader))
+| App                                                                                | Platform            | Free Software                                            |
+|:----------------------------------------------------------------------------------:|:-------------------:|:--------------------------------------------------------:|
+|[Fluent Reader](https://hyliu.me/fluent-reader/)                                    |Windows, Linux, macOS|[Open Source](https://github.com/yang991178/fluent-reader)|
+|[Readably](https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably)|Android              |Closed Source                                             |
+|[Fiery Feeds](https://apps.apple.com/app/fiery-feeds-rss-reader/id1158763303)       |iOS                  |Closed Source                                             |
+|[Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153)                 |iOS                  |Commercial                                                |
+|[Reeder](https://www.reederapp.com/)                                                |iOS                  |Commercial                                                |
+|[ReadKit](https://apps.apple.com/app/readkit/id588726889)                           |macOS                |Commercial                                                |
 
 ## Features
 

--- a/docs/fr/users/06_Fever_API.md
+++ b/docs/fr/users/06_Fever_API.md
@@ -23,19 +23,14 @@ Connectez ensuite votre application mobile en utilisant l'adresse de l'API
 
 ## Clients compatibles
 
-Testé avec :
-
-* Android
-  * [Readably](https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably) (Propriétaire)
-
-* iOS
-  * [Fiery Feeds](https://apps.apple.com/app/fiery-feeds-rss-reader/id1158763303) (Propriétaire)
-  * [Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153) (Commercial)
-  * [Reeder](https://www.reederapp.com/) (Commercial) (Connectez-vous plutôt par son option Google Reader API)
-
-* MacOS
-  * [ReadKit](https://apps.apple.com/app/readkit/id588726889) (Commercial)
-
+| App                                                                                | Platform            | License                                            |
+|:----------------------------------------------------------------------------------:|:-------------------:|:--------------------------------------------------------:|
+|[Fluent Reader](https://hyliu.me/fluent-reader/)                                    |Windows, Linux, macOS|[BSD-3-Clause](https://github.com/yang991178/fluent-reader/blob/master/LICENSE)|
+|[Readably](https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably)|Android              |Source fermée                                             |
+|[Fiery Feeds](https://apps.apple.com/app/fiery-feeds-rss-reader/id1158763303)       |iOS                  |Source fermée                                             |
+|[Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153)                 |iOS                  |Source fermée                                             |
+|[Reeder](https://www.reederapp.com/)                                                |iOS                  |Source fermée                                              |
+|[ReadKit](https://apps.apple.com/app/readkit/id588726889)                           |macOS                |Source fermée                                              |
 
 ## Fonctionnalités
 


### PR DESCRIPTION
Fluent Reader is a desktop RSS reader built with Electron, React, and Fluent UI supporting Fever API.

See more: https://github.com/yang991178/fluent-reader


Changes proposed in this pull request:

- Add Fluent reader to API clients

Pull request checklist:

- [x] clear commit messages
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
