### PR TITLE
db username regex relaxed to allow @

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -545,7 +545,7 @@ function printStep2() {
 		<div class="form-group">
 			<label class="group-name" for="user"><?= _t('install.bdd.username') ?></label>
 			<div class="group-controls">
-				<input type="text" id="user" name="user" maxlength="64" pattern="[0-9A-Za-z_.-]{1,64}" value="<?= isset($_SESSION['bd_user']) ? $_SESSION['bd_user'] : '' ?>" tabindex="3" />
+				<input type="text" id="user" name="user" maxlength="64" pattern="[0-9A-Za-z@_.-]{1,64}" value="<?= isset($_SESSION['bd_user']) ? $_SESSION['bd_user'] : '' ?>" tabindex="3" />
 			</div>
 		</div>
 


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- relax the regex that validates the database username during installation to allow names containing '@' , this is required to use 'Azure Database for PostgreSQL' where user names are 'user@dbname'


How to test the feature manually:
Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [-] unit tests written (optional if too hard)
- [-] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
