### PR TITLE
Remove shortcut validation

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -177,15 +177,13 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			$shortcuts = Minz_Request::param('shortcuts');
 			if (false !== Minz_Request::param('load_default_shortcuts')) {
 				$default = Minz_Configuration::load(FRESHRSS_PATH . '/config-user.default.php');
-				$shortcuts = $data['shortcuts'];
+				$shortcuts = $default['shortcuts'];
 			}
-			FreshRSS_Context::$user_conf->shortcuts = validateShortcutList($shortcuts);
+			FreshRSS_Context::$user_conf->shortcuts = array_map('trim', $shortcuts);
 			FreshRSS_Context::$user_conf->save();
 			invalidateHttpCache();
 
 			Minz_Request::good(_t('feedback.conf.shortcuts_updated'), array('c' => 'configure', 'a' => 'shortcut'));
-		} else {
-			FreshRSS_Context::$user_conf->shortcuts = validateShortcutList(FreshRSS_Context::$user_conf->shortcuts);
 		}
 
 		Minz_View::prependTitle(_t('conf.shortcut.title') . ' · ');

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Pomocí přepínače <kbd>⇧ Shift</kbd> fungují navigační zkratky v rámci kanálů.<br/>Pomocí přepínače <kbd>Alt ⎇</kbd> fungují v rámci kategorií.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',	// TODO - Translation
 		'next_article' => 'Skočit na další článek',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Switch to normal view',	// TODO - Translation
 		'other_action' => 'Ostatní akce',
 		'previous_article' => 'Skočit na předchozí článek',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Mit der <kbd>⇧ Umschalttaste</kbd> finden die Tastenkombination auf Feeds Anwendung.<br/>Mit der <kbd>Alt ⎇</kbd>-Taste finden die Tastenkombination auf Kategorien Anwendung.',
 		'navigation_no_mod_help' => 'Die folgenden Navigationsverknüpfungen unterstützen keine Modifikatoren.',
 		'next_article' => 'Zum nächsten Artikel springen',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Wechsle zur normalen Ansicht',
 		'other_action' => 'Andere Aktionen',
 		'previous_article' => 'Zum vorherigen Artikel springen',

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'With the <kbd>⇧ Shift</kbd> modifier, navigation shortcuts apply on feeds.<br/>With the <kbd>Alt ⎇</kbd> modifier, navigation shortcuts apply on categories.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',
 		'next_article' => 'Open the next article',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',
 		'normal_view' => 'Switch to normal view',
 		'other_action' => 'Other actions',
 		'previous_article' => 'Open the previous article',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'With the <kbd>⇧ Shift</kbd> modifier, navigation shortcuts apply on feeds.<br/>With the <kbd>Alt ⎇</kbd> modifier, navigation shortcuts apply on categories.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',
 		'next_article' => 'Open the next article',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',
 		'normal_view' => 'Switch to normal view',
 		'other_action' => 'Other actions',
 		'previous_article' => 'Open the previous article',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Con el modificador <kbd>⇧ Mayúsculas</kbd> es posible usar los atajos de teclado en las fuentes.<br/>Con el modificador <kbd>Alt ⎇</kbd> es posible aplicar los atajos de teclado en las categorías.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',	// TODO - Translation
 		'next_article' => 'Saltar al siguiente artículo',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Switch to normal view',	// TODO - Translation
 		'other_action' => 'Otras acciones',
 		'previous_article' => 'Saltar al artículo anterior',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Avec le modificateur <kbd>⇧ Maj</kbd>, les raccourcis de navigation s’appliquent aux flux.<br/>Avec le modificateur <kbd>Alt ⎇</kbd>, les raccourcis de navigation s’appliquent aux catégories.',
 		'navigation_no_mod_help' => 'Les raccourcis suivant ne supportent pas les modificateurs.',
 		'next_article' => 'Passer à l’article suivant',
+		'non_standard' => 'Certains raccourcis (<kbd>%s</kbd>) peuvent ne pas fonctionner.',
 		'normal_view' => 'Basculer vers la vue normale',
 		'other_action' => 'Autres actions',
 		'previous_article' => 'Passer à l’article précédent',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'בעזרת מקש השיפט קיצורי דרך חלים על הזנות .<br/>עם מקש האלט הם חלים על קטגוריות.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',	// TODO - Translation
 		'next_article' => 'דילוג למאמר הבא',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Switch to normal view',	// TODO - Translation
 		'other_action' => 'פעולות אחרות',
 		'previous_article' => 'דילוג למאמר הקודם',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Con il tasto <kbd>⇧ Shift</kbd> i comandi di navigazione verranno applicati ai feeds.<br/>Con il tasto <kbd>Alt ⎇</kbd> i comandi di navigazione verranno applicati alle categorie.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',	// TODO - Translation
 		'next_article' => 'Salta al contenuto successivo',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Switch to normal view',	// TODO - Translation
 		'other_action' => 'Altre azioni',
 		'previous_article' => 'Salta al contenuto precedente',

--- a/app/i18n/kr/conf.php
+++ b/app/i18n/kr/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => '<kbd>⇧ Shift</kbd> 키를 누른 상태에선 탐색 단축키가 피드에 적용됩니다.<br/><kbd>Alt ⎇</kbd> 키를 누른 상태에선 탐색 단축키가 카테고리에 적용됩니다.',
 		'navigation_no_mod_help' => '아래 탐색 단축키에는 "Shift"와 "Alt" 키가 적용되지 않습니다.',
 		'next_article' => '다음 글 보기',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => '일반 모드로 전환',
 		'other_action' => '다른 동작',
 		'previous_article' => '이전 글 보기',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Met de <kbd>⇧ Shift</kbd> toets worden navigatieverwijzingen op feeds toegepast.<br/>Met de <kbd>Alt ⎇</kbd> toets worden navigatieverwijzingen op categorieën toegepast.',
 		'navigation_no_mod_help' => 'De volgende navigatiesnelkoppelingen ondersteunen geen toetsencombinaties.',
 		'next_article' => 'Spring naar volgende artikel',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Schakel naar gewoon aanzicht',
 		'other_action' => 'Andere acties',
 		'previous_article' => 'Spring naar vorige artikel',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Amb lo modificador <kbd>⇧ Shift</kbd>, los acorchis de navigacion s’aplican als fluxes.<br/>Amb lo modificador <kbd>Alt ⎇</kbd>, los acorchis de navigacion s’aplican a las categorias.',
 		'navigation_no_mod_help' => 'Los acorchis clavièrs de navigacion son pas compatibles amb los modificadors.',
 		'next_article' => 'Passar a l’article seguent',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Passar a la vista normala',
 		'other_action' => 'Autras accions',
 		'previous_article' => 'Passar a l’article precedent',

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Z wykorzystaniem modyfikatora <kbd>⇧ Shift</kbd> skróty nawigacyjne stosowane są dla kanałów.<br/>Z wykorzystaniem modyfikatora <kbd>Alt ⎇</kbd> skróty nawigacyjne stosowane są dla kategorii.',
 		'navigation_no_mod_help' => 'Pozostałe skróty nawigacyjne nie wspierają modyfikatorów.',
 		'next_article' => 'Otworzenie następnej wiadomości',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Przełączenie na widok normalny',
 		'other_action' => 'Inne akcje',
 		'previous_article' => 'Otworzenie poprzedniej wiadomości',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Com o modificador <kbd>⇧ Shift</kbd>, atalhos de navegação aplicam aos feeds.<br/>Com o <kbd>Alt ⎇</kbd> modificador, atalhos de navegação aplicam as categorias.',
 		'navigation_no_mod_help' => 'Os seguintes atalhos de navegação não suportam modificadores.',
 		'next_article' => 'Pule para o próximo artigo',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Mudar para a visualização normal',
 		'other_action' => 'Outras ações',
 		'previous_article' => 'Pule para o artigo anterior',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'With the <kbd>⇧ Shift</kbd> modifier, navigation shortcuts apply on feeds.<br/>With the <kbd>Alt ⎇</kbd> modifier, navigation shortcuts apply on categories.',	// TODO - Translation
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',	// TODO - Translation
 		'next_article' => 'Skip to the next article',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Switch to normal view',	// TODO - Translation
 		'other_action' => 'Other actions',	// TODO - Translation
 		'previous_article' => 'Skip to the previous article',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => 'Po stlačení skratky s klávesou <kbd>⇧ Shift</kbd>, sa skratky navigácie vzťahujú na kanály.<br/>Po stlačení skratky s klávesou <kbd>Alt ⎇</kbd>, sa skratky navigácie vzťahujú na kategórie.',
 		'navigation_no_mod_help' => 'Tieto skratky navigácie nepodporujú klávesy "Shift" a "Alt".',
 		'next_article' => 'Otvorí ďalší článok',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Prepne do základného zobrazenia',
 		'other_action' => 'Ostatné akcie',
 		'previous_article' => 'Otvorí predošlý článok',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => '<kbd>⇧ Shift</kbd> tuşu ile kısayollar akışlar için geçerli olur.<br/><kbd>Alt ⎇</kbd> tuşu ile kısayollar kategoriler için geçerli olur.',
 		'navigation_no_mod_help' => 'The following navigation shortcuts do not support modifiers.',	// TODO - Translation
 		'next_article' => 'Sonraki makaleye geç',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => 'Switch to normal view',	// TODO - Translation
 		'other_action' => 'Diğer eylemler',
 		'previous_article' => 'Önceki makaleye geç',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -191,6 +191,7 @@ return array(
 		'navigation_help' => '组合 <kbd>⇧ Shift</kbd> 键，浏览快捷键将生效于订阅源。<br/>组合 <kbd>Alt ⎇</kbd> 键，浏览快捷键将生效于分类。',
 		'navigation_no_mod_help' => '以下快捷键不支持组合键（Shift 或 Alt）',
 		'next_article' => '打开下一篇文章',
+		'non_standard' => 'Some keys (<kbd>%s</kbd>) may not work as shortcuts.',	// TODO - Translation
 		'normal_view' => '切换到普通视图',
 		'other_action' => '其他操作',
 		'previous_article' => '打开上一篇文章',

--- a/app/views/configure/shortcut.phtml
+++ b/app/views/configure/shortcut.phtml
@@ -11,9 +11,15 @@
 
 	<?php $s = FreshRSS_Context::$user_conf->shortcuts; ?>
 
+	<legend><?= _t('conf.shortcut') ?></legend>
+	<?php if ([] !== $nonStandard = getNonStandardShortcuts($s)): ?>
+		<p class="alert alert-error">
+			<?= _t('conf.shortcut.non_standard', implode('</kbd>, <kbd>', $nonStandard)) ?>
+		</p>
+	<?php endif; ?>
+
 	<form method="post" action="<?= _url('configure', 'shortcut') ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
-		<legend><?= _t('conf.shortcut') ?></legend>
 
 		<noscript><p class="alert alert-error"><?= _t('conf.shortcut.javascript') ?></p></noscript>
 

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -1,6 +1,6 @@
 <?php
 $mark = FreshRSS_Context::$user_conf->mark_when;
-$s = validateShortcutList(FreshRSS_Context::$user_conf->shortcuts);
+$s = FreshRSS_Context::$user_conf->shortcuts;
 $extData = Minz_ExtensionManager::callHook('js_vars', []);
 echo htmlspecialchars(json_encode(array(
 	'context' => array(

--- a/cli/i18n/ignore/en-us.php
+++ b/cli/i18n/ignore/en-us.php
@@ -288,6 +288,7 @@ return array(
 	'conf.shortcut.navigation_help',
 	'conf.shortcut.navigation_no_mod_help',
 	'conf.shortcut.next_article',
+	'conf.shortcut.non_standard',
 	'conf.shortcut.normal_view',
 	'conf.shortcut.other_action',
 	'conf.shortcut.previous_article',

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -534,32 +534,17 @@ const SHORTCUT_KEYS = [
 			'End', 'Enter', 'Escape', 'Home', 'Insert', 'PageDown', 'PageUp', 'Space', 'Tab',
 		];
 
-function validateShortcutList($shortcuts) {
-	$legacy = array(
-			'down' => 'ArrowDown', 'left' => 'ArrowLeft', 'page_down' => 'PageDown', 'page_up' => 'PageUp',
-			'right' => 'ArrowRight', 'up' => 'ArrowUp',
-		);
-	$upper = null;
-	$shortcuts_ok = array();
+function getNonStandardShortcuts($shortcuts) {
+	$standard = strtolower(implode(' ', SHORTCUT_KEYS));
 
-	foreach ($shortcuts as $key => $value) {
-		if ('' === $value) {
-			$shortcuts_ok[$key] = $value;
-		} elseif (in_array($value, SHORTCUT_KEYS)) {
-			$shortcuts_ok[$key] = $value;
-		} elseif (isset($legacy[$value])) {
-			$shortcuts_ok[$key] = $legacy[$value];
-		} else {	//Case-insensitive search
-			if ($upper === null) {
-				$upper = array_map('strtoupper', SHORTCUT_KEYS);
-			}
-			$i = array_search(strtoupper($value), $upper);
-			if ($i !== false) {
-				$shortcuts_ok[$key] = SHORTCUT_KEYS[$i];
-			}
+	$nonStandard = array_filter($shortcuts, function ($shortcut) use ($standard) {
+		if (false !== strpos($shortcut, ' ')) {
+			return true;
 		}
-	}
-	return $shortcuts_ok;
+		return !preg_match("/${shortcut}/i", $standard);
+	});
+
+	return $nonStandard;
 }
 
 function errorMessage($errorTitle, $error = '') {


### PR DESCRIPTION
Closes #3481

Changes proposed in this pull request:

- Remove shortcut validation

How to test the feature manually:

1. configure a non-standard shortcut key
2. save it to see it stored in the configuration
3. open the feed page and use it

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, only standard shortcuts were supported. When other shortcuts were
configured, they were filtered out.
Now, those shortcuts are stored in the configuration and an alert message
is displayed to alert the user that he is using non-standard shortcuts.