### PR TITLE
Add class autoload for extension

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -296,6 +296,11 @@ In addition, you will have a number of methods directly inherited from `Minz_Ext
 * `getFileUrl($filename, $type)` will return the URL to a file in the `static` directory. The first parameter is the name of the file (without `static /`), the second is the type of file to be used (`css` or` js`).
 * `registerController($base_name)` will tell Minz to take into account the given controller in the routing system. The controller must be located in your `Controllers` directory, the name of the file must be` <base_name>Controller.php` and the name of the `FreshExtension_<base_name>_Controller` class.
 
+> If your extension code is scattered in different classes, you need to load their source before using them.
+> Of course you could include the files manually, but it's more efficient to load them automatically.
+> To do so, you just need to define the `autoload` method which will include them when needed.
+> This method will be registered automatically when the extension is enabled.
+
 **TODO**
 
 * `registerViews()`

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -188,7 +188,7 @@ class Minz_ExtensionManager {
 	 * Add the extension to the list of the known extensions ($ext_list).
 	 *
 	 * If the extension is present in $ext_auto_enabled and if its type is "system",
-	 * it will be enabled in the same time.
+	 * it will be enabled at the same time.
 	 *
 	 * @param Minz_Extension $ext a valid extension.
 	 */
@@ -216,6 +216,10 @@ class Minz_ExtensionManager {
 		if (isset(self::$ext_list[$ext_name])) {
 			$ext = self::$ext_list[$ext_name];
 			self::$ext_list_enabled[$ext_name] = $ext;
+
+			if (method_exists($ext, 'autoload')) {
+				spl_autoload_register([$ext, 'autoload']);
+			}
 			$ext->enable();
 			$ext->init();
 		}


### PR DESCRIPTION
Changes proposed in this pull request:

- add autoloading for extension

How to test the feature manually:

1. create an extension using external classes
2. load them automatically by creating the `autoload` method in the extension

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

When an extension defines an `autoload` method, it will be registered
automatically before enabling the extension.
For the extension creator, it's easier because there is no need to
register it manually.