### PR TITLE
Add full content delimiter and action

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -447,12 +447,14 @@ class FreshRSS_Entry extends Minz_Model {
 						$feed->attributes()
 					);
 					if ('' !== $fullContent) {
+						$fullContent = "<!-- FULLCONTENT start //-->{$fullContent}<!-- FULLCONTENT end //-->";
+						$originalContent = preg_replace('#<!-- FULLCONTENT start //-->.*<!-- FULLCONTENT end //-->#s', '', $this->content());
 						switch ($feed->attributes('content_action')) {
 							case 'prepend':
-								$this->content = $fullContent . $this->content();
+								$this->content = $fullContent . $originalContent;
 								break;
 							case 'append':
-								$this->content = $this->content() . $fullContent;
+								$this->content = $originalContent . $fullContent;
 								break;
 							case 'replace':
 							default:


### PR DESCRIPTION
Changes proposed in this pull request:

- Add full content delimiter and action

How to test the feature manually:

1. Reload many times a feed with a content retrieved by a CSS selector (append or prepend mode only)
2. Check that the retrieved content is not repeated

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, when appending or prepending the content of the CSS selector
content, it was added to the content. It was working fine for the
first call but every subsequent calls were pilling the retrieved
content on top of the already retrieved content. Thus we had an ever
growing content with a lot of duplication.
Now, the CSS selector content is identified by an HTML comment which
is used to remove the content for every subsequent calls.

The bug was introduced in #3453
