### PR TITLE
Introduced $noredirect in actualizeAction()

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -547,7 +547,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		$url = Minz_Request::param('url');
 		$force = Minz_Request::param('force');
 		$maxFeeds = (int)Minz_Request::param('maxFeeds');
-		$noredirect = (bool)Minz_Request::param('noredirect') ==1;
+		$noredirect = Minz_Request::paramBoolean('noredirect');
 		$noCommit = Minz_Request::fetchPOST('noCommit', 0) == 1;
 
 		if ($id == -1 && !$noCommit) {	//Special request only to commit & refresh DB cache

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -547,6 +547,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		$url = Minz_Request::param('url');
 		$force = Minz_Request::param('force');
 		$maxFeeds = (int)Minz_Request::param('maxFeeds');
+		$noredirect = (bool)Minz_Request::param('noredirect') ==1;
 		$noCommit = Minz_Request::fetchPOST('noCommit', 0) == 1;
 
 		if ($id == -1 && !$noCommit) {	//Special request only to commit & refresh DB cache
@@ -571,6 +572,15 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 			Minz_Request::setGoodNotification(_t('feedback.sub.feed.actualizeds'));
 			// No layout in ajax request.
 			$this->view->_layout(false);
+		} if ($noredirect) {
+			if ($updated_feeds === 1) {
+				echo(_t('feedback.sub.feed.actualized', $feed->name()));
+			} elseif ($updated_feeds > 1) {
+				echo(_t('feedback.sub.feed.n_actualized', $updated_feeds));
+			} else {
+				echo(_t('feedback.sub.feed.no_refresh'));
+			}	
+			exit(0);
 		} else {
 			// Redirect to the main page with correct notification.
 			if ($updated_feeds === 1) {

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -579,7 +579,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				echo(_t('feedback.sub.feed.n_actualized', $updated_feeds));
 			} else {
 				echo(_t('feedback.sub.feed.no_refresh'));
-			}	
+			}
 			exit(0);
 		} else {
 			// Redirect to the main page with correct notification.


### PR DESCRIPTION
Changes proposed in this pull request:

Introduced the variable $noredirect
If set to 1 no redirect will happen after actualizeAction()

How to test the feature manually:

1. go to https://Freshrss.example.com/p/i/?c=feed&a=actualize&user=user&token=token&noredirect=1
2. No redirect happen after the fetch of the feeds

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

I will update the Documention if this change make sense to the team
