### PR TITLE
SimplePie fix PHP8 uncatched error

### DIFF
--- a/lib/SimplePie/SimplePie/Locator.php
+++ b/lib/SimplePie/SimplePie/Locator.php
@@ -75,12 +75,19 @@ class SimplePie_Locator
 		$this->force_fsockopen = $force_fsockopen;
 		$this->curl_options = $curl_options;
 
-		if (class_exists('DOMDocument'))
+		if (class_exists('DOMDocument') && $this->file->body != '')
 		{
 			$this->dom = new DOMDocument();
 
 			set_error_handler(array('SimplePie_Misc', 'silence_errors'));
-			$this->dom->loadHTML($this->file->body);
+			try
+			{
+				$this->dom->loadHTML($this->file->body);
+			}
+			catch (Throwable $ex)
+			{
+				$this->dom = null;
+			}
 			restore_error_handler();
 		}
 		else


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3537
When `loadHTML()` is given a null or empty string.

```
PHP Fatal error:  Uncaught ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty in /var/www/freshrss/lib/SimplePie/SimplePie/Locator.php:83
```
