### PR TITLE
Support standard HTTP 410 Gone

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -349,6 +349,11 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 			} catch (FreshRSS_Feed_Exception $e) {
 				Minz_Log::warning($e->getMessage());
 				$feedDAO->updateLastUpdate($feed->id(), true);
+				if ($e->getCode() === 410) {
+					// HTTP 410 Gone
+					Minz_Log::warning('Muting gone feed: ' . $feed->url(false));
+					$feedDAO->mute($feed->id(), true);
+				}
 				$feed->unlock();
 				continue;
 			}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -287,7 +287,8 @@ class FreshRSS_Feed extends Minz_Model {
 				if ((!$mtime) || $simplePie->error()) {
 					$errorMessage = $simplePie->error();
 					throw new FreshRSS_Feed_Exception(
-						($errorMessage == '' ? 'Unknown error for feed' : $errorMessage) . ' [' . $this->url . ']'
+						($errorMessage == '' ? 'Unknown error for feed' : $errorMessage) . ' [' . $this->url . ']',
+						$simplePie->status_code()
 					);
 				}
 

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -192,6 +192,11 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		}
 	}
 
+	public function mute($id, $value = true) {
+		$sql = 'UPDATE `_feed` SET ttl=' . ($value ? '-' : '') . 'ABS(ttl) WHERE id=' . intval($id);
+		return $this->pdo->exec($sql);
+	}
+
 	public function changeCategory($idOldCat, $idNewCat) {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
 		$newCat = $catDAO->searchById($idNewCat);

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -431,6 +431,13 @@ class SimplePie
 	public $error;
 
 	/**
+	 * @var int HTTP status code
+	 * @see SimplePie::status_code()
+	 * @access private
+	 */
+	public $status_code;
+
+	/**
 	 * @var object Instance of SimplePie_Sanitize (or other class)
 	 * @see SimplePie::set_sanitize_class()
 	 * @access private
@@ -1677,6 +1684,7 @@ class SimplePie
 					}
 
 					$file = $this->registry->create('File', array($this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options, $this->syslog_enabled));
+					$this->status_code = $file->status_code;
 
 					if ($file->success)
 					{
@@ -1733,6 +1741,8 @@ class SimplePie
 				$file = $this->registry->create('File', array($this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options, $this->syslog_enabled));
 			}
 		}
+		$this->status_code = $file->status_code;
+
 		// If the file connection has an error, set SimplePie::error to that and quit
 		if (!$file->success && !($file->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($file->status_code === 200 || $file->status_code > 206 && $file->status_code < 300)))
 		{
@@ -1840,6 +1850,16 @@ class SimplePie
 	public function error()
 	{
 		return $this->error;
+	}
+
+	/**
+	 * Get the last HTTP status code
+	 *
+	 * @return int Status code
+	 */
+	public function status_code()
+	{
+		return $this->status_code;
 	}
 
 	/**

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -123,6 +123,7 @@ class SimplePie_File
 					curl_setopt($fp, CURLOPT_ENCODING, 'none');
 					$this->headers = curl_exec($fp);
 				}
+				$this->status_code = curl_getinfo($fp, CURLINFO_HTTP_CODE);
 				if (curl_errno($fp))
 				{
 					$this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp);


### PR DESCRIPTION
When a feed returns an HTTP 410 Gone, mute the corresponding feed, i.e. stop refreshing it.
Example of such feed, Les Décodeurs (Libération) https://rss.liberation.fr/rss/100893/
