### PR TITLE
Better Date/Time improvements 

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -44,6 +44,6 @@
 			?></span><?php
 		endif;
 	?></a></li>
-	<?php if ($topline_date) { ?><li class="item date"><time datetime="<?= $this->entry->machineReadableDate() ?>"><?= $this->entry->date() ?></time>&nbsp;</li><?php } ?>
+	<?php if ($topline_date) { ?><li class="item date"><time datetime="<?= $this->entry->machineReadableDate() ?>"><?= date('Y-m-d h:i A',strtotime($this->entry->machineReadableDate())) ?></time>&nbsp;</li><?php } ?>
 	<?php if ($topline_link) { ?><li class="item link"><a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>" title="<?= _t('conf.shortcut.see_on_website') ?>"><?= _i('link') ?></a></li><?php } ?>
 </ul>


### PR DESCRIPTION
 #853

[Time format with a string](https://github.com/FreshRSS/FreshRSS/pull/3268/commits/325cf7b015ab5f3e88c3d757cfe5aaecc01066bf)

![ffed2](https://user-images.githubusercontent.com/9639436/100401628-182a6e80-306b-11eb-8172-fdd25174d4a5.jpg)

A better way to manage the date/time.
Maybe if we could give the user access to change the string somehow?
It could be better if the user can see the time passed since that post 

Changes proposed in this pull request:

- Better management for the Date/Time 
  * 12/24 Hours clock, Names of Days, Months, Years.
![feed23](https://user-images.githubusercontent.com/9639436/100401749-693a6280-306b-11eb-89d3-4e8feccf16ec.jpg)

- Showing up the time passed for the post. E.g 5 hours ago, 3 months ago.. etc

- Ui settings to make it easily customizable. . _sadly too much for me_

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
