### PR TITLE
Reload full content when changed

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -377,6 +377,9 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 								continue;
 							}
 
+							// If the entry has changed, there is a good chance for the full content to haved changed as well.
+							$entry->loadCompleteContent(true);
+
 							if (!$entryDAO->inTransaction()) {
 								$entryDAO->beginTransaction();
 							}

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -377,7 +377,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 								continue;
 							}
 
-							// If the entry has changed, there is a good chance for the full content to haved changed as well.
+							// If the entry has changed, there is a good chance for the full content to have changed as well.
 							$entry->loadCompleteContent(true);
 
 							if (!$entryDAO->inTransaction()) {

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -433,9 +433,9 @@ class FreshRSS_Entry extends Minz_Model {
 		$feed = $this->feed(true);
 		if ($feed != null && trim($feed->pathEntries()) != '') {
 			$entryDAO = FreshRSS_Factory::createEntryDao();
-			$entry = $entryDAO->searchByGuid($this->feedId, $this->guid);
+			$entry = $force ? null : $entryDAO->searchByGuid($this->feedId, $this->guid);
 
-			if ($entry && !$force) {
+			if ($entry) {
 				// l'article existe déjà en BDD, en se contente de recharger ce contenu
 				$this->content = $entry->content();
 			} else {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -468,8 +468,7 @@ class FreshRSS_Feed extends Minz_Model {
 			$entry->_tags($tags);
 			$entry->_feed($this);
 			$entry->hash();	//Must be computed before loading full content
-			// Optionally load full content for truncated feeds
-			$entry->loadCompleteContent();
+			$entry->loadCompleteContent();	// Optionally load full content for truncated feeds
 
 			yield $entry;
 		}
@@ -498,9 +497,7 @@ class FreshRSS_Feed extends Minz_Model {
 	}
 
 	protected function cacheFilename() {
-		$url = $this->url;	//Includes #force_feed when applicable
-		$url .= empty($this->attributes['curl_params']) ? '' : '#' . urlencode(var_export($this->attributes['curl_params'], true));
-		return CACHE_PATH . '/' . sha1($url) . '.spc';
+		return CACHE_PATH . '/' . md5($this->url) . '.spc';
 	}
 
 	public function clearCache() {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -467,10 +467,9 @@ class FreshRSS_Feed extends Minz_Model {
 			);
 			$entry->_tags($tags);
 			$entry->_feed($this);
-			if ($this->pathEntries != '') {
-				// Optionally load full content for truncated feeds
-				$entry->loadCompleteContent();
-			}
+			$entry->hash();	//Must be computed before loading full content
+			// Optionally load full content for truncated feeds
+			$entry->loadCompleteContent();
 
 			yield $entry;
 		}
@@ -499,7 +498,9 @@ class FreshRSS_Feed extends Minz_Model {
 	}
 
 	protected function cacheFilename() {
-		return CACHE_PATH . '/' . md5($this->url) . '.spc';
+		$url = $this->url;	//Includes #force_feed when applicable
+		$url .= empty($this->attributes['curl_params']) ? '' : '#' . urlencode(var_export($this->attributes['curl_params'], true));
+		return CACHE_PATH . '/' . sha1($url) . '.spc';
 	}
 
 	public function clearCache() {


### PR DESCRIPTION
If an article is changed, reload also its full content when applicable.
And fix a related bug: the hash to detect changes must be computed before loading the full content.