### PR TITLE
Add user query manual sorting

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -275,6 +275,8 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 	 * checking if categories and feeds are still in use.
 	 */
 	public function queriesAction() {
+		Minz_View::appendScript(Minz_Url::display('/scripts/user.query.js?' . @filemtime(PUBLIC_PATH . '/scripts/user.query.js')));
+
 		$category_dao = FreshRSS_Factory::createCategoryDao();
 		$feed_dao = FreshRSS_Factory::createFeedDao();
 		$tag_dao = FreshRSS_Factory::createTagDao();

--- a/app/views/configure/queries.phtml
+++ b/app/views/configure/queries.phtml
@@ -77,7 +77,6 @@
 		<div class="form-group form-actions">
 			<div class="group-controls">
 				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
-				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 			</div>
 		</div>
 		<?php } else { ?>

--- a/app/views/configure/queries.phtml
+++ b/app/views/configure/queries.phtml
@@ -3,12 +3,12 @@
 <div class="post">
 	<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
 
-	<form method="post" action="<?= _url('configure', 'queries') ?>">
+	<form method="post" action="<?= _url('configure', 'queries') ?>" id="configureQueries">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<legend><?= _t('conf.query') ?></legend>
 
 		<?php foreach ($this->queries as $key => $query) { ?>
-		<div class="form-group" id="query-group-<?= $key ?>">
+		<div class="form-group" id="query-group-<?= $key ?>" draggable="true">
 			<label class="group-name" for="queries_<?= $key ?>_name">
 				<?= _t('conf.query.number', $key + 1) ?>
 			</label>

--- a/p/scripts/user.query.js
+++ b/p/scripts/user.query.js
@@ -1,0 +1,48 @@
+// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-3.0
+"use strict";
+/* jshint esversion:6, strict:global */
+
+function init_draggable() {
+	if (!window.context) {
+		if (window.console) {
+			console.log('FreshRSS user query waiting for JS…');
+		}
+		setTimeout(init_draggable, 50);
+		return;
+	}
+	
+	let source;
+	const configureQueries = document.querySelector('#configureQueries');
+
+	configureQueries.addEventListener('dragstart', event => {
+		source = event.target.closest('[draggable="true"]');
+		event.dataTransfer.setData('text/html', source.outerHTML);
+		event.dataTransfer.effectAllowed = 'move';
+	});
+	configureQueries.addEventListener('dragover', event => event.preventDefault());
+	configureQueries.addEventListener('dragleave', event => event.preventDefault());
+	configureQueries.addEventListener('drop', event => {
+		event.preventDefault();
+		event.stopPropagation();
+		const dropQuery = event.target.closest('[draggable="true"]');
+		if (null === dropQuery) {
+			source.remove();
+			configureQueries.querySelector('legend').insertAdjacentHTML('afterend', event.dataTransfer.getData('text/html'));
+		} else if (source !== dropQuery) {
+			source.remove();
+			dropQuery.insertAdjacentHTML('afterend', event.dataTransfer.getData('text/html'));
+		}
+	});
+
+	// This is needed to work around a Firefox bug → https://bugzilla.mozilla.org/show_bug.cgi?id=800050
+	configureQueries.addEventListener('focusin', event => {
+		event.target.closest('input[id^="queries_"][id$="_name"]').select();
+	});
+}
+
+if (document.readyState && document.readyState !== 'loading') {
+	init_draggable();
+} else if (document.addEventListener) {
+	document.addEventListener('DOMContentLoaded', event => init_draggable(), false);
+}
+// @license-end


### PR DESCRIPTION
Changes proposed in this pull request:

- Add user query sorting by drag and drop
- Remove useless cancel action on user query configuration page

How to test the feature manually:

1. Bookmark some user queries
2. Display the user query configuration page
3. Drag and drop them to reorder them (don't forget to submit your changes to apply them)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

See #2015 and #2216