### PR TITLE
Add a file for each PDO class

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -241,7 +241,7 @@ class FreshRSS_DatabaseDAO extends Minz_ModelPdo {
 		$sqlite = null;
 
 		try {
-			$sqlite = new MinzPDOSQLite('sqlite:' . $filename);
+			$sqlite = new Minz_PdoSqlite('sqlite:' . $filename);
 		} catch (Exception $e) {
 			$error = 'Error while initialising SQLite copy: ' . $e->getMessage();
 			return self::stdError($error);

--- a/docs/en/developers/Minz/migrations.md
+++ b/docs/en/developers/Minz/migrations.md
@@ -18,7 +18,7 @@ Example:
 // File: app/migrations/2020_01_11_CreateFooTable.php
 class FreshRSS_Migration_2020_01_11_CreateFooTable {
 	public static function migrate() {
-		$pdo = new MinzPDOSQLite('sqlite:/some/path/db.sqlite');
+		$pdo = new Minz_PdoSqlite('sqlite:/some/path/db.sqlite');
 		$result = $pdo->exec('CREATE TABLE foos (bar TEXT)');
 		if ($result === false) {
 			$error = $pdo->errorInfo();

--- a/lib/Minz/ModelPdo.php
+++ b/lib/Minz/ModelPdo.php
@@ -1,8 +1,9 @@
 <?php
+
 /**
  * MINZ - Copyright 2011 Marien Fressinaud
  * Sous licence AGPL3 <http://www.gnu.org/licenses/>
-*/
+ */
 
 /**
  * La classe Model_sql représente le modèle interragissant avec les bases de données
@@ -63,12 +64,12 @@ class Minz_ModelPdo {
 						$dsn .= ';port=' . $dbServer['port'];
 					}
 					$driver_options[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES utf8mb4';
-					$this->pdo = new MinzPDOMySql($dsn . $dsnParams, $db['user'], $db['password'], $driver_options);
+					$this->pdo = new Minz_PdoMysql($dsn . $dsnParams, $db['user'], $db['password'], $driver_options);
 					$this->pdo->setPrefix($db['prefix'] . $currentUser . '_');
 					break;
 				case 'sqlite':
 					$dsn = 'sqlite:' . join_path(DATA_PATH, 'users', $currentUser, 'db.sqlite');
-					$this->pdo = new MinzPDOSQLite($dsn . $dsnParams, $db['user'], $db['password'], $driver_options);
+					$this->pdo = new Minz_PdoSqlite($dsn . $dsnParams, $db['user'], $db['password'], $driver_options);
 					$this->pdo->setPrefix('');
 					break;
 				case 'pgsql':
@@ -79,7 +80,7 @@ class Minz_ModelPdo {
 					if (!empty($dbServer['port'])) {
 						$dsn .= ';port=' . $dbServer['port'];
 					}
-					$this->pdo = new MinzPDOPGSQL($dsn . $dsnParams, $db['user'], $db['password'], $driver_options);
+					$this->pdo = new Minz_PdoPgsql($dsn . $dsnParams, $db['user'], $db['password'], $driver_options);
 					$this->pdo->setPrefix($db['prefix'] . $currentUser . '_');
 					break;
 				default:
@@ -113,97 +114,5 @@ class Minz_ModelPdo {
 	public static function clean() {
 		self::$sharedPdo = null;
 		self::$sharedCurrentUser = '';
-	}
-}
-
-abstract class MinzPDO extends PDO {
-	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
-		parent::__construct($dsn, $username, $passwd, $options);
-		$this->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-	}
-
-	abstract public function dbType();
-
-	private $prefix = '';
-	public function prefix() { return $this->prefix; }
-	public function setPrefix($prefix) { $this->prefix = $prefix; }
-
-	private function autoPrefix($sql) {
-		return str_replace('`_', '`' . $this->prefix, $sql);
-	}
-
-	protected function preSql($statement) {
-		if (preg_match('/^(?:UPDATE|INSERT|DELETE)/i', $statement)) {
-			invalidateHttpCache();
-		}
-		return $this->autoPrefix($statement);
-	}
-
-	public function lastInsertId($name = null) {
-		if ($name != null) {
-			$name = $this->preSql($name);
-		}
-		return parent::lastInsertId($name);
-	}
-
-	public function prepare($statement, $driver_options = array()) {
-		$statement = $this->preSql($statement);
-		return parent::prepare($statement, $driver_options);
-	}
-
-	public function exec($statement) {
-		$statement = $this->preSql($statement);
-		return parent::exec($statement);
-	}
-
-	public function query($query, $fetch_mode = null, ...$fetch_mode_args) {
-		$query = $this->preSql($query);
-		return $fetch_mode ? parent::query($query, $fetch_mode, ...$fetch_mode_args) : parent::query($query);
-	}
-}
-
-class MinzPDOMySql extends MinzPDO {
-	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
-		parent::__construct($dsn, $username, $passwd, $options);
-		$this->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
-	}
-
-	public function dbType() {
-		return 'mysql';
-	}
-
-	public function lastInsertId($name = null) {
-		return parent::lastInsertId();	//We discard the name, only used by PostgreSQL
-	}
-}
-
-class MinzPDOSQLite extends MinzPDO {
-	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
-		parent::__construct($dsn, $username, $passwd, $options);
-		$this->exec('PRAGMA foreign_keys = ON;');
-	}
-
-	public function dbType() {
-		return 'sqlite';
-	}
-
-	public function lastInsertId($name = null) {
-		return parent::lastInsertId();	//We discard the name, only used by PostgreSQL
-	}
-}
-
-class MinzPDOPGSQL extends MinzPDO {
-	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
-		parent::__construct($dsn, $username, $passwd, $options);
-		$this->exec("SET NAMES 'UTF8';");
-	}
-
-	public function dbType() {
-		return 'pgsql';
-	}
-
-	protected function preSql($statement) {
-		$statement = parent::preSql($statement);
-		return str_replace(array('`', ' LIKE '), array('"', ' ILIKE '), $statement);
 	}
 }

--- a/lib/Minz/Pdo.php
+++ b/lib/Minz/Pdo.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * MINZ - Copyright 2011 Marien Fressinaud
+ * Sous licence AGPL3 <http://www.gnu.org/licenses/>
+ */
+
+abstract class Minz_Pdo extends PDO {
+	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
+		parent::__construct($dsn, $username, $passwd, $options);
+		$this->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+	}
+
+	abstract public function dbType();
+
+	private $prefix = '';
+	public function prefix() { return $this->prefix; }
+	public function setPrefix($prefix) { $this->prefix = $prefix; }
+
+	private function autoPrefix($sql) {
+		return str_replace('`_', '`' . $this->prefix, $sql);
+	}
+
+	protected function preSql($statement) {
+		if (preg_match('/^(?:UPDATE|INSERT|DELETE)/i', $statement)) {
+			invalidateHttpCache();
+		}
+		return $this->autoPrefix($statement);
+	}
+
+	public function lastInsertId($name = null) {
+		if ($name != null) {
+			$name = $this->preSql($name);
+		}
+		return parent::lastInsertId($name);
+	}
+
+	public function prepare($statement, $driver_options = array()) {
+		$statement = $this->preSql($statement);
+		return parent::prepare($statement, $driver_options);
+	}
+
+	public function exec($statement) {
+		$statement = $this->preSql($statement);
+		return parent::exec($statement);
+	}
+
+	public function query($query, $fetch_mode = null, ...$fetch_mode_args) {
+		$query = $this->preSql($query);
+		return $fetch_mode ? parent::query($query, $fetch_mode, ...$fetch_mode_args) : parent::query($query);
+	}
+}

--- a/lib/Minz/PdoMysql.php
+++ b/lib/Minz/PdoMysql.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * MINZ - Copyright 2011 Marien Fressinaud
+ * Sous licence AGPL3 <http://www.gnu.org/licenses/>
+ */
+
+class Minz_PdoMysql extends Minz_Pdo {
+	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
+		parent::__construct($dsn, $username, $passwd, $options);
+		$this->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+	}
+
+	public function dbType() {
+		return 'mysql';
+	}
+
+	public function lastInsertId($name = null) {
+		return parent::lastInsertId();	//We discard the name, only used by PostgreSQL
+	}
+}

--- a/lib/Minz/PdoPgsql.php
+++ b/lib/Minz/PdoPgsql.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * MINZ - Copyright 2011 Marien Fressinaud
+ * Sous licence AGPL3 <http://www.gnu.org/licenses/>
+ */
+
+class Minz_PdoPgsql extends Minz_Pdo {
+	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
+		parent::__construct($dsn, $username, $passwd, $options);
+		$this->exec("SET NAMES 'UTF8';");
+	}
+
+	public function dbType() {
+		return 'pgsql';
+	}
+
+	protected function preSql($statement) {
+		$statement = parent::preSql($statement);
+		return str_replace(array('`', ' LIKE '), array('"', ' ILIKE '), $statement);
+	}
+}

--- a/lib/Minz/PdoSqlite.php
+++ b/lib/Minz/PdoSqlite.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * MINZ - Copyright 2011 Marien Fressinaud
+ * Sous licence AGPL3 <http://www.gnu.org/licenses/>
+ */
+
+class Minz_PdoSqlite extends Minz_Pdo {
+	public function __construct($dsn, $username = null, $passwd = null, $options = null) {
+		parent::__construct($dsn, $username, $passwd, $options);
+		$this->exec('PRAGMA foreign_keys = ON;');
+	}
+
+	public function dbType() {
+		return 'sqlite';
+	}
+
+	public function lastInsertId($name = null) {
+		return parent::lastInsertId();	//We discard the name, only used by PostgreSQL
+	}
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- split Minz pdo file to have a class per file

How to test the feature manually:

1. Use the application, as the modification changes the database access, you'll notice right away if it's not working.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, we had 5 classes in the ModelPdo file. It was bad for 2 reasons.
The first reason is that it is considered bad practice to have multiple
class in one file. This is especially true when using autoloading. On top
of that it is less readable considering the size of the file. The second
reason is that so far we were lucky. Everytime we needed to access the
database, it was through the ModelPdo class which loads all the other
classes. If we want to access directly the connection, it wont be loaded.
On top of that, the system is configured to work on a single database,
but as we have every connection definition in a single file, all classes
were loaded at the same time. Thus using memory and processing time for
nothing.
Now, we have a file for each class. To work with autoloading, classes
were slightly renamed to match autoloading rules.
