### PR TITLE
When ssl_verify is false, decrease SSL security

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -381,6 +381,9 @@ class FreshRSS_Entry extends Minz_Model {
 		if (isset($attributes['ssl_verify'])) {
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $attributes['ssl_verify'] ? 2 : 0);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $attributes['ssl_verify'] ? true : false);
+			if (!$attributes['ssl_verify']) {
+				curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'DEFAULT@SECLEVEL=1');
+			}
 		}
 		$html = curl_exec($ch);
 		$c_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -184,6 +184,9 @@ function customSimplePie($attributes = array()) {
 	if (isset($attributes['ssl_verify'])) {
 		$curl_options[CURLOPT_SSL_VERIFYHOST] = $attributes['ssl_verify'] ? 2 : 0;
 		$curl_options[CURLOPT_SSL_VERIFYPEER] = $attributes['ssl_verify'] ? true : false;
+		if (!$attributes['ssl_verify']) {
+			$curl_options[CURLOPT_SSL_CIPHER_LIST] = 'DEFAULT@SECLEVEL=1';
+		}
 	}
 	$simplePie->set_curl_options($curl_options);
 


### PR DESCRIPTION
When `ssl_verify` option is set to false for a feed, allow lower security such as SHA-1 signatures.
Needed for older sites when FreshRSS is running on current Debian or Ubuntu.

* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900984
* https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
* https://stackoverflow.com/questions/58342699/php-curl-curl-error-35-error1414d172ssl-routinestls12-check-peer-sigalgwr

Fix error of type `cURL error 35: error:1414D172:SSL routines:tls12_check_peer_sigalg:wrong signature`

Example of feeds:
* https://www.version2.dk/it-nyheder/rss
* https://ing.dk/rss/nyheder