### PR TITLE
Minz provide action name in controller exception

### DIFF
--- a/lib/Minz/ActionException.php
+++ b/lib/Minz/ActionException.php
@@ -1,7 +1,10 @@
 <?php
 class Minz_ActionException extends Minz_Exception {
 	public function __construct ($controller_name, $action_name, $code = self::ERROR) {
-		$message = 'Invalid action name for controller ' . $controller_name;
+		// Just for security, as we are not supposed to get non-alphanumeric characters.
+		$action_name = rawurlencode($action_name);
+
+		$message = "Invalid action name “${action_name}” for controller “${controller_name}”.";
 		parent::__construct ($message, $code);
 	}
 }


### PR DESCRIPTION
Re-introduce a (safe) action name in the error message in case of wrong controller call to ease debugging.
Contributes to https://github.com/FreshRSS/FreshRSS/issues/3584
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/2157
