### PR TITLE
Fix initI18n

### DIFF
--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -90,8 +90,9 @@ class FreshRSS extends Minz_FrontController {
 	}
 
 	private static function initI18n() {
-		$selected_language = FreshRSS_Auth::hasAccess() ? FreshRSS_Context::$user_conf->language : null;
-		$language = Minz_Translate::getLanguage($selected_language, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
+		$userLanguage = isset(FreshRSS_Context::$user_conf) ? FreshRSS_Context::$user_conf->language : null;
+		$systemLanguage = isset(FreshRSS_Context::$system_conf) ? FreshRSS_Context::$system_conf->language : null;
+		$language = Minz_Translate::getLanguage($userLanguage, Minz_Request::getPreferredLanguages(), $systemLanguage);
 
 		Minz_Session::_param('language', $language);
 		Minz_Translate::init($language);

--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -103,7 +103,7 @@ class Minz_Translate {
 			}
 		}
 
-		return $default;
+		return $default ? $default : 'en';
 	}
 
 	/**


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3136
#fix https://github.com/FreshRSS/FreshRSS/issues/3246#issuecomment-725463337

It was due to calling `initI18n()` before `FreshRSS_Context` is initialised in some situations

Introduced by https://github.com/FreshRSS/FreshRSS/pull/3022
Will be better fixed when https://github.com/FreshRSS/FreshRSS/pull/3070 lands