### PR TITLE
Fix user queries with labels

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -288,7 +288,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 				if ($query['search']) {
 					$query['search'] = urldecode($query['search']);
 				}
-				$queries[] = new FreshRSS_UserQuery($query, $feed_dao, $category_dao);
+				$queries[] = new FreshRSS_UserQuery($query, $feed_dao, $category_dao, $tag_dao);
 			}
 			FreshRSS_Context::$user_conf->queries = $queries;
 			FreshRSS_Context::$user_conf->save();
@@ -298,7 +298,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 		} else {
 			$this->view->queries = array();
 			foreach (FreshRSS_Context::$user_conf->queries as $key => $query) {
-				$this->view->queries[$key] = new FreshRSS_UserQuery($query, $feed_dao, $category_dao);
+				$this->view->queries[$key] = new FreshRSS_UserQuery($query, $feed_dao, $category_dao, $tag_dao);
 			}
 		}
 

--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -76,7 +76,7 @@ class FreshRSS_UserQuery {
 	 */
 	private function parseGet($get) {
 		$this->get = $get;
-		if (preg_match('/(?P<type>[acfs])(_(?P<id>\d+))?/', $get, $matches)) {
+		if (preg_match('/(?P<type>[acfst])(_(?P<id>\d+))?/', $get, $matches)) {
 			switch ($matches['type']) {
 				case 'a':
 					$this->parseAll();

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Zobrazit "%s" kategorii',
 		'get_favorite' => 'Zobrazit oblíbené články',
 		'get_feed' => 'Zobrazit "%s" článkek',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Zrušit filtr',
 		'none' => 'Ještě jste nevytvořil žádný uživatelský dotaz.',
 		'number' => 'Dotaz n°%d',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Kategorie "%s" anzeigen',
 		'get_favorite' => 'Lieblingsartikel anzeigen',
 		'get_feed' => 'Feed "%s" anzeigen',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Kein Filter',
 		'none' => 'Sie haben bisher keine Benutzerabfrage erstellt.',
 		'number' => 'Abfrage Nr. %d',

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Display "%s" category',
 		'get_favorite' => 'Display favorite articles',
 		'get_feed' => 'Display "%s" feed',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'No filter',
 		'none' => 'You haven’t created any user queries yet.',
 		'number' => 'Query n°%d',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Display "%s" category',
 		'get_favorite' => 'Display favourite articles',
 		'get_feed' => 'Display "%s" feed',
+		'get_tag' => 'Display "%s" label',
 		'no_filter' => 'No filter',
 		'none' => 'You haven’t created any user queries yet.',
 		'number' => 'Query n°%d',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Mostrar la categoría "%s"',
 		'get_favorite' => 'Mostrar artículos favoritos',
 		'get_feed' => 'Mostrar fuente "%s"',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Sin filtro',
 		'none' => 'Todavía no has creado ninguna consulta de usuario.',
 		'number' => 'Consulta n° %d',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Afficher la catégorie "%s"',
 		'get_favorite' => 'Afficher les articles favoris',
 		'get_feed' => 'Afficher le flux "%s"',
+		'get_tag' => 'Afficher l’étiquette "%s"',
 		'no_filter' => 'Aucun filtre appliqué',
 		'none' => 'Vous n’avez pas encore créé de filtre.',
 		'number' => 'Filtre n°%d',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'הצגת קטגוריה "%s"',
 		'get_favorite' => 'הצגת מאמרים מועדפים',
 		'get_feed' => 'הצגת הזנה %s',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'ללא סינון',
 		'none' => 'אף שאילתה לא נוצרה עדיין.',
 		'number' => 'שאילתה מספר °%d',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Mostra la categoria "%s" ',
 		'get_favorite' => 'Mostra articoli preferiti',
 		'get_feed' => 'Mostra feed "%s" ',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Nessun filtro',
 		'none' => 'Non hai creato nessuna ricerca personale.',
 		'number' => 'Ricerca n°%d',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => '"%s" 카테고리 표시',
 		'get_favorite' => '즐겨찾기에 등록된 글 표시',
 		'get_feed' => '"%s" 피드 표시',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => '필터가 없습니다',
 		'none' => '아직 사용자 쿼리를 만들지 않았습니다.',
 		'number' => '쿼리 #%d',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Toon "%s" categorie',
 		'get_favorite' => 'Toon favoriete artikelen',
 		'get_feed' => 'Toon "%s" feed',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Geen filter',
 		'none' => 'U hebt nog geen gebruikers query aangemaakt..',
 		'number' => 'Query n°%d',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Mostrar la categoria « %s »',
 		'get_favorite' => 'Mostrar los articles favorits',
 		'get_feed' => 'Mostrar lo flux « %s »',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Cap de filtre aplicat',
 		'none' => 'Avètz pas encara creat cap de filtre.',
 		'number' => 'Filtre n°%d',

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Wyświetlenie kategorii "%s"',
 		'get_favorite' => 'Wyświetlenie ulubionych wiadomości',
 		'get_feed' => 'Wyświetlenie kanału "%s"',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Brak filtrów',
 		'none' => 'Nie zapisałeś jeszcze żadnego zapytania.',
 		'number' => 'Zapytanie nr %d',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Visualizar "%s" categoria',
 		'get_favorite' => 'Visualizar artigos favoritos',
 		'get_feed' => 'Visualizar "%s" feed',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Sem filtro',
 		'none' => 'Você não criou nenhuma query de usuário ainda.',
 		'number' => 'Query n°%d',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Display "%s" category',	// TODO - Translation
 		'get_favorite' => 'Display favorite articles',
 		'get_feed' => 'Display "%s" feed',	// TODO - Translation
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'No filter',	// TODO - Translation
 		'none' => 'You haven’t created any user query yet.',
 		'number' => 'Query n°%d',	// TODO - Translation

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => 'Zobraziť kategóriu "%s"',
 		'get_favorite' => 'Zobraziť obľúbené články',
 		'get_feed' => 'Zobraziť kanál "%s"',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Žiadny filter',
 		'none' => 'Zatiaľ ste nevytvorili používateľský dopyt.',
 		'number' => 'Dopyt číslo %d',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => '"%s" kategorisini göster',
 		'get_favorite' => 'Favori makaleleri göster',
 		'get_feed' => '"%s" akışını göster',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => 'Filtre yok',
 		'none' => 'Henüz hiç kullanıcı sorgusu oluşturmadınız.',
 		'number' => 'Sorgu n°%d',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -70,6 +70,7 @@ return array(
 		'get_category' => '显示分类 "%s"',
 		'get_favorite' => '显示收藏文章',
 		'get_feed' => '显示订阅源 "%s"',
+		'get_tag' => 'Display "%s" label',	// TODO - Translation
 		'no_filter' => '无过滤器',
 		'none' => '你未创建任何自定义查询。',
 		'number' => '查询 n°%d',


### PR DESCRIPTION
Closes #3215

Changes proposed in this pull request:

- Fix user queries translation when they use labels as filter

How to test the feature manually:

1. Create a label
2. Apply it on articles
3. Select the label to display only its linked articles
4. Create a user query based on that result
5. Check the user query configuration page to check the translation

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before user queries with labels were not translated. Actually, it was not
even processed.
Now those user queries are translated properly.

See #3215

