### PR TITLE
Change base extension class type

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -3,7 +3,7 @@
 /**
  * The extension base class.
  */
-class Minz_Extension {
+abstract class Minz_Extension {
 	private $name;
 	private $entrypoint;
 	private $path;
@@ -31,11 +31,9 @@ class Minz_Extension {
 	 * - version: a version for the current extension.
 	 * - type: "system" or "user" (default).
 	 *
-	 * It must not be redefined by child classes.
-	 *
 	 * @param $meta_info contains information about the extension.
 	 */
-	public function __construct($meta_info) {
+	final public function __construct($meta_info) {
 		$this->name = $meta_info['name'];
 		$this->entrypoint = $meta_info['entrypoint'];
 		$this->path = $meta_info['path'];
@@ -50,8 +48,6 @@ class Minz_Extension {
 	/**
 	 * Used when installing an extension (e.g. update the database scheme).
 	 *
-	 * It must be redefined by child classes.
-	 *
 	 * @return true if the extension has been installed or a string explaining
 	 *         the problem.
 	 */
@@ -63,8 +59,6 @@ class Minz_Extension {
 	 * Used when uninstalling an extension (e.g. revert the database scheme to
 	 * cancel changes from install).
 	 *
-	 * It must be redefined by child classes.
-	 *
 	 * @return true if the extension has been uninstalled or a string explaining
 	 *         the problem.
 	 */
@@ -75,10 +69,8 @@ class Minz_Extension {
 	/**
 	 * Call at the initialization of the extension (i.e. when the extension is
 	 * enabled by the extension manager).
-	 *
-	 * It must be redefined by child classes.
 	 */
-	public function init() {}
+	abstract public function init();
 
 	/**
 	 * Set the current extension to enable.
@@ -115,8 +107,6 @@ class Minz_Extension {
 
 	/**
 	 * Handle the configure action.
-	 *
-	 * It must be redefined by child classes.
 	 */
 	public function handleConfigureAction() {}
 

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -172,14 +172,6 @@ class Minz_ExtensionManager {
 			                  '` is not an instance of `Minz_Extension`');
 			return null;
 		}
-		$reflector = new ReflectionClass($extension);
-		$className = $reflector->getName();
-		if ('Minz_Extension' === $reflector->getMethod('handleConfigureAction')->class ||
-			'Minz_Extension' === $reflector->getMethod('install')->class ||
-			'Minz_Extension' === $reflector->getMethod('init')->class ||
-			'Minz_Extension' === $reflector->getMethod('uninstall')->class) {
-			Minz_Log::error("The '{$className}' extension class definition is deprecated. It will continue to work with the current version but will break in the future. The '{$className}' extension class needs to override the 'handleConfigurationAction' method, the 'install' method, the 'init' method, and the 'uninstall' method to work properly.");
-		}
 
 		return $extension;
 	}


### PR DESCRIPTION
Changes proposed in this pull request:

- Change the extension base class to abstract

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, there was some guidelines on how to use the extension class
and how to extend it. Those guidelines were defined as comments.
Now, those guidelines are enforced by the code itself. There is no
need for those comments anymore.

Beware, this change will break every extension that are not following
those guideline. I've made the change for the core extensions but works
need to be done for the others.
