### PR TITLE
Add constant for PHP requirements

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -358,9 +358,6 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			Minz_Error::error(403);
 		}
 
-		$can_enable_email_validation = version_compare(PHP_VERSION, '5.5') >= 0;
-		$this->view->can_enable_email_validation = $can_enable_email_validation;
-
 		if (Minz_Request::isPost()) {
 			$limits = FreshRSS_Context::$system_conf->limits;
 			$limits['max_registrations'] = Minz_Request::param('max-registrations', 1);
@@ -370,9 +367,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			FreshRSS_Context::$system_conf->limits = $limits;
 			FreshRSS_Context::$system_conf->title = Minz_Request::param('instance-name', 'FreshRSS');
 			FreshRSS_Context::$system_conf->auto_update_url = Minz_Request::param('auto-update-url', false);
-			if ($can_enable_email_validation) {
-				FreshRSS_Context::$system_conf->force_email_validation = Minz_Request::param('force-email-validation', false);
-			}
+			FreshRSS_Context::$system_conf->force_email_validation = Minz_Request::param('force-email-validation', false);
 			FreshRSS_Context::$system_conf->save();
 
 			invalidateHttpCache();

--- a/app/install.php
+++ b/app/install.php
@@ -371,7 +371,7 @@ function printStep1() {
 	<?php if ($res['php'] == 'ok') { ?>
 	<p class="alert alert-success"><span class="alert-head"><?= _t('gen.short.ok') ?></span> <?= _t('install.check.php.ok', PHP_VERSION) ?></p>
 	<?php } else { ?>
-	<p class="alert alert-error"><span class="alert-head"><?= _t('gen.short.damn') ?></span> <?= _t('install.check.php.nok', PHP_VERSION, '5.6.0') ?></p>
+	<p class="alert alert-error"><span class="alert-head"><?= _t('gen.short.damn') ?></span> <?= _t('install.check.php.nok', PHP_VERSION, FRESHRSS_MIN_PHP_VERSION) ?></p>
 	<?php } ?>
 
 	<?php if ($res['pdo'] == 'ok') { ?>

--- a/app/views/configure/system.phtml
+++ b/app/views/configure/system.phtml
@@ -38,23 +38,21 @@
 			</div>
 		</div>
 
-		<?php if ($this->can_enable_email_validation) { ?>
-			<div class="form-group">
-				<div class="group-controls">
-					<label class="checkbox" for="force-email-validation">
-						<input
-							type="checkbox"
-							name="force-email-validation"
-							id="force-email-validation"
-							value="1"
-							<?= FreshRSS_Context::$system_conf->force_email_validation ? 'checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$system_conf->force_email_validation ?>"
-						/>
-						<?= _t('admin.system.force_email_validation') ?>
-					</label>
-				</div>
+		<div class="form-group">
+			<div class="group-controls">
+				<label class="checkbox" for="force-email-validation">
+					<input
+						type="checkbox"
+						name="force-email-validation"
+						id="force-email-validation"
+						value="1"
+						<?= FreshRSS_Context::$system_conf->force_email_validation ? 'checked="checked"' : '' ?>
+						data-leave-validation="<?= FreshRSS_Context::$system_conf->force_email_validation ?>"
+					/>
+					<?= _t('admin.system.force_email_validation') ?>
+				</label>
 			</div>
-		<?php } ?>
+		</div>
 
 		<div class="form-group">
 			<label class="group-name" for="max-feeds"><?= _t('admin.system.max-feeds') ?></label>

--- a/app/views/update/checkInstall.phtml
+++ b/app/views/update/checkInstall.phtml
@@ -9,7 +9,7 @@
 	<p class="alert <?= $status ? 'alert-success' : 'alert-error' ?>">
 		<?php
 			if ($key === 'php') {
-				echo _t('admin.check_install.' . $key . '.' . ($status ? 'ok' : 'nok'), PHP_VERSION, '5.6.0');
+				echo _t('admin.check_install.' . $key . '.' . ($status ? 'ok' : 'nok'), PHP_VERSION, FRESHRSS_MIN_PHP_VERSION);
 			} else {
 				echo _t('admin.check_install.' . $key . '.' . ($status ? 'ok' : 'nok'));
 			}

--- a/constants.php
+++ b/constants.php
@@ -2,6 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
+define('FRESHRSS_MIN_PHP_VERSION', '5.6.0');
 define('FRESHRSS_VERSION', '1.17.1-dev');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');

--- a/lib/Minz/Mailer.php
+++ b/lib/Minz/Mailer.php
@@ -34,14 +34,8 @@ class Minz_Mailer {
 
 	/**
 	 * Constructor.
-	 *
-	 * If PHP version is < 5.5, a warning is logged.
 	 */
 	public function __construct () {
-		if (version_compare(PHP_VERSION, '5.5') < 0) {
-			Minz_Log::warning('Minz_Mailer cannot be used with a version of PHP < 5.5.');
-		}
-
 		$this->view = new Minz_View();
 		$this->view->_layout(false);
 		$this->view->attributeParams();

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -6,7 +6,7 @@ Minz_Configuration::register('default_system', join_path(FRESHRSS_PATH, 'config.
 Minz_Configuration::register('default_user', join_path(FRESHRSS_PATH, 'config-user.default.php'));
 
 function checkRequirements($dbType = '') {
-	$php = version_compare(PHP_VERSION, '5.6.0') >= 0;
+	$php = version_compare(PHP_VERSION, FRESHRSS_MIN_PHP_VERSION) >= 0;
 	$curl = extension_loaded('curl');
 	$pdo_mysql = extension_loaded('pdo_mysql');
 	$pdo_sqlite = extension_loaded('pdo_sqlite');

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -1,6 +1,6 @@
 <?php
-if (version_compare(PHP_VERSION, '5.6.0', '<')) {
-	die('FreshRSS error: FreshRSS requires PHP 5.6.0+!');
+if (version_compare(PHP_VERSION, FRESHRSS_MIN_PHP_VERSION, '<')) {
+	die(sprintf('FreshRSS error: FreshRSS requires PHP %s+!', FRESHRSS_MIN_PHP_VERSION));
 }
 
 if (!function_exists('mb_strcut')) {
@@ -416,7 +416,7 @@ function check_install_php() {
 	$pdo_pgsql = extension_loaded('pdo_pgsql');
 	$pdo_sqlite = extension_loaded('pdo_sqlite');
 	return array(
-		'php' => version_compare(PHP_VERSION, '5.5.0') >= 0,
+		'php' => version_compare(PHP_VERSION, FRESHRSS_MIN_PHP_VERSION) >= 0,
 		'minz' => file_exists(LIB_PATH . '/Minz'),
 		'curl' => extension_loaded('curl'),
 		'pdo' => $pdo_mysql || $pdo_sqlite || $pdo_pgsql,


### PR DESCRIPTION
Changes proposed in this pull request:

- Add constant for PHP requirements
- Remove PHP version checks for obsolete versions

How to test the feature manually:

1.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
