### PR TITLE
Fix commitNewEntries query

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -158,7 +158,7 @@ SELECT @rank:=@rank+1 AS id, guid, title, author, content_bin, link, date, `last
 FROM `_entrytmp`
 ORDER BY date;
 
-DELETE FROM `_entrytmp` WHERE id <= @rank;';
+DELETE FROM `_entrytmp` WHERE id <= @rank;
 SQL;
 		$hadTransaction = $this->pdo->inTransaction();
 		if (!$hadTransaction) {


### PR DESCRIPTION
There was an erroneous '; at the end of the commitNewEntries DELETE query, resulting in an exception during actualization with this output:

```
FreshRSS starting feeds actualization at 2021-01-11T14:06:09+00:00
FreshRSS actualize candrews...
PHP Fatal error:  Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''' at line 1 in /var/www/localhost/htdocs/FreshRSS/lib/Minz/Pdo.php:45
Stack trace:
#0 /var/www/localhost/htdocs/FreshRSS/lib/Minz/Pdo.php(45): PDO->exec()
#1 /var/www/localhost/htdocs/FreshRSS/app/Models/EntryDAO.php(167): Minz_Pdo->exec()
#2 /var/www/localhost/htdocs/FreshRSS/app/Controllers/feedController.php(505): FreshRSS_EntryDAO->commitNewEntries()
#3 /var/www/localhost/htdocs/FreshRSS/app/Controllers/feedController.php(548): FreshRSS_feed_Controller::actualizeFeed()
#4 /var/www/localhost/htdocs/FreshRSS/lib/Minz/Dispatcher.php(119): FreshRSS_feed_Controller->actualizeAction()
#5 /var/www/localhost/htdocs/FreshRSS/lib/Minz/Dispatcher.php(47): Minz_Dispatcher->launchAction()
#6 /var/www/localhost/htdocs/FreshRSS/lib/Minz/FrontController.php(81): Minz_Dispatcher->run()
#7 /var/www/localhost/htdocs/FreshRSS/app/actualize_script.php(75): Minz_FrontController->run()
#8 {main}
  thrown in /var/www/localhost/htdocs/FreshRSS/lib/Minz/Pdo.php on line 45
Results:
```

Changes proposed in this pull request:

- Fix error in SQL query

How to test the feature manually:

1. Run feed actualization
2. Note that no errors occur

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
