### PR TITLE
Fix wrong SimplePie type hint

### DIFF
--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -1622,7 +1622,7 @@ class SimplePie
 	 * Fetch the data via SimplePie_File
 	 *
 	 * If the data is already cached, attempt to fetch it from there instead
-	 * @param SimplePie_Cache|false $cache Cache handler, or false to not load from the cache
+	 * @param SimplePie_Cache_Base|false $cache Cache handler, or false to not load from the cache
 	 * @return array|true Returns true if the data was loaded from the cache, or an array of HTTP headers and sniffed type
 	 */
 	protected function fetch_data(&$cache)


### PR DESCRIPTION
`SimplePie_Cache` also exists but is something else.
This created errors in IDE.

![image](https://user-images.githubusercontent.com/1008324/114066947-8a725180-989c-11eb-8192-84ddf70a207d.png)
