### PR TITLE
Add a deprecation log error for extensions

### DIFF
--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -172,6 +172,14 @@ class Minz_ExtensionManager {
 			                  '` is not an instance of `Minz_Extension`');
 			return null;
 		}
+		$reflector = new ReflectionClass($extension);
+		$className = $reflector->getName();
+		if ('Minz_Extension' === $reflector->getMethod('handleConfigureAction')->class ||
+			'Minz_Extension' === $reflector->getMethod('install')->class ||
+			'Minz_Extension' === $reflector->getMethod('init')->class ||
+			'Minz_Extension' === $reflector->getMethod('uninstall')->class) {
+			Minz_Log::error("The '{$className}' extension class definition is deprecated. It will continue to work with the current version but will break in the future. The '{$className}' extension class needs to override the 'handleConfigurationAction' method, the 'install' method, the 'init' method, and the 'uninstall' method to work properly.");
+		}
 
 		return $extension;
 	}


### PR DESCRIPTION
Changes proposed in this pull request:

- Add error when loading extension which do not override mandatory methods

How to test the feature manually:

1. Browse the logs

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Extensions must override some parent methods. The rule is just a
guideline because only described in comments. The idea is to
deprecate that flexibility and add it to the code. To warn users
beforehand, we log error message regarding incomplete extensions.

See #3333
