### PR TITLE
Optimize theme Pafat for the mobile view

### DIFF
--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -120,6 +120,7 @@ form th {
 .stick {
 	vertical-align: middle;
 	font-size: 0;
+	min-width: 215px;
 }
 
 .stick input,
@@ -1167,6 +1168,7 @@ a.btn {
 
 	.nav_menu .stick {
 		margin: 0 10px;
+		min-width: max-content;
 	}
 
 	.nav_menu .stick .btn {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -1168,7 +1168,7 @@ a.btn {
 
 	.nav_menu .stick {
 		margin: 0 10px;
-		min-width: max-content;
+		min-width: 0;
 	}
 
 	.nav_menu .stick .btn {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -120,7 +120,6 @@ form th {
 .stick {
 	vertical-align: middle;
 	font-size: 0;
-	min-width: 215px;
 }
 
 .stick input,

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -120,6 +120,7 @@ form th {
 .stick {
 	vertical-align: middle;
 	font-size: 0;
+	min-width: 215px;
 }
 
 .stick input,
@@ -1167,6 +1168,7 @@ a.btn {
 
 	.nav_menu .stick {
 		margin: 0 10px;
+		min-width: max-content;
 	}
 
 	.nav_menu .stick .btn {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -1168,7 +1168,7 @@ a.btn {
 
 	.nav_menu .stick {
 		margin: 0 10px;
-		min-width: max-content;
+		min-width: 0;
 	}
 
 	.nav_menu .stick .btn {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -120,7 +120,6 @@ form th {
 .stick {
 	vertical-align: middle;
 	font-size: 0;
-	min-width: 215px;
 }
 
 .stick input,


### PR DESCRIPTION
It is better for the mobile view to delete the button's `min-width`.

Before:

![Before](https://user-images.githubusercontent.com/27203797/109256897-f8554300-7831-11eb-8a3d-1fe8862bdcc6.jpg)

After:

![After](https://user-images.githubusercontent.com/27203797/109256907-fe4b2400-7831-11eb-89f6-7ab20cb4b7ad.jpg)
