### PR TITLE
Fix navigation JS error

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1093,7 +1093,7 @@ function init_nav_entries() {
 				return false;
 			};
 		nav_entries.querySelector('.up').onclick = function (e) {
-				const active_item = document.querySelector('.flux.current'),
+				const active_item = (document.querySelector('.flux.current') || document.querySelector('.flux')),
 					windowTop = document.scrollingElement.scrollTop,
 					item_top = active_item.offsetParent.offsetTop + active_item.offsetTop;
 


### PR DESCRIPTION
Closes #3654

Changes proposed in this pull request:

- Fix navigation error when no article is selected

How to test the feature manually:

1. Display articles without selecting one
2. Use the up navigation button
3. Check that it does not generate an error in the console

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, the UP navigation button was generating an error when no article was
selected. The process to navigate to the first element was using the position
of the current element to compute the offset, thus generating said error.
Now, if no article is selected, the first article is used as a fall-back.
