### PR TITLE
Better OPML import of feeds in multiple categories

### DIFF
--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -251,6 +251,13 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 		$nb_cats = count($this->catDAO->listCategories(false));
 		$limits = FreshRSS_Context::$system_conf->limits;
 
+		//Sort with categories first
+		usort($opml_elements, function ($a, $b) {
+			return strcmp(
+				(isset($a['xmlUrl']) ? 'Z' : 'A') . $a['text'],
+				(isset($b['xmlUrl']) ? 'Z' : 'A') . $b['text']);
+		});
+
 		foreach ($opml_elements as $elt) {
 			if (isset($elt['xmlUrl'])) {
 				// If xmlUrl exists, it means it is a feed


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3284
Helps https://github.com/FreshRSS/FreshRSS/issues/1989

In OPMLs files in which feeds are listed several times, favour the version in a category instead of in no category.