### PR TITLE
Fix init in CLI install

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -152,7 +152,7 @@ function saveStep2() {
 			opcache_reset();
 		}
 
-		FreshRSS_Context::initSystem();
+		FreshRSS_Context::initSystem(true);
 
 		$ok = false;
 		try {

--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -86,7 +86,7 @@ if (function_exists('opcache_reset')) {
 	opcache_reset();
 }
 
-FreshRSS_Context::initSystem();
+FreshRSS_Context::initSystem(true);
 
 Minz_Session::_param('currentUser', '_');	//Default user
 


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3528
Config was not properly reloaded after being populated.
This would lead to errors:
* if pdo-sqlite is not available
* if the MySQL or PostgreSQL database is not already existing, as it would not be auto-created by FreshRSS
