### PR TITLE
tec: Remove data/do-install.txt

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -44,7 +44,6 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 			$return = 1;
 		}
 		chdir($cwd);
-		deleteInstall();
 		$line = is_array($output) ? implode('; ', $output) : '' . $output;
 		return $return == 0 ? true : 'Git error: ' . $line;
 	}

--- a/app/i18n/cz/install.php
+++ b/app/i18n/cz/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Vyberte jazyk FreshRSS',
 		'defined' => 'Jazyk byl nastaven.',
 	),
-	'not_deleted' => 'Nastala chyba, soubor <em>%s</em> musíte smazat ručně.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'Instalace byla úspěšná.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/de/install.php
+++ b/app/i18n/de/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Wählen Sie eine Sprache für FreshRSS',
 		'defined' => 'Die Sprache wurde festgelegt.',
 	),
-	'not_deleted' => 'Etwas ist schiefgelaufen; Sie müssen die Datei <em>%s</em> manuell löschen.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'Der Installationsvorgang war erfolgreich.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/en-us/install.php
+++ b/app/i18n/en-us/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Choose a language for FreshRSS',
 		'defined' => 'Language has been defined.',
 	),
-	'not_deleted' => 'Something went wrong; you must delete the file <em>%s</em> manually.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'The installation process was successful.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',

--- a/app/i18n/en/install.php
+++ b/app/i18n/en/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Choose a language for FreshRSS',
 		'defined' => 'Language has been defined.',
 	),
-	'not_deleted' => 'Something went wrong; you must delete the file <em>%s</em> manually.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',
 	'ok' => 'The installation process was successful.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',

--- a/app/i18n/es/install.php
+++ b/app/i18n/es/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Selecciona el idioma para FreshRSS',
 		'defined' => 'Idioma seleccionado.',
 	),
-	'not_deleted' => 'Parece que ha habido un error. Debes eliminar el archivo <em>%s</em> de forma manual.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'La instalación se ha completado correctamente.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/fr/install.php
+++ b/app/i18n/fr/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Choisissez la langue pour FreshRSS',
 		'defined' => 'La langue a bien été définie.',
 	),
-	'not_deleted' => 'Quelque chose s’est mal passé, vous devez supprimer le fichier <em>%s</em> à la main.',
+	'missing_applied_migrations' => 'Quelque chose s’est mal passé, vous devriez créer le fichier <em>%s</em> à la main.',
 	'ok' => 'L’installation s’est bien passée.',
 	'session' => array(
 		'nok' => 'Le serveur Web semble mal configué pour les cookies nécessaires aux sessions PHP!',

--- a/app/i18n/he/install.php
+++ b/app/i18n/he/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'בחירת שפה ל FreshRSS',
 		'defined' => 'השפה הוגדרה.',
 	),
-	'not_deleted' => 'משהו נכשל; יש צורך למחוק את הקובץ <em>%s</em> ידנית.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'The installation process was successful.',	// TODO - Translation
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/it/install.php
+++ b/app/i18n/it/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Seleziona la lingua per FreshRSS',
 		'defined' => 'Lingua impostata.',
 	),
-	'not_deleted' => 'Qualcosa non ha funzionato; devi cancellare il file <em>%s</em> manualmente.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'Processo di installazione terminato con successo.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/kr/install.php
+++ b/app/i18n/kr/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'FreshRSS에서 사용할 언어를 고르세요',
 		'defined' => '언어가 설정되었습니다.',
 	),
-	'not_deleted' => '무언가 잘못되었습니다; <em>%s</em> 파일을 직접 삭제해주세요.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => '설치 과정이 성공적으로 끝났습니다.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/nl/install.php
+++ b/app/i18n/nl/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Kies een taal voor FreshRSS',
 		'defined' => 'Taal is bepaald.',
 	),
-	'not_deleted' => 'Er ging iets fout! U moet het bestand <em>%s</em> handmatig verwijderen.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'De installatieprocedure is geslaagd.',
 	'session' => array(
 		'nok' => 'De webserver lijkt niet goed te zijn geconfigureerd voor de cookies die voor PHP-sessies nodig zijn!',

--- a/app/i18n/oc/install.php
+++ b/app/i18n/oc/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Causissètz la lenga per FreshRSS',
 		'defined' => 'La lenga es corrèctament definida.',
 	),
-	'not_deleted' => 'Quicòm a trucat, sembla qu’avètz suprimit <em>%s</em> a la man.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'L’installacion s’es corrèctament passada.',
 	'session' => array(
 		'nok' => 'Sembla que lo servidor web siá pas corrèctament configurat pels cookies per las sessions PHP !',

--- a/app/i18n/pl/install.php
+++ b/app/i18n/pl/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Choose a language for FreshRSS',	// TODO - Translation
 		'defined' => 'Language has been defined.',	// TODO - Translation
 	),
-	'not_deleted' => 'Something went wrong; you must delete the file <em>%s</em> manually.',	// TODO - Translation
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'The installation process was successful.',	// TODO - Translation
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/pt-br/install.php
+++ b/app/i18n/pt-br/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Escolha o idioma para o FreshRSS',
 		'defined' => 'O idioma foi definido.',
 	),
-	'not_deleted' => 'Algo deu errado; você deve deletar o arquivo <em>%s</em> manualmente.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'O processo de instalação foi um sucesso.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/ru/install.php
+++ b/app/i18n/ru/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Выберите язык для FreshRSS',
 		'defined' => 'Язык выбран.',
 	),
-	'not_deleted' => 'Что-то пошло не так; удалите файл <em>%s</em> вручную.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'Установка успешна.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/sk/install.php
+++ b/app/i18n/sk/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'Vyberte jazyk pre FreshRSS',
 		'defined' => 'Jazyk bol nastavený.',
 	),
-	'not_deleted' => 'Niečo sa nepodarilo. Musíte ručne zmazať súbor <em>%s</em>.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'Inštalácia bola úspešná.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/tr/install.php
+++ b/app/i18n/tr/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => 'FreshRSS için bir dil seçin',
 		'defined' => 'Dil belirlendi.',
 	),
-	'not_deleted' => 'Hata meydana geldi; <em>%s</em> dosyasını elle silmelisiniz.',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => 'Kurulum başarıyla tamamlandı.',
 	'session' => array(
 		'nok' => 'The web server seems to be incorrectly configured for cookies required for PHP sessions!',	// TODO - Translation

--- a/app/i18n/zh-cn/install.php
+++ b/app/i18n/zh-cn/install.php
@@ -111,7 +111,7 @@ return array(
 		'choose' => '为 FreshRSS 选择语言',
 		'defined' => '语言已指定',
 	),
-	'not_deleted' => '出现错误，你必须手动删除文件 <em>%s</em>',
+	'missing_applied_migrations' => 'Something went wrong; you should create an empty file <em>%s</em> manually.',	// TODO - Translation
 	'ok' => '安装成功',
 	'session' => array(
 		'nok' => 'Web 服务器似乎未正确配置 PHP 会话所需的 cookie！',

--- a/app/install.php
+++ b/app/install.php
@@ -611,7 +611,10 @@ function printStep4() {
 
 function printStep5() {
 ?>
-	<p class="alert alert-error"><span class="alert-head"><?= _t('gen.short.damn') ?></span> <?= _t('install.not_deleted', DATA_PATH . '/do-install.txt') ?></p>
+	<p class="alert alert-error">
+		<span class="alert-head"><?= _t('gen.short.damn') ?></span>
+		<?= _t('install.missing_applied_migrations', DATA_PATH . '/applied_migrations.txt') ?>
+	</p>
 <?php
 }
 
@@ -636,7 +639,7 @@ case 3:
 case 4:
 	break;
 case 5:
-	if (setupMigrations() && deleteInstall()) {
+	if (setupMigrations()) {
 		header('Location: index.php');
 	}
 	break;

--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -2,7 +2,7 @@
 <?php
 require(__DIR__ . '/_cli.php');
 
-if (!file_exists(DATA_PATH . '/do-install.txt')) {
+if (file_exists(DATA_PATH . '/applied_migrations.txt')) {
 	fail('FreshRSS seems to be already installed!' . "\n" . 'Please use `./cli/reconfigure.php` instead.', EXIT_CODE_ALREADY_EXISTS);
 }
 
@@ -114,10 +114,6 @@ accessRights();
 
 if (!setupMigrations()) {
 	fail('FreshRSS access right problem while creating migrations version file!');
-}
-
-if (!deleteInstall()) {
-	fail('FreshRSS access right problem while deleting install file!');
 }
 
 done();

--- a/cli/i18n/ignore/en-us.php
+++ b/cli/i18n/ignore/en-us.php
@@ -684,7 +684,6 @@ return array(
 	'install.language._',
 	'install.language.choose',
 	'install.language.defined',
-	'install.not_deleted',
 	'install.ok',
 	'install.session.nok',
 	'install.step',

--- a/cli/prepare.php
+++ b/cli/prepare.php
@@ -23,10 +23,6 @@ foreach ($dirs as $dir) {
 	$ok &= touch(DATA_PATH . $dir . '/index.html');
 }
 
-if (!is_file(DATA_PATH . '/config.php')) {
-	$ok &= touch(DATA_PATH . '/do-install.txt');
-}
-
 file_put_contents(DATA_PATH . '/.htaccess',
 "# Apache 2.2\n" .
 "<IfModule !mod_authz_core.c>\n" .

--- a/docs/en/admins/04_Updating.md
+++ b/docs/en/admins/04_Updating.md
@@ -23,9 +23,8 @@ Generally, the update procedure via git works as follows:
 3. Perform a hard reset to discard local changes.
 4. Delete manual additions. Be sure to move your backup out of the directory before doing this step!
 5. Pull the new version.
-6. Remove `./data/do-install.txt`.
-7. Re-set group read (and write, if you wish) permissions on all files in `.`, and group write permissions on `./data/`.
+6. Re-set group read (and write, if you wish) permissions on all files in `.`, and group write permissions on `./data/`.
 
 ## Updating from a Zip Archive
 
-Updating to a new version from a zip archive is always an option. Begin by unzipping the archive into your FreshRSS directory, overwriting old files, remove `./data/do-install.txt`, and finally re-set group read (and write, if you wish) permissions on all files in `.` and group write permissions on `./data/`.
+Updating to a new version from a zip archive is always an option. Begin by unzipping the archive into your FreshRSS directory, overwriting old files, and finally re-set group read (and write, if you wish) permissions on all files in `.` and group write permissions on `./data/`.

--- a/docs/en/admins/07_LinuxUpdate.md
+++ b/docs/en/admins/07_LinuxUpdate.md
@@ -65,13 +65,7 @@ git status
 
 The command should tell you the tag that you're using. It must be the same as the one associated with [the latest release on GitHub](https://github.com/FreshRSS/FreshRSS/releases/latest). If you use the rolling release, it should tell you that your `edge` branch is up to date with `origin`.
 
-6. Delete the file that triggers the install wizard
-
-```sh
-rm data/do-install.txt
-```
-
-7. Re-set correct permissions so that your web server can access the files
+6. Re-set correct permissions so that your web server can access the files
 
 ```sh
 chown -R :www-data . && chmod -R g+r . && chmod -R g+w ./data/
@@ -112,6 +106,5 @@ chown -R :www-data . && chmod -R g+r . && chmod -R g+w ./data/
 
 ```sh
 rm -f freshrss.zip
-rm -f data/do-install.txt
 rm -rf FreshRSS-*/
 ```

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -113,12 +113,6 @@ function initDb() {
 	return $databaseDAO->testConnection();
 }
 
-function deleteInstall() {
-	$path = join_path(DATA_PATH, 'do-install.txt');
-	@unlink($path);
-	return !file_exists($path);
-}
-
 function setupMigrations() {
 	$migrations_path = APP_PATH . '/migrations';
 	$migrations_version_path = DATA_PATH . '/applied_migrations.txt';

--- a/p/i/index.php
+++ b/p/i/index.php
@@ -23,7 +23,10 @@
 require(__DIR__ . '/../../constants.php');
 require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader
 
-if (file_exists(DATA_PATH . '/do-install.txt')) {
+$migrations_path = APP_PATH . '/migrations';
+$applied_migrations_path = DATA_PATH . '/applied_migrations.txt';
+
+if (!file_exists($applied_migrations_path)) {
 	require(APP_PATH . '/install.php');
 } else {
 	session_cache_limiter('');
@@ -41,22 +44,6 @@ if (file_exists(DATA_PATH . '/do-install.txt')) {
 			exit();	//No need to send anything
 		}
 	}
-
-	$migrations_path = APP_PATH . '/migrations';
-	$applied_migrations_path = DATA_PATH . '/applied_migrations.txt';
-
-	// The next line is temporary: the migrate method expects the applied_migrations.txt
-	// file to exist. This is because the install script creates this file, so
-	// if it is missing, it means the application is not installed. But we
-	// should also take care of applications installed before the new
-	// migrations system (<=1.16). Indeed, they are installed but the migrations
-	// version file doesn't exist. So for now (1.17), we continue to check if the
-	// application is installed with the do-install.txt file: if yes, we create
-	// the version file. Starting from version 1.18, all the installed systems
-	// will have the file and so we will be able to remove this temporary line
-	// and stop using the do-install.txt file to check if FRSS is already
-	// installed.
-	touch($applied_migrations_path);
 
 	$error = false;
 	try {


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove file data/do-install.txt and its references
- Remove deleteInstall() method
- Change install process to start it if data/applied_migrations.txt is missing
- Update documentation to remove the step asking to delete data/do-install.txt

How to test the feature manually:

1. git pull new code
2. check data/do-install.txt is still missing
3. check FRSS doesn't offer to be reinstalled, even after `touch data/do-install.txt`
4. remove data/applied_migrations.txt
5. check FRSS offers to be reinstalled
6. run `rm data/do-install.txt` and `touch data/applied_migrations.txt` to be in initial state

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) N/A
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
