### PR TITLE
Fix undefined variable & dead code when adding feed

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -173,9 +173,6 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				$opts[CURLOPT_PROXY] = $proxy_address;
 				$opts[CURLOPT_PROXYTYPE] = intval($proxy_type);
 			}
-			if ($cookie !== '') {
-				$opts[CURLOPT_COOKIE] = $cookie;
-			}
 			if ($useragent !== '') {
 				$opts[CURLOPT_USERAGENT] = $useragent;
 			}


### PR DESCRIPTION
Fix warning due to undefined `$cookie` variable. `CURLOPT_COOKIE` is not used when adding a feed.
Problem introduced in https://github.com/FreshRSS/FreshRSS/pull/3494