### PR TITLE
tell git .png and .waff files are not text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto eol=lf
+*.png -text
+*.waff -text
+*.waff2 -text


### PR DESCRIPTION
When I git-pull 1.17.0 and later, I immediately have "changed files" in the form of .png and .waff files that git wants to CRLF -> LF convert.  I can't stash these changes, can't check out another branch, etc until I have done something with them.
This addition to .gitattributes tells git these files are not text, so it doesn't try to end-of-line convert them.