### PR TITLE
Friendly syntax for Intellisense

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -20,44 +20,38 @@ define('CORE_EXTENSIONS_PATH', LIB_PATH . '/core-extensions');
 define('TESTS_PATH', FRESHRSS_PATH . '/tests');
 //</Not customisable>
 
-function safe_define($name, $value) {
-	if (!defined($name)) {
-		return define($name, $value);
-	}
-}
-
 if (file_exists(__DIR__ . '/constants.local.php')) {
 	//Include custom / local settings:
 	include(__DIR__ . '/constants.local.php');
 }
 
-safe_define('FRESHRSS_USERAGENT', 'FreshRSS/' . FRESHRSS_VERSION . ' (' . PHP_OS . '; ' . FRESHRSS_WEBSITE . ')');
+defined('FRESHRSS_USERAGENT') or define('FRESHRSS_USERAGENT', 'FreshRSS/' . FRESHRSS_VERSION . ' (' . PHP_OS . '; ' . FRESHRSS_WEBSITE . ')');
 
 // PHP text output compression http://php.net/ob_gzhandler (better to do it at Web server level)
-safe_define('PHP_COMPRESSION', false);
+defined('PHP_COMPRESSION') or define('PHP_COMPRESSION', false);
 
-safe_define('COPY_LOG_TO_SYSLOG', filter_var(getenv('COPY_LOG_TO_SYSLOG'), FILTER_VALIDATE_BOOLEAN));
+defined('COPY_LOG_TO_SYSLOG') or define('COPY_LOG_TO_SYSLOG', filter_var(getenv('COPY_LOG_TO_SYSLOG'), FILTER_VALIDATE_BOOLEAN));
 // For cases when syslog is not available
-safe_define('COPY_SYSLOG_TO_STDERR', filter_var(getenv('COPY_SYSLOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
+defined('COPY_SYSLOG_TO_STDERR') or define('COPY_SYSLOG_TO_STDERR', filter_var(getenv('COPY_SYSLOG_TO_STDERR'), FILTER_VALIDATE_BOOLEAN));
 
 // Maximum log file size in Bytes, before it will be divided by two
-safe_define('MAX_LOG_SIZE', 1048576);
+defined('MAX_LOG_SIZE') or define('MAX_LOG_SIZE', 1048576);
 
 //This directory must be writable
-safe_define('DATA_PATH', FRESHRSS_PATH . '/data');
+defined('DATA_PATH') or define('DATA_PATH', FRESHRSS_PATH . '/data');
 
-safe_define('UPDATE_FILENAME', DATA_PATH . '/update.php');
-safe_define('USERS_PATH', DATA_PATH . '/users');
-safe_define('ADMIN_LOG', USERS_PATH . '/_/log.txt');
-safe_define('API_LOG', USERS_PATH . '/_/log_api.txt');
-safe_define('CACHE_PATH', DATA_PATH . '/cache');
-safe_define('PSHB_LOG', USERS_PATH . '/_/log_pshb.txt');
-safe_define('PSHB_PATH', DATA_PATH . '/PubSubHubbub');
-safe_define('EXTENSIONS_DATA', DATA_PATH . '/extensions-data');
-safe_define('THIRDPARTY_EXTENSIONS_PATH', FRESHRSS_PATH . '/extensions');
+defined('UPDATE_FILENAME') or define('UPDATE_FILENAME', DATA_PATH . '/update.php');
+defined('USERS_PATH') or define('USERS_PATH', DATA_PATH . '/users');
+defined('ADMIN_LOG') or define('ADMIN_LOG', USERS_PATH . '/_/log.txt');
+defined('API_LOG') or define('API_LOG', USERS_PATH . '/_/log_api.txt');
+defined('CACHE_PATH') or define('CACHE_PATH', DATA_PATH . '/cache');
+defined('PSHB_LOG') or define('PSHB_LOG', USERS_PATH . '/_/log_pshb.txt');
+defined('PSHB_PATH') or define('PSHB_PATH', DATA_PATH . '/PubSubHubbub');
+defined('EXTENSIONS_DATA') or define('EXTENSIONS_DATA', DATA_PATH . '/extensions-data');
+defined('THIRDPARTY_EXTENSIONS_PATH') or define('THIRDPARTY_EXTENSIONS_PATH', FRESHRSS_PATH . '/extensions');
 
 //Deprecated constants
-safe_define('EXTENSIONS_PATH', FRESHRSS_PATH . '/extensions');
+defined('EXTENSIONS_PATH') or define('EXTENSIONS_PATH', FRESHRSS_PATH . '/extensions');
 
 //Directory used for feed mutex with *.freshrss.lock files. Must be writable.
-safe_define('TMP_PATH', sys_get_temp_dir());
+defined('TMP_PATH') or define('TMP_PATH', sys_get_temp_dir());


### PR DESCRIPTION
Dynamic code declaration is not well detected, especially for constants, so change to more standard syntax, which is correctly detected by Intellisense / Intelephense.

Furthermore, this custom `safe_define()` function has been confusing for some users, e.g. https://github.com/FreshRSS/FreshRSS/issues/2723#issuecomment-753318513

Before the fix:
![image](https://user-images.githubusercontent.com/1008324/114064551-0e770a00-989a-11eb-8079-33f445505b29.png)
