### PR TITLE
Add username hint for permissions during install

### DIFF
--- a/app/i18n/cz/install.php
+++ b/app/i18n/cz/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Zkontrolujte oprávnění adresáře <em>%s</em>. HTTP server musí mít do tohoto adresáře práva zápisu.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Zkontrolujte oprávnění adresáře <em>%s</em>. HTTP server musí mít do tohoto adresáře práva zápisu.',
 			'ok' => 'Oprávnění adresáře users jsou v pořádku.',

--- a/app/i18n/de/install.php
+++ b/app/i18n/de/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Überprüfen Sie die Berechtigungen des Verzeichnisses <em>%s</em>. Der HTTP-Server muss Schreibrechte besitzen.',
 			'ok' => 'Die Berechtigungen des Temp Verzeichnisses sind in Ordnung.',
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Überprüfen Sie die Berechtigungen des Verzeichnisses <em>%s</em>. Der HTTP-Server muss Schreibrechte besitzen.',
 			'ok' => 'Die Berechtigungen des Verzeichnisses <em>%s</em> sind in Ordnung.',

--- a/app/i18n/en-us/install.php
+++ b/app/i18n/en-us/install.php
@@ -33,7 +33,7 @@ return array(
 		'_' => 'Checks',
 		'already_installed' => 'We have detected that FreshRSS is already installed!',
 		'cache' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the cache directory are good.',
 		),
 		'ctype' => array(
@@ -45,7 +45,7 @@ return array(
 			'ok' => 'You have the cURL library.',
 		),
 		'data' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the data directory are good.',
 		),
 		'dom' => array(
@@ -53,7 +53,7 @@ return array(
 			'ok' => 'You have the required library to browse the DOM.',
 		),
 		'favicons' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the favicons directory are good.',
 		),
 		'fileinfo' => array(
@@ -89,11 +89,12 @@ return array(
 			'ok' => 'Your PHP version, %s, is compatible with FreshRSS.',
 		),
 		'tmp' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the temp directory are good.',
 		),
+		'unknown_process_username' => 'unknown',
 		'users' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the users directory are good.',
 		),
 		'xml' => array(

--- a/app/i18n/en/install.php
+++ b/app/i18n/en/install.php
@@ -33,7 +33,7 @@ return array(
 		'_' => 'Checks',
 		'already_installed' => 'We have detected that FreshRSS is already installed!',
 		'cache' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permission.',
 			'ok' => 'Permissions on the cache directory are good.',
 		),
 		'ctype' => array(
@@ -45,7 +45,7 @@ return array(
 			'ok' => 'You have the cURL library.',
 		),
 		'data' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permission.',
 			'ok' => 'Permissions on the data directory are good.',
 		),
 		'dom' => array(
@@ -53,7 +53,7 @@ return array(
 			'ok' => 'You have the required library to browse the DOM.',
 		),
 		'favicons' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permission.',
 			'ok' => 'Permissions on the favicons directory are good.',
 		),
 		'fileinfo' => array(
@@ -89,11 +89,12 @@ return array(
 			'ok' => 'Your PHP version, %s, is compatible with FreshRSS.',
 		),
 		'tmp' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the temp directory are good.',
 		),
+		'unknown_process_username' => 'unknown',
 		'users' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the users directory are good.',
 		),
 		'xml' => array(

--- a/app/i18n/es/install.php
+++ b/app/i18n/es/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Revisa los permisos en el directorio <em>%s</em>. El servidor HTTP debe contar con permisos de escritura.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Revisa los permisos en el directorio <em>%s</em>. El servidor HTTP debe contar con permisos de escritura.',
 			'ok' => 'Los permisos en el directorio users son correctos.',

--- a/app/i18n/fr/install.php
+++ b/app/i18n/fr/install.php
@@ -33,7 +33,7 @@ return array(
 		'_' => 'Vérifications',
 		'already_installed' => 'FreshRSS semble avoir déjà été installé !',
 		'cache' => array(
-			'nok' => 'Veuillez vérifier les droits sur le répertoire <em>%s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
+			'nok' => 'Veuillez vérifier les droits de l’utilisateur <em>%2$s</em> sur le répertoire <em>%1$s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
 			'ok' => 'Les droits sur le répertoire de cache sont bons.',
 		),
 		'ctype' => array(
@@ -45,7 +45,7 @@ return array(
 			'ok' => 'Vous disposez de cURL.',
 		),
 		'data' => array(
-			'nok' => 'Veuillez vérifier les droits sur le répertoire <em>%s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
+			'nok' => 'Veuillez vérifier les droits de l’utilisateur <em>%2$s</em> sur le répertoire <em>%1$s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
 			'ok' => 'Les droits sur le répertoire de data sont bons.',
 		),
 		'dom' => array(
@@ -53,7 +53,7 @@ return array(
 			'ok' => 'Vous disposez de la librairie pour parcourir le DOM.',
 		),
 		'favicons' => array(
-			'nok' => 'Veuillez vérifier les droits sur le répertoire <em>%s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
+			'nok' => 'Veuillez vérifier les droits de l’utilisateur <em>%2$s</em> sur le répertoire <em>%1$s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
 			'ok' => 'Les droits sur le répertoire des favicons sont bons.',
 		),
 		'fileinfo' => array(
@@ -89,11 +89,12 @@ return array(
 			'ok' => 'Votre version de PHP est la %s, qui est compatible avec FreshRSS.',
 		),
 		'tmp' => array(
-			'nok' => 'Veuillez vérifier les droits sur le répertoire <em>%s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
+			'nok' => 'Veuillez vérifier les droits de l’utilisateur <em>%2$s</em> sur le répertoire <em>%1$s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
 			'ok' => 'Les droits sur le répertoire temporaire sont bons.',
 		),
+		'unknown_process_username' => 'inconnu',
 		'users' => array(
-			'nok' => 'Veuillez vérifier les droits sur le répertoire <em>%s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
+			'nok' => 'Veuillez vérifier les droits de l’utilisateur <em>%2$s</em> sur le répertoire <em>%1$s</em>. Le serveur HTTP doit être capable d’écrire dedans.',
 			'ok' => 'Les droits sur le répertoire des utilisateurs sont bons.',
 		),
 		'xml' => array(

--- a/app/i18n/he/install.php
+++ b/app/i18n/he/install.php
@@ -33,7 +33,7 @@ return array(
 		'_' => 'בדיקות',
 		'already_installed' => 'We have detected that FreshRSS is already installed!',	// TODO - Translation
 		'cache' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'ההרשאות בתיקיית המטמון תקינות',
 		),
 		'ctype' => array(
@@ -45,7 +45,7 @@ return array(
 			'ok' => 'יש לכם את גירסת %s של cURL',
 		),
 		'data' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'ההרשאות בתיקיית הדאטא תקינות',
 		),
 		'dom' => array(
@@ -53,7 +53,7 @@ return array(
 			'ok' => 'הספרייה הנדרשת לסיור ב DOM מותקנת',
 		),
 		'favicons' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'ההרשאות בתיקיית הfavicons תקינות',
 		),
 		'fileinfo' => array(
@@ -89,11 +89,12 @@ return array(
 			'ok' => 'גירסת PHP שלכם היא %s, שתואמת ל FreshRSS',
 		),
 		'tmp' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',	// TODO - Translation
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',	// TODO - Translation
 			'ok' => 'Permissions on the users directory are good.',	// TODO - Translation
 		),
 		'xml' => array(

--- a/app/i18n/it/install.php
+++ b/app/i18n/it/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Verifica i permessi sulla cartella <em>%s</em>. Il server HTTP deve avere i permessi per scriverci dentro.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Verifica i permessi sulla cartella <em>%s</em>. Il server HTTP deve avere i permessi per scriverci dentro.',
 			'ok' => 'I permessi sulla cartella users sono corretti.',

--- a/app/i18n/kr/install.php
+++ b/app/i18n/kr/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => '<em>%s</em> 디렉토리의 권한을 확인하세요. HTTP 서버가 쓰기 권한을 가지고 있어야 합니다.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => '<em>%s</em> 디렉토리의 권한을 확인하세요. HTTP 서버가 쓰기 권한을 가지고 있어야 합니다.',
 			'ok' => 'users 디렉토리의 권한이 올바르게 설정되어 있습니다.',

--- a/app/i18n/nl/install.php
+++ b/app/i18n/nl/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Controleer permissies van de <em>%s</em> map. HTTP server moet rechten hebben om er in te kunnen schrijven.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Controleer permissies van de <em>%s</em> map. HTTP server moet rechten hebben om er in te kunnen schrijven.',
 			'ok' => 'Permissies van de users map zijn goed.',

--- a/app/i18n/oc/install.php
+++ b/app/i18n/oc/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Volgatz verificar los dreches sul repertòri <em>%s</em>. Lo servidor HTTP deu poder escriure dedins.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Volgatz verificar los dreches sul repertòri <em>%s</em>. Lo servidor HTTP deu poder escriure dedins.',
 			'ok' => 'Los dreches sul repertòri dels utilizaires son bons.',

--- a/app/i18n/pl/install.php
+++ b/app/i18n/pl/install.php
@@ -33,7 +33,7 @@ return array(
 		'_' => 'Checks',	// TODO - Translation
 		'already_installed' => 'We have detected that FreshRSS is already installed!',	// TODO - Translation
 		'cache' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the cache directory are good.',	// TODO - Translation
 		),
 		'ctype' => array(
@@ -45,7 +45,7 @@ return array(
 			'ok' => 'You have the cURL library.',	// TODO - Translation
 		),
 		'data' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the data directory are good.',	// TODO - Translation
 		),
 		'dom' => array(
@@ -53,7 +53,7 @@ return array(
 			'ok' => 'You have the required library to browse the DOM.',	// TODO - Translation
 		),
 		'favicons' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permission.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',
 			'ok' => 'Permissions on the favicons directory are good.',	// TODO - Translation
 		),
 		'fileinfo' => array(
@@ -89,11 +89,12 @@ return array(
 			'ok' => 'Your PHP version, %s, is compatible with FreshRSS.',	// TODO - Translation
 		),
 		'tmp' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',	// TODO - Translation
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
-			'nok' => 'Check permissions on the <em>%s</em> directory. The HTTP server must have write permissions.',	// TODO - Translation
+			'nok' => 'Check permissions on the <em>%1$s</em> directory for <em>%2$s</em> user. The HTTP server must have write permissions.',	// TODO - Translation
 			'ok' => 'Permissions on the users directory are good.',	// TODO - Translation
 		),
 		'xml' => array(

--- a/app/i18n/pt-br/install.php
+++ b/app/i18n/pt-br/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Verifiquei as permissões no diretório <em>%s</em>. O servidor HTTP deve ter direitos para escrever dentro desta pasta.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Verifiquei as permissões no diretório <em>%s</em>. O servidor HTTP deve ter direitos para escrever dentro desta pasta.',
 			'ok' => 'Permissões no diretório users estão corretos.',

--- a/app/i18n/ru/install.php
+++ b/app/i18n/ru/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Проверьте права доступа к папке <em>%s</em> . Сервер HTTP должен иметь права на запись в эту папку.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Проверьте права доступа к папке <em>%s</em> . Сервер HTTP должен иметь права на запись в эту папку.',
 			'ok' => 'Права на папку users в порядке.',

--- a/app/i18n/sk/install.php
+++ b/app/i18n/sk/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => 'Skontrolujte oprávnenia prístupu do priečinku <em>%s</em>. HTTP server musí mať právo doň zapisovať.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => 'Skontrolujte oprávnenia prístupu do priečinku <em>%s</em>. HTTP server musí mať právo doň zapisovať.',
 			'ok' => 'Oprávnenia prístupu do priečinku používateľov sú OK.',

--- a/app/i18n/tr/install.php
+++ b/app/i18n/tr/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => '<em>%s</em> klasör yetkisini kontrol edin. HTTP yazma yetkisi olmalı.',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => '<em>%s</em> klasör yetkisini kontrol edin. HTTP yazma yetkisi olmalı.',
 			'ok' => 'Kullanıcılar klasörü yetkileri sorunsuz.',

--- a/app/i18n/zh-cn/install.php
+++ b/app/i18n/zh-cn/install.php
@@ -92,6 +92,7 @@ return array(
 			'nok' => '请检查 <em>%s</em> 目录权限。HTTP 服务器必须有其写入权限。',
 			'ok' => 'Permissions on the temp directory are good.',	// TODO - Translation
 		),
+		'unknown_process_username' => 'unknown',	// TODO - Translation
 		'users' => array(
 			'nok' => '请检查 <em>%s</em> 目录权限。HTTP 服务器必须有其写入权限。',
 			'ok' => 'users 目录权限正常',

--- a/cli/i18n/ignore/en-us.php
+++ b/cli/i18n/ignore/en-us.php
@@ -672,6 +672,7 @@ return array(
 	'install.check.php.ok',
 	'install.check.tmp.nok',
 	'install.check.tmp.ok',
+	'install.check.unknown_process_username',
 	'install.check.users.nok',
 	'install.check.users.ok',
 	'install.check.xml.nok',


### PR DESCRIPTION
Closes #2758

Changes proposed in this pull request:

- Add username hint for permission checks during install

How to test the feature manually:

1. Make a new install with the wrong permissions on folders

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

The username is retrieved by 2 different means to support different
configurations and architectures. If there is no way to find the
username, the "unknown" string is displayed instead.