### PR TITLE
Fixes a minor jaggy motion of the sidebar.

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1296,6 +1296,7 @@ input:checked + .slide-container .properties {
 
 	.aside:target {
 		width: 90%;
+		height: 200%;
 	}
 
 	.aside_feed .configure-feeds {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1296,7 +1296,7 @@ input:checked + .slide-container .properties {
 
 	.aside:target {
 		width: 90%;
-		height: 200%;
+		height: 100vh;
 	}
 
 	.aside_feed .configure-feeds {


### PR DESCRIPTION
Fixes jaggy motion of the sidebar while scrolling on mobile clients.

I didn't try many values aside from %200 cause it worked very well from the first time. I was using a Galaxy S8+

PS: Also, I use a value for the width of 50% instead of 90% for better aesthetics.

Closes #

Changes proposed in this pull request:

- Adding the variable "height" with a value of 200% to the sidebar
-
-

How to test the feature manually:

1. Any smartphone
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
