### PR TITLE
Fix search param encoding in user query

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -347,7 +347,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 		if (Minz_Request::isPost()) {
 			$params = array_filter(Minz_Request::param('query', []));
 			if (!empty($params['search'])) {
-				$params['search'] = urldecode($params['search']);
+				$params['search'] = htmlspecialchars_decode($params['search'], ENT_QUOTES);
 			}
 			if (!empty($params['state'])) {
 				$params['state'] = array_sum($params['state']);

--- a/app/views/helpers/configure/query.phtml
+++ b/app/views/helpers/configure/query.phtml
@@ -19,7 +19,7 @@
 		<div class="form-group">
 			<label class="group-name" for=""><?= _t('conf.query.filter.search') ?></label>
 			<div class="group-controls">
-				<input type="text" id="query_search" name="query[search]"  class="extend" value="<?= urldecode($this->query->getSearch()) ?>"/>
+				<input type="text" id="query_search" name="query[search]"  class="extend" value="<?= htmlspecialchars($this->query->getSearch(), ENT_COMPAT, 'UTF-8') ?>"/>
 			</div>
 		</div>
 		<div class="form-group">


### PR DESCRIPTION
Closes #3538

Changes proposed in this pull request:

- Fix search param encoding in user query

How to test the feature manually:

1. make a search using quotes (") like `intitle:"something to search for"`
2. bookmark that query
3. edit the user query and see that the search parameter is the same as before

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, the chosen encoding was not the best for the task since some part
of the value was truncated when used with quotes.
Now, the encoding allows to work smoothly with quotes.