### PR TITLE
Add system configuration for extension

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -300,6 +300,9 @@ The `Minz_Extension` abstract class defines another set of methods that should n
 * the `registerViews` method registers the extension views in FreshRSS.
 * the `registerTranslates` method registers the extension translation files in FreshRSS.
 * the `registerHook` method registers hook actions in different part of the application.
+* the `getSystemConfiguration` method retrieves the extension configuration for the system.
+* the `setSystemConfiguration` method stores the extension configuration for the system.
+* the `removeSystemConfiguration` method removes the extension configuration for the system.
 * the `getUserConfiguration` method retrieves the extension configuration for the current user.
 * the `setUserConfiguration` method stores the extension configuration for the current user.
 * the `removeUserConfiguration` method removes the extension configuration for the current user.


### PR DESCRIPTION
Changes proposed in this pull request:

- Add system configuration support in extension

How to test the feature manually:

1. In an extension code, create, update or delete system configuration.
2. Check in the configuration file that all actions on step 1 are executed.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, only the user configuration was supported by extensions. But it was
limiting if one has to create a system extension with configuration.
Now, both user and system configuration are supported.
