### PR TITLE
Fix extension file search

### DIFF
--- a/p/ext.php
+++ b/p/ext.php
@@ -13,6 +13,28 @@ const SUPPORTED_TYPES = [
 	'svg' => 'image/svg+xml',
 ];
 
+/**
+ * @return string
+ */
+function get_absolute_filename(string $file_name) {
+	$core_extension = realpath(CORE_EXTENSIONS_PATH . '/' . $file_name);
+	if (false !== $core_extension) {
+		return $core_extension;
+	}
+
+	$extension = realpath(EXTENSIONS_PATH . '/' . $file_name);
+	if (false !== $extension) {
+		return $extension;
+	}
+
+	$third_party_extension = realpath(THIRDPARTY_EXTENSIONS_PATH . '/' . $file_name);
+	if (false !== $third_party_extension) {
+		return $third_party_extension;
+	}
+
+	return '';
+}
+
 function is_valid_path_extension($path, $extensionPath) {
 	// It must be under the extension path.
 	$real_ext_path = realpath($extensionPath);
@@ -71,7 +93,7 @@ if (empty(SUPPORTED_TYPES[$file_type])) {
 	sendBadRequestResponse('File type is not supported.');
 }
 
-$absolute_filename = realpath(EXTENSIONS_PATH . '/' . $file_name);
+$absolute_filename = get_absolute_filename($file_name);
 if (!is_valid_path($absolute_filename)) {
 	sendBadRequestResponse('File is not supported.');
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix extension file search
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, it was possible to retrieve only the files from extensions. Thus
making core extension files unreachable.
Now, the selected file is search through all extensions folders.