### PR TITLE
Session compatibility PHP 7.1 and older

### DIFF
--- a/lib/Minz/Session.php
+++ b/lib/Minz/Session.php
@@ -12,14 +12,16 @@ class Minz_Session {
 	private static $locked = false;
 
 	public static function lock() {
-		if (!self::$volatile && !self::$locked && session_start()) {
+		if (!self::$volatile && !self::$locked) {
+			session_start();
 			self::$locked = true;
 		}
 		return self::$locked;
 	}
 
 	public static function unlock() {
-		if (!self::$volatile && session_write_close()) {
+		if (!self::$volatile) {
+			session_write_close();
 			self::$locked = false;
 		}
 		return self::$locked;


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3239
Reason: https://php.net/session-write-close used to return void and not boolean before PHP 7.2