### PR TITLE
Update Travis.yaml to support newer PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,30 +32,6 @@ jobs:
         - COMPOSER_BIN=$(composer global config --absolute bin-dir)
         - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
         - $COMPOSER_BIN/phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
-    - name: "PHP 7.3 Syntax, linter and tests"
-      php: "7.3"
-      install:
-        - composer global require squizlabs/php_codesniffer
-        - composer global require phpunit/phpunit ^9
-      script:
-        - phpenv rehash
-        - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
-        - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
-        - COMPOSER_BIN=$(composer global config --absolute bin-dir)
-        - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
-        - $COMPOSER_BIN/phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
-
-    - name: "PHP 7.1 Syntax and tests"
-      php: "7.1"
-      install:
-        - composer global require phpunit/phpunit ^7
-      script:
-        - phpenv rehash
-        - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
-        - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
-        - COMPOSER_BIN=$(composer global config --absolute bin-dir)
-        - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
-
     - name: "PHP 5.6 Syntax"
       php: "5.6"
       script:
@@ -64,14 +40,14 @@ jobs:
         - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
 
     - name: "Translations format"
-      php: "7.3"
+      php: "7.4"
       script:
         - phpenv rehash
         - php cli/manipulate.translation.php -a format
         - git diff --exit-code
 
     - name: "Translations"
-      php: "7.3"
+      php: "7.4"
       script:
         - phpenv rehash
         - php cli/check.translation.php -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,39 @@ jobs:
   fast_finish: true
   allow_failures:
     - name: "Translations"
+    - name: "PHP 8.0 Syntax, linter and tests"
+
 
   include:
+    - name: "PHP 8.0 Syntax, linter and tests"
+      php: "8.0"
+      install:
+        - composer global require squizlabs/php_codesniffer
+        - composer global require phpunit/phpunit ^9
+      script:
+        - phpenv rehash
+        - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
+        - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
+        - COMPOSER_BIN=$(composer global config --absolute bin-dir)
+        - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
+        - $COMPOSER_BIN/phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
+    - name: "PHP 7.4 Syntax, linter and tests"
+      php: "7.4"
+      install:
+        - composer global require squizlabs/php_codesniffer
+        - composer global require phpunit/phpunit ^9
+      script:
+        - phpenv rehash
+        - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
+        - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
+        - COMPOSER_BIN=$(composer global config --absolute bin-dir)
+        - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
+        - $COMPOSER_BIN/phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
     - name: "PHP 7.3 Syntax, linter and tests"
       php: "7.3"
       install:
         - composer global require squizlabs/php_codesniffer
-        - composer global require phpunit/phpunit ^7
+        - composer global require phpunit/phpunit ^9
       script:
         - phpenv rehash
         - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results

--- a/tests/app/Models/CategoryTest.php
+++ b/tests/app/Models/CategoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class FreshRSS_CategoryTest extends PHPUnit\Framework\TestCase {
+class CategoryTest extends PHPUnit\Framework\TestCase {
 
 	public function test__construct_whenNoParameters_createsObjectWithDefaultValues() {
 		$category = new FreshRSS_Category();

--- a/tests/app/Utils/passwordUtilTest.php
+++ b/tests/app/Utils/passwordUtilTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class FreshRSS_password_UtilTest extends PHPUnit\Framework\TestCase {
+class passwordUtilTest extends PHPUnit\Framework\TestCase {
 	public function testCheck() {
 		$password = '1234567';
 

--- a/tests/lib/Minz/MigratorTest.php
+++ b/tests/lib/Minz/MigratorTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 
-class Minz_MigratorTest extends TestCase
+class MigratorTest extends TestCase
 {
 	public function testAddMigration() {
 		$migrator = new Minz_Migrator();


### PR DESCRIPTION
Closes #3458

Changes proposed in this pull request:
- Updates Travis to add PHP 7.4 and 8.0
- Allow failures on PHP 8 (for now)
- Upgrade PHPUnit to 9.0
- Removes PHP 7.1 and 7.3 from Tests.
-   Updates the Class name for `CategoryTest.php` , `passwordUtilTest.php`, and `MigratorTest.php` to fix Unit test WARNINGs

How to test the feature manually:

I'm fairly new to Travis so I'm not sure, hoping there is a way to test the config without committing this branch. 

Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
