### PR TITLE
Add a method to retrieve a configuration value

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -12,6 +12,7 @@ abstract class Minz_Extension {
 	private $version;
 	private $type;
 	private $config_key = 'extensions';
+	private $user_configuration;
 
 	public static $authorized_types = array(
 		'system',
@@ -234,6 +235,21 @@ abstract class Minz_Extension {
 		}
 
 		return FreshRSS_Context::$user_conf->{$this->config_key}[$this->getName()];
+	}
+
+	/**
+	 * @param mixed $default
+	 * @return mixed
+	 */
+	public function getUserConfigurationValue(string $key, $default = null) {
+		if (!is_array($this->user_configuration)) {
+			$this->user_configuration = $this->getUserConfiguration();
+		}
+
+		if (array_key_exists($key, $this->user_configuration)) {
+			return $this->user_configuration[$key];
+		}
+		return $default;
 	}
 
 	public function setUserConfiguration(array $configuration) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a method to retrieve a configuration value
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

This will simplify extension code by removing a lot of logic from
the extension itself when it's not needed. I've tested it on one
of my extension with all the other recent extension modifications
and I could remove half of the code needed before.