### PR TITLE
PHP8: Update PHPUnit version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ lint-fix: bin/phpcbf ## Fix the errors detected by the linter
 
 bin/phpunit:
 	mkdir -p bin/
-	wget -O bin/phpunit https://phar.phpunit.de/phpunit-7.5.9.phar
-	echo '5404288061420c3921e53dd3a756bf044be546c825c5e3556dea4c51aa330f69 bin/phpunit' | sha256sum -c - || rm bin/phpunit
+	wget -O bin/phpunit https://phar.phpunit.de/phpunit-9.5.2.phar
+	echo 'bcf913565bc60dfb5356cf67cbbccec1d8888dbd595b0fbb8343a5019342c67c bin/phpunit' | sha256sum -c - || rm bin/phpunit
 
 bin/phpcs:
 	mkdir -p bin/


### PR DESCRIPTION

Changes proposed in this pull request:

- Update PHPUnit version

How to test the feature manually:

1. Launch tests before the use of the new phpunit version (PHP8)
2. Update phpunit version
3. Launch tests after the use of the new phpunit version (PHP8)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Tests weren't running with the previous version because of a reserved
word in PHP8. The latest version of the library fixes that.
See https://github.com/sebastianbergmann/phpunit/issues/4373 for more
information.
