### PR TITLE
Docker LogFormat Alpine

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -3,7 +3,7 @@ Listen 0.0.0.0:80
 DocumentRoot /var/www/FreshRSS/p/
 RemoteIPHeader X-Forwarded-For
 RemoteIPTrustedProxy 10.0.0.1/8 172.16.0.1/12 192.168.0.1/16
-LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy
+LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy
 CustomLog /dev/stdout combined_proxy
 ErrorLog /dev/stderr
 AllowEncodedSlashes On


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3233
In Alpine, we would need to enable mod_logio.c to use %O. Revert to more standard %b
https://httpd.apache.org/docs/2.4/mod/mod_log_config.html#logformat