### PR TITLE
Fix share option sort

### DIFF
--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -43,6 +43,10 @@ class FreshRSS_Share {
 			$share_options['type'] = $share_type;
 			self::register($share_options);
 		}
+
+		uasort(self::$list_sharing, function ($a, $b) {
+			return strcasecmp($a->name(), $b->name());
+		});
 	}
 
 	/**


### PR DESCRIPTION
Changes proposed in this pull request:

- Change share option sort in the configuration page

How to test the feature manually:

1. Go to the share configuration page.
2. Display the share drop-down list.
3. Shares must be sorted alphabetically.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, share options were displayed in the order defined in the
configuration file. So the order reflected the share history and
was not really usable.
Now, share options are displayed in alphabetical order which makes
much more sense.