### PR TITLE
Add autofocus on subscription page

### DIFF
--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -27,7 +27,7 @@
 		<div class="form-group">
 			<label class="group-name" for="url_rss"><?= _t('sub.feed.url') ?></label>
 			<div class="group-controls">
-				<input id="url_rss" name="url_rss" type="url" required="required" autocomplete="off" class="long"/>
+				<input id="url_rss" name="url_rss" type="url" required="required" autocomplete="off" class="long" autofocus="autofocus" />
 			</div>
 		</div>
 


### PR DESCRIPTION
Changes proposed in this pull request:

- autofocusing on the URL input when landing on the subscription page

How to test the feature manually:

1. Open the subscription page
2. Check that the focus is on the feed URL input

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, there was no autofocusing on the subscription page. It feels
a bit off since most of the time, when you're landing on that page
you want to add a new feed.
Now, the focus is on the feed URL input to smooth the process of adding
a feed.