### PR TITLE
Check pdo_sqlite for export/import SQLite

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -199,6 +199,9 @@ class FreshRSS_DatabaseDAO extends Minz_ModelPdo {
 	const SQLITE_IMPORT = 2;
 
 	public function dbCopy($filename, $mode, $clearFirst = false) {
+		if (!extension_loaded('pdo_sqlite')) {
+			return self::stdError('PHP extension pdo_sqlite is missing!');
+		}
 		$error = '';
 
 		$userDAO = FreshRSS_Factory::createUserDao();


### PR DESCRIPTION
Following https://github.com/FreshRSS/FreshRSS/pull/3544 (works without pdo_sqlite), test that `pdo_sqlite` is loaded for export/import SQLite.