### PR TITLE
Fix feed sort order

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -62,6 +62,10 @@ class FreshRSS_Category extends Minz_Model {
 			}
 		}
 
+		usort($this->feeds, function ($a, $b) {
+			return strnatcasecmp($a->name(), $b->name());
+		});
+
 		return $this->feeds;
 	}
 


### PR DESCRIPTION
Closes #3228

Changes proposed in this pull request:

- Fix feed sort order

How to test the feature manually:

1. check that the feed order does not change when changing the case of its name

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, the feeds in the list weren't properly ordered. Uppercase
values were before lowercase values.
Now, the feed order is forced to ignore the case.

