### PR TITLE
Use of existing tag name via input field

### DIFF
--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -32,12 +32,14 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 			$checked = Minz_Request::paramTernary('checked');
 			if ($id_entry != false) {
 				$tagDAO = FreshRSS_Factory::createTagDao();
-				if ($existing_tag = $tagDAO->searchByName($name_tag)) {
-					// Use existing tag
-					$tagDAO->tagEntry($existing_tag->id(), $id_entry, $checked);
-				} else {
-					//Create new tag
-					$id_tag = $tagDAO->addTag(array('name' => $name_tag));
+				if ($id_tag == 0 && $name_tag != '' && $checked) {
+					if ($existing_tag = $tagDAO->searchByName($name_tag)) {
+					    // Use existing tag
+                        $tagDAO->tagEntry($existing_tag->id(), $id_entry, $checked);
+                    } else {
+                        //Create new tag
+                        $id_tag = $tagDAO->addTag(array('name' => $name_tag));
+                    }
 				}
 				if ($id_tag != 0) {
 					$tagDAO->tagEntry($id_tag, $id_entry, $checked);

--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -32,10 +32,13 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 			$checked = Minz_Request::paramTernary('checked');
 			if ($id_entry != false) {
 				$tagDAO = FreshRSS_Factory::createTagDao();
-				if ($id_tag == 0 && $name_tag != '' && $checked) {
-					//Create new tag
-					$id_tag = $tagDAO->addTag(array('name' => $name_tag));
-				}
+				if ($existing_tag = $tagDAO->searchByName($name_tag)) {
+						// Use existing tag
+						$tagDAO->tagEntry($existing_tag->id(), $id_entry, $checked);
+					} else {
+						//Create new tag
+						$id_tag = $tagDAO->addTag(array('name' => $name_tag));
+					}
 				if ($id_tag != 0) {
 					$tagDAO->tagEntry($id_tag, $id_entry, $checked);
 				}

--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -33,12 +33,12 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 			if ($id_entry != false) {
 				$tagDAO = FreshRSS_Factory::createTagDao();
 				if ($existing_tag = $tagDAO->searchByName($name_tag)) {
-						// Use existing tag
-						$tagDAO->tagEntry($existing_tag->id(), $id_entry, $checked);
-					} else {
-						//Create new tag
-						$id_tag = $tagDAO->addTag(array('name' => $name_tag));
-					}
+					// Use existing tag
+					$tagDAO->tagEntry($existing_tag->id(), $id_entry, $checked);
+				} else {
+					//Create new tag
+					$id_tag = $tagDAO->addTag(array('name' => $name_tag));
+				}
 				if ($id_tag != 0) {
 					$tagDAO->tagEntry($id_tag, $id_entry, $checked);
 				}


### PR DESCRIPTION
Use existing tag name, when tag name is typed into tag list's text field

Closes #3212 

Changes proposed in this pull request:

- When having a long list of tags, it's easier to type the tag name in the text field, than it is to scroll and find the tag down the list.

How to test the feature manually:

1. Write in a name of an extisting tag in the text field in the tag-list, and check the checkbox. The pre-existing tag is now checked

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
