### PR TITLE
Fix configuration local cache

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -265,6 +265,8 @@ abstract class Minz_Extension {
 
 		FreshRSS_Context::$user_conf->{$this->config_key} = $extensions;
 		FreshRSS_Context::$user_conf->save();
+
+		$this->user_configuration = $configuration;
 	}
 
 	public function removeUserConfiguration(){
@@ -283,5 +285,7 @@ abstract class Minz_Extension {
 
 		FreshRSS_Context::$user_conf->{$this->config_key} = $extensions;
 		FreshRSS_Context::$user_conf->save();
+
+		$this->user_configuration = null;
 	}
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix configuration local cache

How to test the feature manually:

1. 
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, setting values did not refresh the configuration cache. Thus
generating some weird behavior when configuring extensions.
Now, the cache is updated with the most recent values when the
configuration is modified.