### PR TITLE
Fixing user query searches

### DIFF
--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -43,7 +43,9 @@
 
 				<?php foreach (FreshRSS_Context::$user_conf->queries as $query) { ?>
 				<li class="item query">
-					<a href="<?= $query['url'] ?>"><?= $query['name'] ?></a>
+					<a href="<?= Minz_Url::display('/i/?search=' . urlencode($query['name'])) ?>">
+						<?= $query['name'] ?>
+					</a>
 				</li>
 				<?php } ?>
 


### PR DESCRIPTION
Selecting user queries in drop down, now executes search.

Changes proposed in this pull request:

- Changed href when seleced user query

How to test the feature manually:

1. Select user query and the user query is used as a search parameter

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
