### PR TITLE
Docker use Debian instead of Ubuntu

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM debian:10-slim
 
 ENV TZ UTC
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -1,7 +1,7 @@
 # Only relevant for Docker Hub or QEMU multi-architecture builds.
 # Prefer the normal `Dockerfile` if you are building manually on the targeted architecture.
 
-FROM arm32v7/ubuntu:19.10
+FROM arm32v7/debian:10-slim
 
 # Requires ./hooks/*
 COPY ./Docker/qemu-arm-* /usr/bin/


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3026
Ubuntu 19.10 has expired.
I still cannot get Ubuntu 20.04 to work on ARM (Raspberry Pi) https://github.com/FreshRSS/FreshRSS/pull/2943
Move to Debian 10 Buster instead of our current Ubuntu 19.10 (which was based on Debian 10 Buster).