### PR TITLE
two new hooks

### DIFF
--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -175,6 +175,10 @@
 		</a>
 	</div>
 
+	<div class="stick" id="nav_menu_hooks">
+		<?= Minz_ExtensionManager::callHook('nav_menu') ?>
+	</div>
+
 	<div class="item search">
 		<form action="<?= _url('index', 'index') ?>" method="get">
 			<input type="search" name="search" class="extend" value="<?php

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -1,6 +1,7 @@
 <?php
 $mark = FreshRSS_Context::$user_conf->mark_when;
 $s = validateShortcutList(FreshRSS_Context::$user_conf->shortcuts);
+$extData = Minz_ExtensionManager::callHook('js_vars', array());
 echo htmlspecialchars(json_encode(array(
 	'context' => array(
 		'anonymous' => !FreshRSS_Auth::hasAccess(),
@@ -62,4 +63,5 @@ echo htmlspecialchars(json_encode(array(
 		'read' => rawurlencode(_i('read')),
 		'unread' => rawurlencode(_i('unread')),
 	),
+	'extensions' => $extData,
 ), JSON_UNESCAPED_UNICODE), ENT_NOQUOTES, 'UTF-8');

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -1,7 +1,7 @@
 <?php
 $mark = FreshRSS_Context::$user_conf->mark_when;
 $s = validateShortcutList(FreshRSS_Context::$user_conf->shortcuts);
-$extData = Minz_ExtensionManager::callHook('js_vars', array());
+$extData = Minz_ExtensionManager::callHook('js_vars', []);
 echo htmlspecialchars(json_encode(array(
 	'context' => array(
 		'anonymous' => !FreshRSS_Auth::hasAccess(),

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -331,7 +331,7 @@ The following events are available:
 * `menu_admin_entry` (`function() -> string`): add an entry at the end of the "Administration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
 * `menu_configuration_entry` (`function() -> string`): add an entry at the end of the "Configuration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
 * `menu_other_entry` (`function() -> string`): add an entry at the end of the header dropdown menu (i.e. after the "About" entry), the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
-* `nav_menu` (`function() -> string`): will be exectuted if the navigation was build.
+* `nav_menu` (`function() -> string`): will be executed if the navigation was built.
 * `nav_reading_modes` (`function($reading_modes) -> array | null`): **TODO** add documentation
 * `post_update` (`function(none) -> none`): **TODO** add documentation
 * `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -327,9 +327,11 @@ The following events are available:
 * `feed_before_actualize` (`function($feed) -> Feed | null`): will be executed when a feed is updated. The feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `feed_before_insert` (`function($feed) -> Feed | null`): will be executed when a new feed is imported into the database. The new feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `freshrss_init` (`function() -> none`): will be executed at the end of the initialization of FreshRSS, useful to initialize components or to do additional access checks
+* `js_vars` (`function($vars = array) -> array | null`): will be executed if the `jsonVars` in the header will be generated
 * `menu_admin_entry` (`function() -> string`): add an entry at the end of the "Administration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
 * `menu_configuration_entry` (`function() -> string`): add an entry at the end of the "Configuration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
 * `menu_other_entry` (`function() -> string`): add an entry at the end of the header dropdown menu (i.e. after the "About" entry), the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
+* `nav_menu` (`function() -> string`): will be exectuted if the navigation was build.
 * `nav_reading_modes` (`function($reading_modes) -> array | null`): **TODO** add documentation
 * `post_update` (`function(none) -> none`): **TODO** add documentation
 * `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -39,6 +39,10 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'NoneToNone',
 		),
+		'js_vars' => array(  // function($vars = array) -> array | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
 		'menu_admin_entry' => array(  // function() -> string
 			'list' => array(),
 			'signature' => 'NoneToString',
@@ -48,6 +52,10 @@ class Minz_ExtensionManager {
 			'signature' => 'NoneToString',
 		),
 		'menu_other_entry' => array(  // function() -> string
+			'list' => array(),
+			'signature' => 'NoneToString',
+		),
+		'nav_menu' => array(  // function() -> string
 			'list' => array(),
 			'signature' => 'NoneToString',
 		),

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -43,6 +43,7 @@ var context;
 	context.icons = json.icons;
 	context.icons.read = decodeURIComponent(context.icons.read);
 	context.icons.unread = decodeURIComponent(context.icons.unread);
+	context.extensions = json.extensions;
 }());
 //</Global context>
 


### PR DESCRIPTION
For my new extension [Copy2Clipboard](https://github.com/cn-tools/cntools_FreshRssExtensions) i need 2 new hooks.


Changes proposed in this pull request:

- Add hook to add some navigation options: Now the developers of extensions have the chance to add additional navigation points. In my case, i add an COPY button.
- Add hook to add some jsonVars: In my case i need some translated texts in the javascript section. With this hook i can add this texts into the `jsonVar` script-tag and in my javascript code i can use this text with `context.extensions.copy2clipboard.msg_good_more`.

Pull request checklist:

- [ ] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated - EN only!

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
