### PR TITLE
Trim rid param from user query

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -321,6 +321,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			$queries[$key] = new FreshRSS_UserQuery($query, $feed_dao, $category_dao, $tag_dao);
 		}
 		$params = Minz_Request::fetchGET();
+		unset($params['rid']);
 		$params['url'] = Minz_Url::display(array('params' => $params));
 		$params['name'] = _t('conf.query.number', count($queries) + 1);
 		$queries[] = new FreshRSS_UserQuery($params, $feed_dao, $category_dao, $tag_dao);


### PR DESCRIPTION
Caused by https://github.com/FreshRSS/FreshRSS/pull/3208
Before, the 'rid' parameter was saved as part of the user query.