### PR TITLE
refactor: remove referer checks, as they are no longer needed (replaced by csrf token)

### DIFF
--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -65,16 +65,6 @@ class FreshRSS extends Minz_FrontController {
 	private static function initAuth() {
 		FreshRSS_Auth::init();
 		if (Minz_Request::isPost()) {
-			if (!is_referer_from_same_domain()) {
-				// Basic protection against XSRF attacks
-				FreshRSS_Auth::removeAccess();
-				$http_referer = empty($_SERVER['HTTP_REFERER']) ? '' : $_SERVER['HTTP_REFERER'];
-				self::initI18n();
-				Minz_Error::error(403, array('error' => array(
-						_t('feedback.access.denied'),
-						' [HTTP_REFERER=' . htmlspecialchars($http_referer, ENT_NOQUOTES, 'UTF-8') . ']'
-					)));
-			}
 			if (!(FreshRSS_Auth::isCsrfOk() ||
 				(Minz_Request::controllerName() === 'auth' && Minz_Request::actionName() === 'login') ||
 				(Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'create' && !FreshRSS_Auth::hasAccess('admin')) ||

--- a/app/i18n/cz/install.php
+++ b/app/i18n/cz/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Nemáte PHP fileinfo (balíček fileinfo).',
 			'ok' => 'Máte rozšíření fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Zkontrolujte prosím že neměníte HTTP REFERER.',
-			'ok' => 'Váš HTTP REFERER je znám a odpovídá Vašemu serveru.',
-		),
 		'json' => array(
 			'nok' => 'Pro parsování JSON chybí doporučená knihovna.',
 			'ok' => 'Máte doporučenou knihovnu pro parsování JSON.',

--- a/app/i18n/de/install.php
+++ b/app/i18n/de/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Ihnen fehlt PHP fileinfo (Paket fileinfo).',
 			'ok' => 'Sie haben die fileinfo-Erweiterung.',
 		),
-		'http_referer' => array(
-			'nok' => 'Bitte stellen Sie sicher, dass Sie Ihren HTTP REFERER nicht abändern.',
-			'ok' => 'Ihr HTTP REFERER ist bekannt und entspricht Ihrem Server.',
-		),
 		'json' => array(
 			'nok' => 'Ihnen fehlt eine empfohlene Bibliothek um JSON zu parsen.',
 			'ok' => 'Sie haben eine empfohlene Bibliothek um JSON zu parsen.',

--- a/app/i18n/en-us/install.php
+++ b/app/i18n/en-us/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Cannot find the PHP fileinfo library (fileinfo package).',
 			'ok' => 'You have the fileinfo library.',
 		),
-		'http_referer' => array(
-			'nok' => 'Please check that you are not altering your HTTP REFERER.',
-			'ok' => 'Your HTTP REFERER is known and corresponds to your server.',
-		),
 		'json' => array(
 			'nok' => 'Cannot find the recommended library to parse JSON.',
 			'ok' => 'You have the recommended library to parse JSON.',

--- a/app/i18n/en/install.php
+++ b/app/i18n/en/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Cannot find the PHP fileinfo library (fileinfo package).',
 			'ok' => 'You have the fileinfo library.',
 		),
-		'http_referer' => array(
-			'nok' => 'Please check that you are not altering your HTTP REFERER.',
-			'ok' => 'Your HTTP REFERER is known and corresponds to your server.',
-		),
 		'json' => array(
 			'nok' => 'Cannot find the recommended library to parse JSON.',
 			'ok' => 'You have the recommended library to parse JSON.',

--- a/app/i18n/es/install.php
+++ b/app/i18n/es/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'No se ha podido localizar la librería PHP fileinfo (paquete fileinfo).',
 			'ok' => 'Dispones de la librería fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Por favor, comprueba que no estás alterando tu configuración HTTP REFERER.',
-			'ok' => 'La configuración HTTP REFERER es conocida y se corresponde con la de tu servidor.',
-		),
 		'json' => array(
 			'nok' => 'No se ha podido localizar la librería para procesar JSON.',
 			'ok' => 'Dispones de la librería recomendada para procesar JSON.',

--- a/app/i18n/fr/install.php
+++ b/app/i18n/fr/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Vous ne disposez pas de PHP fileinfo (paquet fileinfo).',
 			'ok' => 'Vous disposez de fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Veuillez vérifier que vous ne modifiez pas votre HTTP REFERER.',
-			'ok' => 'Le HTTP REFERER est connu et semble correspondre à votre serveur.',
-		),
 		'json' => array(
 			'nok' => 'Vous ne disposez pas de l’extension recommendée JSON (paquet php-json).',
 			'ok' => 'Vous disposez de l’extension recommendée JSON.',

--- a/app/i18n/he/install.php
+++ b/app/i18n/he/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Cannot find the PHP fileinfo library (fileinfo package).',	// TODO - Translation
 			'ok' => 'You have the fileinfo library.',	// TODO - Translation
 		),
-		'http_referer' => array(
-			'nok' => 'נא לדבוק שאינך פוגעת ב HTTP REFERER שלך.',
-			'ok' => 'הHTTP REFERER ידוע ותאם לשרת שלך.',
-		),
 		'json' => array(
 			'nok' => 'Cannot find the recommended library to parse JSON.',	// TODO - Translation
 			'ok' => 'You have the recommended library to parse JSON.',	// TODO - Translation

--- a/app/i18n/it/install.php
+++ b/app/i18n/it/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Manca il supporto per PHP fileinfo (pacchetto fileinfo).',
 			'ok' => 'Estensione fileinfo presente.',
 		),
-		'http_referer' => array(
-			'nok' => 'Per favore verifica che non stai alterando il tuo HTTP REFERER.',
-			'ok' => 'Il tuo HTTP REFERER riconosciuto corrisponde al tuo server.',
-		),
 		'json' => array(
 			'nok' => 'You lack a recommended library to parse JSON.',
 			'ok' => 'You have the recommended library to parse JSON.',	// TODO - Translation

--- a/app/i18n/kr/install.php
+++ b/app/i18n/kr/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'fileinfo 라이브러리를 찾을 수 없습니다 (fileinfo 패키지).',
 			'ok' => 'fileinfo 라이브러리가 설치되어 있습니다.',
 		),
-		'http_referer' => array(
-			'nok' => 'HTTP REFERER가 변경되지 않았는지 확인해주세요.',
-			'ok' => 'HTTP REFERER가 서버와 일치하는 것을 확인했습니다.',
-		),
 		'json' => array(
 			'nok' => 'JSON 확장 기능을 찾을 수 없습니다 (php-json 패키지).',
 			'ok' => 'JSON 확장 기능이 설치되어 있습니다.',

--- a/app/i18n/nl/install.php
+++ b/app/i18n/nl/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'U mist PHP fileinfo (fileinfo package).',
 			'ok' => 'U hebt de fileinfo uitbreiding.',
 		),
-		'http_referer' => array(
-			'nok' => 'Controleer a.u.b. dat u niet uw HTTP REFERER wijzigd.',
-			'ok' => 'Uw HTTP REFERER is bekend en komt overeen met uw server.',
-		),
 		'json' => array(
 			'nok' => 'U mist een benodigede bibliotheek om JSON te gebruiken.',
 			'ok' => 'U hebt de benodigde bibliotheek om JSON te gebruiken.',

--- a/app/i18n/oc/install.php
+++ b/app/i18n/oc/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Avètz pas PHP fileinfo (paquet fileinfo).',
 			'ok' => 'Avètz la bibliotèca fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Mercés de verificar que modificatz pas vòstre HTTP REFERER.',
-			'ok' => 'Lo HTTP REFERER es conegut e sembla correspondre a vòstre servidor.',
-		),
 		'json' => array(
 			'nok' => 'Impossible de trobar l’extension recomandada JSON (paquet php-json).',
 			'ok' => 'Avètz l’exension recomandada JSON.',

--- a/app/i18n/pl/install.php
+++ b/app/i18n/pl/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Cannot find the PHP fileinfo library (fileinfo package).',	// TODO - Translation
 			'ok' => 'You have the fileinfo library.',	// TODO - Translation
 		),
-		'http_referer' => array(
-			'nok' => 'Please check that you are not altering your HTTP REFERER.',	// TODO - Translation
-			'ok' => 'Your HTTP REFERER is known and corresponds to your server.',	// TODO - Translation
-		),
 		'json' => array(
 			'nok' => 'Cannot find the recommended library to parse JSON.',	// TODO - Translation
 			'ok' => 'You have the recommended library to parse JSON.',	// TODO - Translation

--- a/app/i18n/pt-br/install.php
+++ b/app/i18n/pt-br/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Não foi possível encontrar a biblioteca fileinfo do PHP (fileinfo).',
 			'ok' => 'Você tem a biblioteca fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Por favor verifique se você não está alterando o cabeçalho HTTP REFERER.',
-			'ok' => 'O cabeçalho HTTP REFERER é conhecido e corresponde ao seu servidor.',
-		),
 		'json' => array(
 			'nok' => 'Não foi possível encontrar JSON (php-json).',
 			'ok' => 'Você tem a extensão JSON.',

--- a/app/i18n/ru/install.php
+++ b/app/i18n/ru/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'У вас нет расширения PHP fileinfo (пакет fileinfo).',
 			'ok' => 'У вас установлено расширение fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Убедитесь, что вы не изменяете ваш HTTP REFERER.',
-			'ok' => 'Ваш HTTP REFERER известен и соотвествует вашему серверу.',
-		),
 		'json' => array(
 			'nok' => 'Cannot find the recommended library to parse JSON.',	// TODO - Translation
 			'ok' => 'You have the recommended library to parse JSON.',	// TODO - Translation

--- a/app/i18n/sk/install.php
+++ b/app/i18n/sk/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'Nepodarilo sa nájsť knižniuc PHP fileinfo (balík fileinfo).',
 			'ok' => 'Našla sa knižnica fileinfo.',
 		),
-		'http_referer' => array(
-			'nok' => 'Prosím, skontrolujte, či ste nezmenili váš HTTP REFERER.',
-			'ok' => 'Váš HTTP REFERER je OK.',
-		),
 		'json' => array(
 			'nok' => 'Nepodarilo sa nájsť požadovanú knižnicu na spracovanie formátu JSON.',
 			'ok' => 'Našla sa požadovaná knižnica na spracovanie formátu JSON.',

--- a/app/i18n/tr/install.php
+++ b/app/i18n/tr/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => 'PHP fileinfo eksik (fileinfo package).',
 			'ok' => 'fileinfo eklentisi sorunsuz.',
 		),
-		'http_referer' => array(
-			'nok' => 'Lütfen HTTP REFERER değiştirmediğinize emin olun.',
-			'ok' => 'HTTP REFERER ve sunucunuz arası iletişim sorunsuz.',
-		),
 		'json' => array(
 			'nok' => 'Tavsiye edilen JSON çözümleme kütüphanesi eksik.',
 			'ok' => 'Tavsiye edilen JSON çözümleme kütüphanesi sorunsuz.',

--- a/app/i18n/zh-cn/install.php
+++ b/app/i18n/zh-cn/install.php
@@ -60,10 +60,6 @@ return array(
 			'nok' => '找不到 PHP fileinfo 库（fileinfo）',
 			'ok' => '已找到 fileinfo 库',
 		),
-		'http_referer' => array(
-			'nok' => '请检查你是否修改了 HTTP REFERER',
-			'ok' => '你的 HTTP REFERER 已知且与服务器一致',
-		),
 		'json' => array(
 			'nok' => '找不到推荐的 JSON 解析库',
 			'ok' => '已找到推荐的 JSON 解析库',

--- a/app/install.php
+++ b/app/install.php
@@ -418,7 +418,6 @@ function printStep1() {
 	printStep1Template('tmp', $res['tmp'], [TMP_PATH, $processUsername]);
 	printStep1Template('users', $res['users'], [USERS_PATH, $processUsername]);
 	printStep1Template('favicons', $res['favicons'], [DATA_PATH . '/favicons', $processUsername]);
-	printStep1Template('http_referer', $res['http_referer']);
 	?>
 
 	<?php if (freshrss_already_installed() && $res['all'] == 'ok') { ?>

--- a/cli/i18n/ignore/en-us.php
+++ b/cli/i18n/ignore/en-us.php
@@ -656,8 +656,6 @@ return array(
 	'install.check.favicons.ok',
 	'install.check.fileinfo.nok',
 	'install.check.fileinfo.ok',
-	'install.check.http_referer.nok',
-	'install.check.http_referer.ok',
 	'install.check.json.nok',
 	'install.check.json.ok',
 	'install.check.mbstring.nok',

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -46,7 +46,6 @@ function checkRequirements($dbType = '') {
 	$tmp = TMP_PATH && is_writable(TMP_PATH);
 	$users = USERS_PATH && is_writable(USERS_PATH);
 	$favicons = is_writable(join_path(DATA_PATH, 'favicons'));
-	$http_referer = is_referer_from_same_domain();
 
 	return array(
 		'php' => $php ? 'ok' : 'ko',
@@ -67,10 +66,9 @@ function checkRequirements($dbType = '') {
 		'tmp' => $tmp ? 'ok' : 'ko',
 		'users' => $users ? 'ok' : 'ko',
 		'favicons' => $favicons ? 'ok' : 'ko',
-		'http_referer' => $http_referer ? 'ok' : 'ko',
 		'message' => $message ?: '',
 		'all' => $php && $curl && $pdo && $pcre && $ctype && $dom && $xml &&
-		         $data && $cache && $tmp && $users && $favicons && $http_referer && $message == '' ? 'ok' : 'ko'
+		         $data && $cache && $tmp && $users && $favicons && $message == '' ? 'ok' : 'ko'
 	);
 }
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -393,23 +393,6 @@ function cryptAvailable() {
 	return false;
 }
 
-function is_referer_from_same_domain() {
-	if (empty($_SERVER['HTTP_REFERER'])) {
-		return true;	//Accept empty referer while waiting for good support of meta referrer same-origin policy in browsers
-	}
-	$host = parse_url(((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https://' : 'http://') .
-		(empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] : $_SERVER['HTTP_HOST']));
-	$referer = parse_url($_SERVER['HTTP_REFERER']);
-	if (empty($host['host']) || empty($referer['host']) || $host['host'] !== $referer['host']) {
-		return false;
-	}
-	//TODO: check 'scheme', taking into account the case of a proxy
-	if ((isset($host['port']) ? $host['port'] : 0) !== (isset($referer['port']) ? $referer['port'] : 0)) {
-		return false;
-	}
-	return true;
-}
-
 
 /**
  * Check PHP and its extensions are well-installed.


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/issues/2989#issuecomment-774763134

Changes proposed in this pull request:

- Remove install checks of Referer Header
- Remove checks of Referer for XSRF Mitigation:
The [OWASP Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) recommends using CSRF-Tokens (as we already do).