### PR TITLE
Readd sub.feed.auth.configuration i18n key

### DIFF
--- a/app/i18n/cz/sub.php
+++ b/app/i18n/cz/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Pokročilé',
 		'archiving' => 'Archivace',
 		'auth' => array(
+			'configuration' => 'Přihlášení',
 			'help' => 'Umožní přístup k RSS kanálům chráneným HTTP autentizací',
 			'http' => 'HTTP přihlášení',
 			'password' => 'Heslo',

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Erweitert',
 		'archiving' => 'Archivierung',
 		'auth' => array(
+			'configuration' => 'Anmelden',
 			'help' => 'Die Verbindung erlaubt Zugriff auf HTTP-geschützte RSS-Feeds',
 			'http' => 'HTTP-Authentifizierung',
 			'password' => 'HTTP-Passwort',

--- a/app/i18n/en-us/sub.php
+++ b/app/i18n/en-us/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Advanced',
 		'archiving' => 'Archiving',
 		'auth' => array(
+			'configuration' => 'Login',
 			'help' => 'Allows access to HTTP protected RSS feeds',
 			'http' => 'HTTP Authentication',
 			'password' => 'HTTP password',

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Advanced',
 		'archiving' => 'Archiving',
 		'auth' => array(
+			'configuration' => 'Login',
 			'help' => 'Allows access to HTTP protected RSS feeds',
 			'http' => 'HTTP Authentication',
 			'password' => 'HTTP password',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Avanzado',
 		'archiving' => 'Archivo',
 		'auth' => array(
+			'configuration' => 'Identificación',
 			'help' => 'Permitir acceso a fuentes RSS protegidas con HTTP',
 			'http' => 'Identificación HTTP',
 			'password' => 'Contraseña HTTP',

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Avancé',
 		'archiving' => 'Archivage',
 		'auth' => array(
+			'configuration' => 'Identification',
 			'help' => 'La connexion permet d’accéder aux flux protégés par une authentification HTTP.',
 			'http' => 'Authentification HTTP',
 			'password' => 'Mot de passe HTTP',

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'מתקדם',
 		'archiving' => 'ארכוב',
 		'auth' => array(
+			'configuration' => 'כניסה לחשבון',
 			'help' => 'החיבור מתיר לגשת להזנות RSS מוגנות',
 			'http' => 'HTTP אימות',
 			'password' => 'HTTP סיסמה',

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Avanzate',
 		'archiving' => 'Archiviazione',
 		'auth' => array(
+			'configuration' => 'Autenticazione',
 			'help' => 'Accesso per feeds protetti',
 			'http' => 'Autenticazione HTTP',
 			'password' => 'HTTP password',	// TODO - Translation

--- a/app/i18n/kr/sub.php
+++ b/app/i18n/kr/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => '고급 설정',
 		'archiving' => '보관',
 		'auth' => array(
+			'configuration' => '로그인',
 			'help' => 'HTTP 접속이 제한되는 RSS 피드에 접근합니다',
 			'http' => 'HTTP 인증',
 			'password' => 'HTTP 암호',

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Geavanceerd',
 		'archiving' => 'Archiveren',
 		'auth' => array(
+			'configuration' => 'Log in',
 			'help' => 'Verbinding toestaan toegang te krijgen tot HTTP beveiligde RSS-feeds',
 			'http' => 'HTTP Authenticatie',
 			'password' => 'HTTP wachtwoord',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Avançat',
 		'archiving' => 'Archivar',
 		'auth' => array(
+			'configuration' => 'Identificacion',
 			'help' => 'Permet l’accès als fluxes protegits per una autentificacion HTTP',
 			'http' => 'Autentificacion HTTP',
 			'password' => 'Senhal HTTP',

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Zaawansowane',
 		'archiving' => 'Archiwizacja',
 		'auth' => array(
+			'configuration' => 'Uwierzytelnianie',
 			'help' => 'Pozwala na dostęp do kanałów chronionych hasłem HTTP',
 			'http' => 'HTTP Authentication',	// TODO - Translation
 			'password' => 'Hasło HTTP',

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Avançado',
 		'archiving' => 'Arquivar',
 		'auth' => array(
+			'configuration' => 'Entrar',
 			'help' => 'Permite acesso a feeds RSS protegidos por HTTP',
 			'http' => 'Autenticação HTTP',
 			'password' => 'Senha HTTP',

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Advanced',	// TODO - Translation
 		'archiving' => 'Archivage',
 		'auth' => array(
+			'configuration' => 'Login',	// TODO - Translation
 			'help' => 'Connection allows to access HTTP protected RSS feeds',
 			'http' => 'HTTP Authentication',	// TODO - Translation
 			'password' => 'HTTP password',	// TODO - Translation

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Pokročilé',
 		'archiving' => 'Archivovanie',
 		'auth' => array(
+			'configuration' => 'Prihlásenie',
 			'help' => 'Povoliť prístup do kanálov chránených cez HTTP.',
 			'http' => 'Prihlásenie cez HTTP',
 			'password' => 'Heslo pre HTTP',

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => 'Gelişmiş',
 		'archiving' => 'Arşiv',
 		'auth' => array(
+			'configuration' => 'Giriş',
 			'help' => 'HTTP korumalı RSS akışlarına bağlantı izni sağlar',
 			'http' => 'HTTP Kimlik Doğrulama',
 			'password' => 'HTTP şifre',

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -26,6 +26,7 @@ return array(
 		'advanced' => '高级',
 		'archiving' => '归档',
 		'auth' => array(
+			'configuration' => '认证',
 			'help' => '用于连接启用 HTTP 认证的订阅源',
 			'http' => 'HTTP 认证',
 			'password' => 'HTTP 密码',

--- a/cli/i18n/ignore/en-us.php
+++ b/cli/i18n/ignore/en-us.php
@@ -708,6 +708,7 @@ return array(
 	'sub.feed.add',
 	'sub.feed.advanced',
 	'sub.feed.archiving',
+	'sub.feed.auth.configuration',
 	'sub.feed.auth.help',
 	'sub.feed.auth.http',
 	'sub.feed.auth.password',


### PR DESCRIPTION
Changes proposed in this pull request:

Readd sub.feed.auth.configuration i18n key

I thought the key was useless after 2c4f169, but it’s still used on
update feed page.

Reference: https://github.com/FreshRSS/FreshRSS/pull/3516#issuecomment-804306448

How to test the feature manually:

1. Go to "subscription management"
2. Open the update panel for a feed 
3. Check "Login" appears instead of "sub.feed.auth.configuration"

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) N/A
- [x] documentation updated N/A

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
