### PR TITLE
Add drag & drop marker on user query list

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1423,3 +1423,7 @@ input:checked + .slide-container .properties {
 .preview_background {
 	background-color: transparent;
 }
+
+.drag-drop-marker {
+	margin: -1px;
+}

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1421,3 +1421,7 @@ input:checked + .slide-container .properties {
 .preview_background {
 	background-color: transparent;
 }
+
+.drag-drop-marker {
+	margin: -1px;
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- Add drag & drop marker on user query list

How to test the feature manually:

1. re-order the user queries to see it in action

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, it was nearly impossible to know exactly where the dragged
item will land when dropping it.
Now, there is a visual marker to show the drop location.

An HR tag is inserted dynamically in the DOM. It's possible to style
it if needed.