### PR TITLE
Add user maintenance hooks

### DIFF
--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -72,6 +72,9 @@ foreach ($users as $user) {
 	}
 
 	FreshRSS_Auth::giveAccess();
+
+	Minz_ExtensionManager::callHook('freshrss_user_maintenance');
+
 	$app->init();
 	notice('FreshRSS actualize ' . $user . '...');
 	echo $user, ' ';	//Buffered

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -330,15 +330,16 @@ The following events are available:
 * `entry_before_insert` (`function($entry) -> Entry | null`): will be executed when a feed is refreshed and new entries will be imported into the database. The new entry (instance of FreshRSS\_Entry) will be passed as parameter.
 * `feed_before_actualize` (`function($feed) -> Feed | null`): will be executed when a feed is updated. The feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `feed_before_insert` (`function($feed) -> Feed | null`): will be executed when a new feed is imported into the database. The new feed (instance of FreshRSS\_Feed) will be passed as parameter.
-* `freshrss_init` (`function() -> none`): will be executed at the end of the initialization of FreshRSS, useful to initialize components or to do additional access checks
-* `js_vars` (`function($vars = array) -> array | null`): will be executed if the `jsonVars` in the header will be generated
-* `menu_admin_entry` (`function() -> string`): add an entry at the end of the "Administration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
-* `menu_configuration_entry` (`function() -> string`): add an entry at the end of the "Configuration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
-* `menu_other_entry` (`function() -> string`): add an entry at the end of the header dropdown menu (i.e. after the "About" entry), the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`)
+* `freshrss_init` (`function() -> none`): will be executed at the end of the initialization of FreshRSS, useful to initialize components or to do additional access checks.
+* `freshrss_user_maintenance` (`function() -> none`): will be executed for each user during the `actualize_script`, useful to run some maintenance tasks on the user.
+* `js_vars` (`function($vars = array) -> array | null`): will be executed if the `jsonVars` in the header will be generated.
+* `menu_admin_entry` (`function() -> string`): add an entry at the end of the "Administration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`).
+* `menu_configuration_entry` (`function() -> string`): add an entry at the end of the "Configuration" menu, the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`).
+* `menu_other_entry` (`function() -> string`): add an entry at the end of the header dropdown menu (i.e. after the "About" entry), the returned string must be valid HTML (e.g. `<li class="item active"><a href="url">New entry</a></li>`).
 * `nav_menu` (`function() -> string`): will be executed if the navigation was built.
-* `nav_reading_modes` (`function($reading_modes) -> array | null`): **TODO** add documentation
-* `post_update` (`function(none) -> none`): **TODO** add documentation
-* `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation
+* `nav_reading_modes` (`function($reading_modes) -> array | null`): **TODO** add documentation.
+* `post_update` (`function(none) -> none`): **TODO** add documentation.
+* `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation.
 
 ### Writing your own configure.phtml
 

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -39,6 +39,10 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'NoneToNone',
 		),
+		'freshrss_user_maintenance' => array(  // function() -> none
+			'list' => array(),
+			'signature' => 'NoneToNone',
+		),
 		'js_vars' => array(  // function($vars = array) -> array | null
 			'list' => array(),
 			'signature' => 'OneToOne',


### PR DESCRIPTION
Closes #3398 (partially)

Changes proposed in this pull request:

- Add user maintenance hooks

How to test the feature manually:

1. Add an extension using a new hook.
2. Run the `make refresh` command.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

The new hook allows to add maintenance extensions at the user level.
