### PR TITLE
Minz: support PHP8 lint

### DIFF
--- a/lib/Minz/ModelPdo.php
+++ b/lib/Minz/ModelPdo.php
@@ -158,9 +158,7 @@ abstract class MinzPDO extends PDO {
 
 	public function query($query, $fetch_mode = null, ...$fetch_mode_args) {
 		$query = $this->preSql($query);
-		return $fetch_mode ?
-			parent::query($query, $fetch_mode, ...$fetch_mode_args) :
-			parent::query($query);
+		return $fetch_mode ? parent::query($query, $fetch_mode, ...$fetch_mode_args) : parent::query($query);
 	}
 }
 

--- a/lib/Minz/ModelPdo.php
+++ b/lib/Minz/ModelPdo.php
@@ -157,8 +157,10 @@ abstract class MinzPDO extends PDO {
 	}
 
 	public function query($query, $fetch_mode = null, ...$fetch_mode_args) {
-		$statement = $this->preSql($statement);
-		return parent::query($statement, $fetch_mode);
+		$query = $this->preSql($query);
+		return $fetch_mode ?
+			parent::query($query, $fetch_mode, ...$fetch_mode_args) :
+			parent::query($query);
 	}
 }
 

--- a/lib/Minz/ModelPdo.php
+++ b/lib/Minz/ModelPdo.php
@@ -156,9 +156,9 @@ abstract class MinzPDO extends PDO {
 		return parent::exec($statement);
 	}
 
-	public function query($statement) {
+	public function query($query, $fetch_mode = null, ...$fetch_mode_args) {
 		$statement = $this->preSql($statement);
-		return parent::query($statement);
+		return parent::query($statement, $fetch_mode);
 	}
 }
 


### PR DESCRIPTION
Contributes to https://github.com/FreshRSS/FreshRSS/issues/3082
Fix PHP8 ```Fatal error: Declaration of MinzPDO::query($statement) must be
compatible with PDO::query(string $query, ?int $fetch_mode = null, mixed
...$fetch_mode_args) in /FreshRSS/lib/Minz/ModelPdo.php on line 159
Errors parsing /FreshRSS/lib/Minz/ModelPdo.php```