### PR TITLE
[fix] Add text color to base theme

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -16,6 +16,7 @@ html, body {
 	margin: 0;
 	padding: 0;
 	background: white;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;
 }


### PR DESCRIPTION
How to test the feature manually:

1. Set browser font color to white or some light color.
  ![Screenshot_2020-09-28_11-32-35](https://user-images.githubusercontent.com/202757/94415833-61029b80-017e-11eb-826d-fe8178bcafb3.png)

2. Currently, the text will disappear against the white background.
  ![Screenshot_2020-09-28_11-32-17](https://user-images.githubusercontent.com/202757/94415854-65c74f80-017e-11eb-8a97-1b4d60535c61.png)

3. But with this change, it'll display as was implicitly intended.
  ![Screenshot_2020-09-28_11-34-58](https://user-images.githubusercontent.com/202757/94416089-ae7f0880-017e-11eb-8c4a-a73724e3557e.png)


- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/freshrss/freshrss/3196)
<!-- Reviewable:end -->
