### PR TITLE
Add filters on images and video

### DIFF
--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -21,6 +21,11 @@ img.favicon {
 	border-radius: 2px;
 }
 
+body img,
+body video {
+	filter: brightness(.6) contrast(1.2);
+}
+
 /*=== Forms */
 legend {
 	margin: 20px 0 5px;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -21,6 +21,11 @@ img.favicon {
 	border-radius: 2px;
 }
 
+body img,
+body video {
+	filter: brightness(.6) contrast(1.2);
+}
+
 /*=== Forms */
 legend {
 	margin: 20px 0 5px;


### PR DESCRIPTION
Changes proposed in this pull request:

- Add brightness and contrast filters on images and videos when using the dark mode

How to test the feature manually:

1.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

As this theme is a dark theme, I figured that it would be better
to filter images and videos to ease reading when bright elements
are included.
