### PR TITLE
Fix user configuration in extension

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -240,7 +240,7 @@ abstract class Minz_Extension {
 		if (!$this->isUserConfigurationEnabled()) {
 			return;
 		}
-		if ($this->isExtensionConfigured()) {
+		if (FreshRSS_Context::$user_conf->hasParam($this->config_key)) {
 			$extensions = FreshRSS_Context::$user_conf->{$this->config_key};
 		} else {
 			$extensions = [];


### PR DESCRIPTION
Fix bug introduced in #3397

Changes proposed in this pull request:

- Fix user configuration in extension
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, only one extension could be configured at a time. Thus we
were loosing the configuration for other extensions when saving.
Now, each extension can be saved without overriding data.