### PR TITLE
Fix init system

### DIFF
--- a/p/i/index.php
+++ b/p/i/index.php
@@ -63,6 +63,7 @@ if (file_exists(DATA_PATH . '/do-install.txt')) {
 		// Apply the migrations if any
 		$result = Minz_Migrator::execute($migrations_path, $applied_migrations_path);
 		if ($result === true) {
+			FreshRSS_Context::initSystem();
 			$front_controller = new FreshRSS();
 			$front_controller->init();
 			Minz_Session::_param('keepAlive', 1);	//To prevent the PHP session from expiring


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3323
System would crash when no `FRESHRSS_ENV` environment was set, due to

https://github.com/FreshRSS/FreshRSS/blob/31cb07ac1acf7bad8c1bf6bbef45a17f4e0edbf3/lib/Minz/FrontController.php#L116-L119