### PR TITLE
Remove Minz validation during install.

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -384,12 +384,6 @@ function printStep1() {
 	<p class="alert alert-error"><span class="alert-head"><?= _t('gen.short.damn') ?></span> <?= _t('install.check.php.nok', PHP_VERSION, '5.6.0') ?></p>
 	<?php } ?>
 
-	<?php if ($res['minz'] == 'ok') { ?>
-	<p class="alert alert-success"><span class="alert-head"><?= _t('gen.short.ok') ?></span> <?= _t('install.check.minz.ok') ?></p>
-	<?php } else { ?>
-	<p class="alert alert-error"><span class="alert-head"><?= _t('gen.short.damn') ?></span> <?= _t('install.check.minz.nok', join_path(LIB_PATH, 'Minz')) ?></p>
-	<?php } ?>
-
 	<?php if ($res['pdo'] == 'ok') { ?>
 	<p class="alert alert-success"><span class="alert-head"><?= _t('gen.short.ok') ?></span> <?= _t('install.check.pdo.ok') ?></p>
 	<?php } else { ?>

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -7,7 +7,6 @@ Minz_Configuration::register('default_user', join_path(FRESHRSS_PATH, 'config-us
 
 function checkRequirements($dbType = '') {
 	$php = version_compare(PHP_VERSION, '5.6.0') >= 0;
-	$minz = file_exists(join_path(LIB_PATH, 'Minz'));
 	$curl = extension_loaded('curl');
 	$pdo_mysql = extension_loaded('pdo_mysql');
 	$pdo_sqlite = extension_loaded('pdo_sqlite');
@@ -50,7 +49,6 @@ function checkRequirements($dbType = '') {
 
 	return array(
 		'php' => $php ? 'ok' : 'ko',
-		'minz' => $minz ? 'ok' : 'ko',
 		'curl' => $curl ? 'ok' : 'ko',
 		'pdo-mysql' => $pdo_mysql ? 'ok' : 'ko',
 		'pdo-sqlite' => $pdo_sqlite ? 'ok' : 'ko',
@@ -69,7 +67,7 @@ function checkRequirements($dbType = '') {
 		'favicons' => $favicons ? 'ok' : 'ko',
 		'http_referer' => $http_referer ? 'ok' : 'ko',
 		'message' => $message ?: 'ok',
-		'all' => $php && $minz && $curl && $pdo && $pcre && $ctype && $dom && $xml &&
+		'all' => $php && $curl && $pdo && $pcre && $ctype && $dom && $xml &&
 		         $data && $cache && $users && $favicons && $http_referer && $message == '' ? 'ok' : 'ko'
 	);
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- remove Minz validation during install

How to test the feature manually:

1. install FRSS and check step 1 messages

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

As FRSS always comes with Minz, there is no need to validate that
it is there during install. If it turns out we need to validate that,
we might need to validate other libraries as well.