### PR TITLE
Change zip handling methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ jobs:
   fast_finish: true
   allow_failures:
     - name: "Translations"
-    - name: "PHP 8.0 Syntax, linter and tests"
-
 
   include:
     - name: "PHP 8.0 Syntax, linter and tests"

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -64,31 +64,24 @@ class FreshRSS_importExport_Controller extends Minz_ActionController {
 
 		// We try to list all files according to their type
 		$list = array();
-		if ($type_file === 'zip' && extension_loaded('zip')) {
-			$zip = zip_open($path);
-			if (!is_resource($zip)) {
+		if ('zip' === $type_file && extension_loaded('zip')) {
+			$zip = new ZipArchive();
+			$result = $zip->open($path);
+			if (true !== $result) {
 				// zip_open cannot open file: something is wrong
-				throw new FreshRSS_Zip_Exception($zip);
+				throw new FreshRSS_Zip_Exception($result);
 			}
-			while (($zipfile = zip_read($zip)) !== false) {
-				if (!is_resource($zipfile)) {
-					// zip_entry() can also return an error code!
-					throw new FreshRSS_Zip_Exception($zipfile);
-				} else {
-					$type_zipfile = self::guessFileType(zip_entry_name($zipfile));
-					if ($type_file !== 'unknown') {
-						$list_files[$type_zipfile][] = zip_entry_read(
-							$zipfile,
-							zip_entry_filesize($zipfile)
-						);
-					}
+			for ($i = 0; $i < $zip->numFiles; $i++) {
+				$type_zipfile = self::guessFileType($zip->getNameIndex($i));
+				if ('unknown' !== $type_zipfile) {
+					$list_files[$type_zipfile][] = $zip->getFromIndex($i);
 				}
 			}
-			zip_close($zip);
-		} elseif ($type_file === 'zip') {
+			$zip->close();
+		} elseif ('zip' === $type_file) {
 			// ZIP extension is not loaded
 			throw new FreshRSS_ZipMissing_Exception();
-		} elseif ($type_file !== 'unknown') {
+		} elseif ('unknown' !== $type_file) {
 			$list_files[$type_file][] = file_get_contents($path);
 		}
 


### PR DESCRIPTION

Closes #3460

Changes proposed in this pull request:

- Change zip handling methods

How to test the feature manually:

1. Export a user subscriptions
2. Import for another user the generated file

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, we were using zip function but they are marked as deprecated as of
PHP 8.0. It's not safe to use them anymore since they can be removed at any
given time.
Now, we are using the ZipArchive class to handle our zip methods. It's safe
to use it since it's available for PHP 5.2 and higher.