### PR TITLE
Change links to add feeds

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -116,7 +116,7 @@ $today = @strtotime('today');
 ?>
 <div id="stream" class="prompt alert alert-warn normal">
 	<h2><?= _t('index.feed.empty') ?></h2>
-	<a href="<?= _url('subscription', 'index') ?>"><?= _t('index.feed.add') ?></a><br /><br />
+	<a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a><br /><br />
 </div>
 <?php endif; ?>
 

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -82,6 +82,6 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 ?>
 <div id="stream" class="prompt alert alert-warn reader">
 	<h2><?= _t('index.feed.empty') ?></h2>
-	<a href="<?= _url('subscription', 'index') ?>"><?= _t('index.feed.add') ?></a><br /><br />
+	<a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a><br /><br />
 </div>
 <?php endif; ?>


### PR DESCRIPTION
Closes #3642

Changes proposed in this pull request:

- Fix links to add feeds when hitting an empty page

How to test the feature manually:

1. Make a search with no result to get an empty page
2. Click the link to add some feeds
3. Validate that you are redirected to the add feed form

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, the links was redirecting to the subscription management page which
was the default behavior before changes introduced in 1.17.0 (#3027). All
links were modified except the one for empty content.
Now, the empty content links are redirecting to the proper page.
