### PR TITLE
Fix tag management translation

### DIFF
--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -92,10 +92,10 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 		$tagDAO = FreshRSS_Factory::createTagDao();
 		if (null === $tagDAO->searchByName($name)) {
 			$tagDAO->addTag(['name' => $name]);
-			Minz_Request::good('feedback.tag.created', ['c' => 'tag', 'a' => 'index'], true);
+			Minz_Request::good(_t('feedback.tag.created', $name), ['c' => 'tag', 'a' => 'index'], true);
 		}
 
-		Minz_Request::bad('feedback.tag.name_exists', ['c' => 'tag', 'a' => 'index'], true);
+		Minz_Request::bad(_t('feedback.tag.name_exists', $name), ['c' => 'tag', 'a' => 'index'], true);
 	}
 
 	public function renameAction() {
@@ -103,17 +103,21 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 			Minz_Error::error(405);
 		}
 
-		$name = Minz_Request::param('name');
+		$targetName = Minz_Request::param('name');
+		$sourceId = Minz_Request::param('id_tag');
+
 		$tagDAO = FreshRSS_Factory::createTagDao();
-		$newTag = $tagDAO->searchByName($name);
-		if (null === $newTag) {
-			$tagDAO->updateTag(Minz_Request::param('id_tag'), ['name' => $name]);
+
+		$sourceName = $tagDAO->searchById($sourceId)->name();
+		$targetTag = $tagDAO->searchByName($targetName);
+		if (null === $targetTag) {
+			$tagDAO->updateTag($sourceId, ['name' => $targetName]);
 		} else {
-			$tagDAO->updateEntryTag(Minz_Request::param('id_tag'), $newTag->id());
-			$tagDAO->deleteTag(Minz_Request::param('id_tag'));
+			$tagDAO->updateEntryTag($sourceId, $targetTag->id());
+			$tagDAO->deleteTag($sourceId);
 		}
 
-		Minz_Request::good('feedback.tag.renamed', ['c' => 'tag', 'a' => 'index'], true);
+		Minz_Request::good(_t('feedback.tag.renamed', $sourceName, $targetName), ['c' => 'tag', 'a' => 'index'], true);
 	}
 
 	public function indexAction() {

--- a/app/i18n/cz/feedback.php
+++ b/app/i18n/cz/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Vyprázdněno (smazáno %d článků)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS bude nyní upgradováno na <strong>verzi %s</strong>.',
 		'error' => 'Během upgrade došlo k chybě: %s',

--- a/app/i18n/de/feedback.php
+++ b/app/i18n/de/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Bereinigung abgeschlossen (%d Artikel gelöscht)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS wird nun auf die <strong>Version %s</strong> aktualisiert.',
 		'error' => 'Der Aktualisierungsvorgang stieß auf einen Fehler: %s',

--- a/app/i18n/en-us/feedback.php
+++ b/app/i18n/en-us/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Purge completed (%d articles deleted)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',
 		'error' => 'The update process has encountered an error: %s',

--- a/app/i18n/en/feedback.php
+++ b/app/i18n/en/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Purge completed (%d articles deleted)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',
+		'name_exists' => 'Tag name already exists.',
+		'renamed' => 'Tag "%s" has been renamed to "%s".',
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',
 		'error' => 'The update process has encountered an error: %s',

--- a/app/i18n/es/feedback.php
+++ b/app/i18n/es/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Limpieza completada (se han eliminado %d artículos)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS se va a actualizar a la <strong>versión %s</strong>.',
 		'error' => 'Hubo un error durante el proceso de actualización: %s',

--- a/app/i18n/fr/feedback.php
+++ b/app/i18n/fr/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Purge effectuée (%d articles supprimés).',
 	),
+	'tag' => array(
+		'created' => 'L’étiquette "%s" a été créée.',
+		'name_exists' => 'L’étiquette existe déjà.',
+		'renamed' => 'L’étiquette "%s" a été renommée en "%s".',
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS va maintenant être mis à jour vers la <strong>version %s</strong>.',
 		'error' => 'La mise à jour a rencontré un problème : %s',

--- a/app/i18n/he/feedback.php
+++ b/app/i18n/he/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'הניקוי הושלם (%d מאמרים נמחקו)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will be now updated to the <strong>version %s</strong>.',
 		'error' => 'תהליך העדכון נתקל בשגיאה: %s',

--- a/app/i18n/it/feedback.php
+++ b/app/i18n/it/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Svecchiamento completato (%d articoli cancellati)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS verrà aggiornato alla <strong>versione %s</strong>.',
 		'error' => 'Il processo di aggiornamento ha riscontrato il seguente errore: %s',

--- a/app/i18n/kr/feedback.php
+++ b/app/i18n/kr/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => '삭제 완료 (%d 개의 글을 삭제했습니다)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS가 <strong>%s</strong> 버전으로 업데이트됩니다.',
 		'error' => '업데이트 과정에서 문제가 발생했습니다: %s',

--- a/app/i18n/nl/feedback.php
+++ b/app/i18n/nl/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Opschonen klaar (%d artikelen verwijderd)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS word nu vernieud naar <strong>versie %s</strong>.',
 		'error' => 'Het vernieuwingsproces kwam een fout tegen: %s',

--- a/app/i18n/oc/feedback.php
+++ b/app/i18n/oc/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Purga realizada (%s articles suprimits)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS es per èsser mes a jorn en <strong>version %s</strong>.',
 		'error' => 'La mesa a jorn a conegut un problèma : %s',

--- a/app/i18n/pl/feedback.php
+++ b/app/i18n/pl/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Purge completed (%d articles deleted)',	// TODO - Translation
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS zostanie zaktualizowany do <strong>wersji %s</strong>.',
 		'error' => 'Proces aktualizacji napotkał błąd: %s',

--- a/app/i18n/pt-br/feedback.php
+++ b/app/i18n/pt-br/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Limpeza completa (%d artigos deletados)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'O FreshRSS será atualizado para a <strong>versão %s</strong>.',
 		'error' => 'O processo de atualização encontrou um erro: %s',

--- a/app/i18n/ru/feedback.php
+++ b/app/i18n/ru/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Purge completed (%d articles deleted)',	// TODO - Translation
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',	// TODO - Translation
 		'error' => 'The update process has encountered an error: %s',	// TODO - Translation

--- a/app/i18n/sk/feedback.php
+++ b/app/i18n/sk/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Čistenie ukončené. Počet vymazaných článkov: %d',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS sa teraz aktualizuje <strong>na verziu %s</strong>.',
 		'error' => 'Počas aktualizácie sa vyskytla chyba: %s',

--- a/app/i18n/tr/feedback.php
+++ b/app/i18n/tr/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => 'Temizleme tamamlandı (%d makale silindi)',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS <strong>%s versiyonuna</strong> güncellenecek.',
 		'error' => 'Güncelleme işlemi sırasında hata: %s',

--- a/app/i18n/zh-cn/feedback.php
+++ b/app/i18n/zh-cn/feedback.php
@@ -109,6 +109,11 @@ return array(
 		),
 		'purge_completed' => '清除完成（已删除 %d 篇文章）',
 	),
+	'tag' => array(
+		'created' => 'Tag "%s" has been created.',	// TODO - Translation
+		'name_exists' => 'Tag name already exists.',	// TODO - Translation
+		'renamed' => 'Tag "%s" has been renamed to "%s".',	// TODO - Translation
+	),
 	'update' => array(
 		'can_apply' => 'FreshRSS 将更新到 <strong>版本 %s</strong>.',
 		'error' => '更新出错：%s',


### PR DESCRIPTION
Changes proposed in this pull request:

- Translate feedback messages when managing tags.

How to test the feature manually:

1. open the tag management page,
2. create or rename tags,
3. check feedback messages.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
