### PR TITLE
Add comprehensive user configuration in extensions

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -300,6 +300,9 @@ The `Minz_Extension` abstract class defines another set of methods that should n
 * the `registerViews` method registers the extension views in FreshRSS.
 * the `registerTranslates` method registers the extension translation files in FreshRSS.
 * the `registerHook` method registers hook actions in different part of the application.
+* the `getUserConfiguration` method retrieves the extension configuration for the current user.
+* the `setUserConfiguration` method stores the extension configuration for the current user.
+* the `removeUserConfiguration` method removes the extension configuration for the current user.
 
 > Note that if you modify the later set of methods, you might break the extension system. Thus making FreshRSS unusable. So it's highly recommended to let those unmodified.
 

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -141,6 +141,15 @@ class Minz_Configuration {
 	}
 
 	/**
+	 * Check if a parameter is defined in the configuration
+	 *
+	 * @return bool
+	 */
+	public function hasParam(string $key) {
+		return isset($this->data[$key]);
+	}
+
+	/**
 	 * Return the value of the given param.
 	 *
 	 * @param $key the name of the param.


### PR DESCRIPTION
Changes proposed in this pull request:

- Add comprehensive user configuration in extensions
-
-

How to test the feature manually:

1. Modify an extension code to use the new methods
2. Save the configuration
3. Check that the user configuration file is modified with the extension configuration

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, the extension configuration was handled by its author. There
was discrepancies between extensions on how the configuration was
stored.
Now, we could rely on a single way of storing configuration. This won't
invalidate how the extensions are storing their configuration but will
allow authors to focus on what is important.