### PR TITLE
Fix user creation form redirection

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -287,25 +287,29 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 			$new_user_name = Minz_Request::param('new_user_name');
 			$email = Minz_Request::param('new_user_email', '');
 			$passwordPlain = Minz_Request::param('new_user_passwordPlain', '', true);
+			$badRedirectUrl = [
+				'c' => Minz_Request::param('originController', 'auth'),
+				'a' => Minz_Request::param('originAction', 'register'),
+			];
 
 			if (!self::checkUsername($new_user_name)) {
 				Minz_Request::bad(
 					_t('user.username.invalid'),
-					array('c' => 'auth', 'a' => 'register')
+					$badRedirectUrl
 				);
 			}
 
 			if (FreshRSS_UserDAO::exists($new_user_name)) {
 				Minz_Request::bad(
 					_t('user.username.taken', $new_user_name),
-					array('c' => 'auth', 'a' => 'register')
+					$badRedirectUrl
 				);
 			}
 
 			if (!FreshRSS_password_Util::check($passwordPlain)) {
 				Minz_Request::bad(
 					_t('user.password.invalid'),
-					array('c' => 'auth', 'a' => 'register')
+					$badRedirectUrl
 				);
 			}
 
@@ -315,21 +319,21 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 			if ($system_conf->force_email_validation && empty($email)) {
 				Minz_Request::bad(
 					_t('user.email.feedback.required'),
-					array('c' => 'auth', 'a' => 'register')
+					$badRedirectUrl
 				);
 			}
 
 			if (!empty($email) && !validateEmailAddress($email)) {
 				Minz_Request::bad(
 					_t('user.email.feedback.invalid'),
-					array('c' => 'auth', 'a' => 'register')
+					$badRedirectUrl
 				);
 			}
 
 			if ($tos_enabled && !$accept_tos) {
 				Minz_Request::bad(
 					_t('user.tos.feedback.invalid'),
-					array('c' => 'auth', 'a' => 'register')
+					$badRedirectUrl
 				);
 			}
 

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -5,6 +5,9 @@
 
 	<form method="post" action="<?= _url('user', 'create') ?>" autocomplete="off">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+		<input type="hidden" name="originController" value="<?= Minz_Request::controllerName() ?>" />
+		<input type="hidden" name="originAction" value="<?= Minz_Request::actionName() ?>" />
+
 		<legend><?= _t('admin.user.create') ?></legend>
 
 		<div class="form-group">


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix user creation form redirection

How to test the feature manually:

1. Try to create a user without a password from the user page.
2. Check there is an error displayed and you're still on the user management page.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, when there was an error during the user creation process, the user was
always redirected to the same page no matter where the creation process was
initiated (registration or creation by an admin). Thus, there were no error
messages displayed when something went bad during the creation process by an
admin.
Now, the origin of the user creation has been added to the form to be able to
redirect the user to the proper page.
