### PR TITLE
Drop PHP5 and IE11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
         - COMPOSER_BIN=$(composer global config --absolute bin-dir)
         - $COMPOSER_BIN/phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests
         - $COMPOSER_BIN/phpcs . -p -s
-    - name: "PHP 5.6 Syntax"
-      php: "5.6"
+    - name: "PHP 7.0 Syntax"
+      php: "7.0"
       script:
         - phpenv rehash
         - find . -name \*.php -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null 2>php-l-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 2021-XX-XX FreshRSS 1.18.2-dev
 
 * Compatibility
-	* Require PHP 7.0+ (drop support for PHP 5.x)
-	* Drop support for Microsoft Internet Explorer (IE11)
+	* Require PHP 7.0+ (drop support for PHP 5.x) [#3666](https://github.com/FreshRSS/FreshRSS/pull/3666)
+	* Drop support for Microsoft Internet Explorer (IE11) [#3666](https://github.com/FreshRSS/FreshRSS/pull/3666)
 
 
 ## 2021-06-06 FreshRSS 1.18.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Compatibility
 	* Require PHP 7.0+ (drop support for PHP 5.x) [#3666](https://github.com/FreshRSS/FreshRSS/pull/3666)
 	* Drop support for Microsoft Internet Explorer (IE11) [#3666](https://github.com/FreshRSS/FreshRSS/pull/3666)
+* Deployment
+	* The Docker development image `:oldest` is now based on `alpine:3.5` with PHP 7.0.33 and Apache 2.4.35 [#3666](https://github.com/FreshRSS/FreshRSS/pull/3666)
 
 
 ## 2021-06-06 FreshRSS 1.18.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2021-XX-XX FreshRSS 1.18.2-dev
 
+* Compatibility
+	* Require PHP 7.0+ (drop support for PHP 5.x)
+	* Drop support for Microsoft Internet Explorer (IE11)
 
 
 ## 2021-06-06 FreshRSS 1.18.1

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -1,12 +1,12 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV TZ UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
-	apache2 php5-apache2 \
-	php5 php5-curl php5-gmp php5-intl php5-xml php5-zip \
-	php5-ctype php5-dom php5-iconv php5-json php5-opcache php5-openssl php5-phar php5-xmlreader php5-zlib \
-	php5-pdo_sqlite php5-pdo_mysql php5-pdo_pgsql
+	apache2 php7-apache2 \
+	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
+	php7-ctype php7-dom php7-iconv php7-json php7-opcache php7-openssl php7-phar php7-session php7-xmlreader php7-zlib \
+	php7-pdo_sqlite php7-pdo_mysql php7-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -38,6 +38,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		/etc/apache2/httpd.conf && \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf && \
+	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php7 /usr/bin/php; else true; fi && \
 	touch /var/www/FreshRSS/Docker/env.txt && \
 	echo "27,57 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su apache -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \

--- a/README.fr.md
+++ b/README.fr.md
@@ -42,12 +42,12 @@ FreshRSS n’est fourni avec aucune garantie.
 
 # Prérequis
 
-* Un navigateur Web récent tel que Firefox / IceCat, Internet Explorer 11 / Edge (sauf certains détails), Chromium / Chrome, Opera, Safari.
+* Un navigateur Web récent tel que Firefox / IceCat, Edge, Chromium / Chrome, Opera, Safari.
 	* Fonctionne aussi sur mobile (sauf certaines fonctionnalités)
 * Serveur modeste, par exemple sous Linux ou Windows
 	* Fonctionne même sur un Raspberry Pi 1 avec des temps de réponse < 1s (testé sur 150 flux, 22k articles)
 * Serveur Web Apache2 (recommandé), ou nginx, lighttpd (non testé sur les autres)
-* PHP 5.6+ (PHP 7+ recommandé pour de meilleures performances)
+* PHP 7.0+
 	* Requis : [cURL](https://www.php.net/curl), [DOM](https://www.php.net/dom), [JSON](https://www.php.net/json), [XML](https://www.php.net/xml), [session](https://www.php.net/session), [ctype](https://www.php.net/ctype), et [PDO_MySQL](https://www.php.net/pdo-mysql) ou [PDO_SQLite](https://www.php.net/pdo-sqlite) ou [PDO_PGSQL](https://www.php.net/pdo-pgsql)
 	* Recommandés : [GMP](https://www.php.net/gmp) (pour accès API sur plateformes < 64 bits), [IDN](https://www.php.net/intl.idn) (pour les noms de domaines internationalisés), [mbstring](https://www.php.net/mbstring) (pour le texte Unicode), [iconv](https://www.php.net/iconv) (pour conversion d’encodages), [ZIP](https://www.php.net/zip) (pour import/export), [zlib](https://www.php.net/zlib) (pour les flux compressés)
 * MySQL 5.5.3+ ou équivalent MariaDB, ou SQLite 3.7.4+, ou PostgreSQL 9.5+

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ FreshRSS comes with absolutely no warranty.
 * Light server running Linux or Windows
 	* It even works on Raspberry Pi 1 with response time under a second (tested with 150 feeds, 22k articles)
 * A web server: Apache2 (recommended), nginx, lighttpd (not tested on others)
-* PHP 5.6+ (PHP 7+ recommended for higher performance)
+* PHP 7.0+
 	* Required extensions: [cURL](https://www.php.net/curl), [DOM](https://www.php.net/dom), [JSON](https://www.php.net/json), [XML](https://www.php.net/xml), [session](https://www.php.net/session), [ctype](https://www.php.net/ctype), and [PDO_MySQL](https://www.php.net/pdo-mysql) or [PDO_SQLite](https://www.php.net/pdo-sqlite) or [PDO_PGSQL](https://www.php.net/pdo-pgsql)
 	* Recommended extensions: [GMP](https://www.php.net/gmp) (for API access on 32-bit platforms), [IDN](https://www.php.net/intl.idn) (for Internationalized Domain Names), [mbstring](https://www.php.net/mbstring) (for Unicode strings), [iconv](https://www.php.net/iconv) (for charset conversion), [ZIP](https://www.php.net/zip) (for import/export), [zlib](https://www.php.net/zlib) (for compressed feeds)
 * MySQL 5.5.3+ or MariaDB equivalent, or SQLite 3.7.4+, or PostgreSQL 9.5+

--- a/constants.php
+++ b/constants.php
@@ -2,7 +2,7 @@
 //NB: Do not edit; use ./constants.local.php instead.
 
 //<Not customisable>
-define('FRESHRSS_MIN_PHP_VERSION', '5.6.0');
+define('FRESHRSS_MIN_PHP_VERSION', '7.0.0');
 define('FRESHRSS_VERSION', '1.18.2-dev');
 define('FRESHRSS_WEBSITE', 'https://freshrss.org');
 define('FRESHRSS_WIKI', 'https://freshrss.github.io/FreshRSS/');

--- a/docs/en/admins/02_Prerequisites.md
+++ b/docs/en/admins/02_Prerequisites.md
@@ -7,10 +7,10 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 | Software      | Recommended             | Also Works With         |
 | ------------- | ----------------------- | ----------------------- |
 | Web server    | **Apache 2**            | Nginx, lighttpd         |
-| PHP           | **PHP 7+**              | PHP 5.6+                |
+| PHP           | **PHP 7+**              |                         |
 | PHP modules   | Required: libxml, cURL, JSON, PDO\_MySQL, PCRE and ctype. <br>Required (32-bit only): GMP <br> Recommanded: Zlib, mbstring, iconv, ZipArchive <br> *For the whole modules list see [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/Dockerfile-Alpine#L7-L9)* | |
 | Database      | **MySQL 5.5.3+**        | SQLite 3.7.4+, PostgreSQL 9.5+          |
-| Browser       | **Firefox**             | Chrome, Opera, Safari, or IE11/Edge[^1] |
+| Browser       | **Firefox**             | Chrome, Opera, Safari, or Edge          |
 
 
 # Getting the appropriate version of FreshRSS
@@ -36,5 +36,3 @@ As its name suggests, the development version is the working codebase, intended 
 If you want to keep track of the most recent enhancements or help the developers with bug reports, this is the branch for you. If you use this version, please keep in mind that you need to follow the branch activity on Github (via [the branch RSS feed](https://github.com/FreshRSS/FreshRSS/commits/edge.atom), for instance), and manually pull new commits.
 
 Some say that the main developers use this branch on a daily basis without problem. They may know what they are doing…
-
-[^1]: IE11/Edge may not support all features found in FreshRSS on other browsers

--- a/docs/fr/users/01_Installation.md
+++ b/docs/fr/users/01_Installation.md
@@ -7,10 +7,10 @@ Il est toutefois de votre responsabilité de vérifier que votre hébergement pe
  | Logiciel         | Recommandé                                                                                                     | Fonctionne aussi avec          |
  | --------         | -----------                                                                                                    | ---------------------          |
  | Serveur web      | **Apache 2**                                                                                                   | Nginx                          |
- | PHP              | **PHP 7+**                                                                                                     | PHP 5.6+                       |
+ | PHP              | **PHP 7+**                                                                                                     |                                |
  | Modules PHP      | Requis : libxml, cURL, JSON, PDO_MySQL, PCRE et ctype<br />Requis (32 bits seulement) : GMP<br />Recommandé : Zlib, mbstring et iconv, ZipArchive<br />*Pour une liste complète des modules nécessaires voir le [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/Dockerfile-Alpine#L7-L9)* |                                |
  | Base de données  | **MySQL 5.5.3+**                                                                                               | SQLite 3.7.4+, PostgreSQL 9.5+   |
- | Navigateur       | **Firefox**                                                                                                    | Chrome, Opera, Safari, or IE 11+ |
+ | Navigateur       | **Firefox**                                                                                                    | Chrome, Opera, Safari, or Edge   |
 
 ## Choisir la bonne version de FreshRSS
 


### PR DESCRIPTION
https://github.com/FreshRSS/FreshRSS/discussions/3321
Our Docker `:oldest` is now based on Alpine 3.5 (2016-12-22) with PHP 7.0.33 and Apache 2.4.35.
