### PR TITLE
Travis remove superfluous PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,6 @@ jobs:
         - COMPOSER_BIN=$(composer global config --absolute bin-dir)
         - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
         - $COMPOSER_BIN/phpcs . -p -s
-    - name: "PHP 7.4 Syntax, linter and tests"
-      php: "7.4"
-      install:
-        - composer global require squizlabs/php_codesniffer
-        - composer global require phpunit/phpunit ^9
-      script:
-        - phpenv rehash
-        - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results
-        - if [ -s php-l-results ]; then cat php-l-results; exit 1; fi
-        - COMPOSER_BIN=$(composer global config --absolute bin-dir)
-        - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
-        - $COMPOSER_BIN/phpcs . -p -s
     - name: "PHP 5.6 Syntax"
       php: "5.6"
       script:


### PR DESCRIPTION
Now that Travis tests with PHP8 are all working fine, and as we have PHP 5.6 with the sames tests for our oldest supported version, let's save resources and remove intermediate versions.
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/3459#issuecomment-781974573