### PR TITLE
SimplePie Strip HTML comments

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -165,6 +165,7 @@ function customSimplePie($attributes = array()) {
 	}
 	$simplePie->set_curl_options($curl_options);
 
+	$simplePie->strip_comments(true);
 	$simplePie->strip_htmltags(array(
 		'base', 'blink', 'body', 'doctype', 'embed',
 		'font', 'form', 'frame', 'frameset', 'html',


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3282 (workaround what seems to be an nginx configuration bug)

We do not need to keep HTML comments in RSS content.