### PR TITLE
GitHub action latest tag

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,12 @@
+name: Add latest tag to new release
+on:
+  release:
+    types: [published]
+
+jobs:
+  run:
+    name: Run local action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run latest-tag
+        uses: EndBug/latest-tag@6d22a6738f5c33059e3a8c6ca5dcf8eaf8a14599


### PR DESCRIPTION
Automatically tag the latest release with the `latest` git tag
https://github.com/marketplace/actions/latest-tag