### PR TITLE
Fix author search link

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -88,7 +88,7 @@ $today = @strtotime('today');
 								echo $first ? _t('gen.short.by_author') . ' ' : '· ';
 								$first = false;
 					?>
-	<em><a href="<?= _url('index', 'index', 'search', 'author:' . str_replace(' ', '+', htmlspecialchars_decode($author, ENT_QUOTES))) ?>"><?= $author ?></a></em>
+	<em><a href="<?= Minz_Url::display(Minz_Request::modifiedCurrentRequest(['search' => 'author:' . str_replace(' ', '+', htmlspecialchars_decode($author, ENT_QUOTES))])) ?>"><?= $author ?></a></em>
 					<?php	endforeach; ?>
 					</div><?php endif; ?>
 				</div>

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -57,7 +57,7 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 							echo $first ? _t('gen.short.by_author') . ' ' : '· ';
 							$first = false;
 				?>
-<em><a href="<?= _url('index', 'index', 'search', 'author:' . str_replace(' ', '+', htmlspecialchars_decode($author, ENT_QUOTES))) ?>"><?= $author ?></a></em>
+<em><a href="<?= Minz_Url::display(Minz_Request::modifiedCurrentRequest(['search' => 'author:' . str_replace(' ', '+', htmlspecialchars_decode($author, ENT_QUOTES))])) ?>"><?= $author ?></a></em>
 				<?php
 						endforeach;
 						echo ' — ';

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -71,6 +71,13 @@ class Minz_Request {
 			'params' => self::$params,
 		);
 	}
+	public static function modifiedCurrentRequest(array $extraParams = null) {
+		$currentRequest = self::currentRequest();
+		if (null !== $extraParams) {
+			$currentRequest['params'] = array_merge($currentRequest['params'], $extraParams);
+		}
+		return $currentRequest;
+	}
 
 	/**
 	 * Setteurs


### PR DESCRIPTION
Closes #3314

Changes proposed in this pull request:

- fix author filter when the feed is not in the main stream

How to test the feature manually:

1. Select a feed that is not visible in the main stream
2. Click the author of an article to filter
3. There should be some results

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, when clicking on the author link, the search was done on the
main stream in the normal view. It's fine until the feed is not visible
in the main stream.
Now, the current context is used along with the search.