### PR TITLE
Trim whitespace for feed passwords

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -160,7 +160,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 			// HTTP information are useful if feed is protected behind a
 			// HTTP authentication
 			$user = trim(Minz_Request::param('http_user', ''));
-			$pass = Minz_Request::param('http_pass', '');
+			$pass = trim(Minz_Request::param('http_pass', ''));
 			$http_auth = '';
 			if ($user != '' && $pass != '') {	//TODO: Sanitize
 				$http_auth = $user . ':' . $pass;

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -93,7 +93,7 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 
 		if (Minz_Request::isPost()) {
 			$user = trim(Minz_Request::param('http_user_feed' . $id, ''));
-			$pass = Minz_Request::param('http_pass_feed' . $id, '');
+			$pass = trim(Minz_Request::param('http_pass_feed' . $id, ''));
 
 			$httpAuth = '';
 			if ($user != '' && $pass != '') {	//TODO: Sanitize


### PR DESCRIPTION
We output a space by default in the user interface for setting feed
passwords, in order to prevent aggressive password autocompletion
https://github.com/FreshRSS/FreshRSS/pull/881
However, user might not always override this white space when entering
the password. So here we trim.
(I believe legitimate leading / trailing spaces in passwords are
sufficiently rare not to be a problem)