### PR TITLE
Remove + conversion in search except for tags

### DIFF
--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -217,7 +217,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->intitle = self::removeEmptyValues($this->intitle);
-		$this->intitle = self::decodeSpaces($this->intitle);
 		return $input;
 	}
 
@@ -231,7 +230,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_intitle = self::removeEmptyValues($this->not_intitle);
-		$this->not_intitle = self::decodeSpaces($this->not_intitle);
 		return $input;
 	}
 
@@ -255,7 +253,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->author = self::removeEmptyValues($this->author);
-		$this->author = self::decodeSpaces($this->author);
 		return $input;
 	}
 
@@ -269,7 +266,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_author = self::removeEmptyValues($this->not_author);
-		$this->not_author = self::decodeSpaces($this->not_author);
 		return $input;
 	}
 
@@ -287,7 +283,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->inurl = self::removeEmptyValues($this->inurl);
-		$this->inurl = self::decodeSpaces($this->inurl);
 		return $input;
 	}
 
@@ -297,7 +292,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_inurl = self::removeEmptyValues($this->not_inurl);
-		$this->not_inurl = self::decodeSpaces($this->not_inurl);
 		return $input;
 	}
 
@@ -416,7 +410,6 @@ class FreshRSS_Search {
 		} else {
 			$this->search = explode(' ', $input);
 		}
-		$this->search = self::decodeSpaces($this->search);
 	}
 
 	private function parseNotSearch($input) {
@@ -436,7 +429,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_search = self::removeEmptyValues($this->not_search);
-		$this->not_search = self::decodeSpaces($this->not_search);
 		return $input;
 	}
 
@@ -450,5 +442,4 @@ class FreshRSS_Search {
 		$input = preg_replace('/\s+/', ' ', $input);
 		return trim($input);
 	}
-
 }

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -88,7 +88,7 @@ $today = @strtotime('today');
 								echo $first ? _t('gen.short.by_author') . ' ' : '· ';
 								$first = false;
 					?>
-	<em><a href="<?= Minz_Url::display(Minz_Request::modifiedCurrentRequest(['search' => 'author:' . str_replace(' ', '+', htmlspecialchars_decode($author, ENT_QUOTES))])) ?>"><?= $author ?></a></em>
+	<em><a href="<?= Minz_Url::display(Minz_Request::modifiedCurrentRequest(['search' => 'author:"' . htmlspecialchars_decode($author, ENT_QUOTES) . '"'])) ?>"><?= $author ?></a></em>
 					<?php	endforeach; ?>
 					</div><?php endif; ?>
 				</div>

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -66,6 +66,7 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			array('intitle:"word1 word2\' word3"', array("word1 word2' word3"), null),
 			array("intitle:'word1 word2\" word3'", array('word1 word2" word3'), null),
 			array("intitle:word1 'word2 word3' word4", array('word1'), array('word2 word3', 'word4')),
+			['intitle:word1+word2', ['word1+word2'], null],
 		);
 	}
 
@@ -102,6 +103,7 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			array('author:"word1 word2\' word3"', array("word1 word2' word3"), null),
 			array("author:'word1 word2\" word3'", array('word1 word2" word3'), null),
 			array("author:word1 'word2 word3' word4", array('word1'), array('word2 word3', 'word4')),
+			['author:word1+word2', ['word1+word2'], null],
 		);
 	}
 
@@ -129,6 +131,7 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			array('inurl:"word1 word2"', array('"word1'), array('word2"')),
 			array('inurl:word1 word2 inurl:word3', array('word1', 'word3'), array('word2')),
 			array("inurl:word1 'word2 word3' word4", array('word1'), array('word2 word3', 'word4')),
+			['inurl:word1+word2', ['word1+word2'], null],
 		);
 	}
 
@@ -208,6 +211,7 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			array('#"word1 word2"', array('"word1'), array('word2"')),
 			array('#word1 #word2', array('word1', 'word2'), null),
 			array("#word1 'word2 word3' word4", array('word1'), array('word2 word3', 'word4')),
+			['#word1+word2', ['word1 word2'], null],
 		);
 	}
 
@@ -290,5 +294,4 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			),
 		);
 	}
-
 }


### PR DESCRIPTION
Closes #3454

Changes proposed in this pull request:

- Remove + conversion in search except for tags

How to test the feature manually:

1. add the feed https://www.heise.de/rss/heise-atom.xml
2. search for `intitle:heise+`
3. only title starting with `heise+` should show

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Before, every + sign was converted to a space to allow to search for
spaces. But the documentation stated that to search for space one has
to enclose the string in quotes. This has a confusing behavior when
searching for a string containing a + sign.
Now, the + conversion is kept only for the tag search since it's the
only one documented that way.