### PR TITLE
SimplePie: Fix HTTP 301 permanent redirection

### DIFF
--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -113,11 +113,11 @@ class SimplePie_File
 				curl_setopt($fp, CURLOPT_REFERER, SimplePie_Misc::url_remove_credentials($url));
 				curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
 				curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
-				if (!ini_get('open_basedir') && !ini_get('safe_mode') && version_compare(SimplePie_Misc::get_curl_version(), '7.15.2', '>='))
-				{
-					curl_setopt($fp, CURLOPT_FOLLOWLOCATION, 1);
-					curl_setopt($fp, CURLOPT_MAXREDIRS, $redirects);
-				}
+				//if (!ini_get('open_basedir') && !ini_get('safe_mode') && version_compare(SimplePie_Misc::get_curl_version(), '7.15.2', '>='))
+				//{
+				//	curl_setopt($fp, CURLOPT_FOLLOWLOCATION, 1);
+				//	curl_setopt($fp, CURLOPT_MAXREDIRS, $redirects);
+				//}
 				foreach ($curl_options as $curl_param => $curl_value) {
 					curl_setopt($fp, $curl_param, $curl_value);
 				}
@@ -151,8 +151,9 @@ class SimplePie_File
 						{
 							$this->redirects++;
 							$location = SimplePie_Misc::absolutize_url($this->headers['location'], $url);
+							
 							$previousStatusCode = $this->status_code;
-							$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen);
+							$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options, $syslog_enabled);
 							$this->permanent_url = ($previousStatusCode == 301) ? $location : $url;
 							return;
 						}
@@ -237,7 +238,7 @@ class SimplePie_File
 								$this->redirects++;
 								$location = SimplePie_Misc::absolutize_url($this->headers['location'], $url);
 								$previousStatusCode = $this->status_code;
-								$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen);
+								$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options, $syslog_enabled);
 								$this->permanent_url = ($previousStatusCode == 301) ? $location : $url;
 								return;
 							}

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -151,7 +151,6 @@ class SimplePie_File
 						{
 							$this->redirects++;
 							$location = SimplePie_Misc::absolutize_url($this->headers['location'], $url);
-							
 							$previousStatusCode = $this->status_code;
 							$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options, $syslog_enabled);
 							$this->permanent_url = ($previousStatusCode == 301) ? $location : $url;


### PR DESCRIPTION
When adding feeds it worked fine, but detecting permanent redirects for existing feeds was sometimes broken (only when PHP open_basedir was not set).

Indeed, using the built-in CURLOPT_FOLLOWLOCATION instead of the manual method in SimplePie hides the list of HTTP redirects along the way, and prevents the distinction of e.g. 301 vs. 302 redirects.

This patch disables CURLOPT_FOLLOWLOCATION in SimplePie, and fixes the manual method at the same time.
The use of CURLOPT_FOLLOWLOCATION was nevertheless not systematic (only when open_basedir was not set), so now there is only one logic independent of open_basedir.

I will send a PR upstream to SimplePie.

How to test: pick a feed with 301 redirection such as HTTP to HTTPS, e.g. http://ing.dk/rss/term/341
Manually change back to previous address (to simulate a feed that is changing address)
Refresh feed and observe whether the 301 redirect is obeyed.