### PR TITLE
Fix form login if user does not exist

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -123,6 +123,8 @@ class FreshRSS_auth_Controller extends Minz_ActionController {
 			$username = Minz_Request::param('username', '');
 			$challenge = Minz_Request::param('challenge', '');
 
+			usleep(rand(100, 10000));	//Primitive mitigation of timing attacks, in μs
+
 			FreshRSS_Context::initUser($username);
 			if (FreshRSS_Context::$user_conf == null) {
 				//We do not test here whether the user exists, so most likely an internal error.
@@ -130,7 +132,8 @@ class FreshRSS_auth_Controller extends Minz_ActionController {
 				return;
 			}
 
-			if (!FreshRSS_Context::$user_conf->enabled) {
+			if (!FreshRSS_Context::$user_conf->enabled || FreshRSS_Context::$user_conf->passwordHash == '') {
+				usleep(rand(100, 5000));	//Primitive mitigation of timing attacks, in μs
 				Minz_Error::error(403, array(_t('feedback.auth.login.invalid')), false);
 				return;
 			}


### PR DESCRIPTION
Small bug from https://github.com/FreshRSS/FreshRSS/pull/3070 , leading to an exception due to not being able to log the login error is the user does not exist at all.

Minor: Also add some very primitive mitigation of timing attacks (to find out whether a user exists or not, although I have not checked whether this might be guessed through other means) - before, if the user did not exist, the response was always measurably faster; now it is harder to tell due to the noise