### PR TITLE
Alpine oldest: php5-openssl

### DIFF
--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -5,7 +5,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
 	apache2 php5-apache2 \
 	php5 php5-curl php5-gmp php5-intl php5-xml php5-zip \
-	php5-ctype php5-dom php5-iconv php5-json php5-opcache php5-phar php5-xmlreader php5-zlib \
+	php5-ctype php5-dom php5-iconv php5-json php5-opcache php5-openssl php5-phar php5-xmlreader php5-zlib \
 	php5-pdo_sqlite php5-pdo_mysql php5-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/


### PR DESCRIPTION
alpine:3.13 requires php5-openssl for some https features.

Otherwise, fail on e.g. the extension page:

```
file_get_contents(): php Unable to find the wrapper "https" - did you forget to enable it when you configured PHP? in
/var/www/FreshRSS/app/Controllers/extensionController.php on line 45

PHP Warning:
file_get_contents(https://raw.githubusercontent.com/FreshRSS/Extensions/master/extensions.json):
failed to open stream: No such file or directory in /var/www/FreshRSS/app/Controllers/extensionController.php on line 45

[error] --- Could not fetch available extension from GitHub
```

Does not seem required for newer Alpine versions using PHP7 / PHP8