### PR TITLE
Git 2.21 compatiblity

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -16,7 +16,8 @@ class FreshRSS_update_Controller extends Minz_ActionController {
 			throw new Exception($errorMessage);
 		}
 
-		exec('git branch --show-current', $output, $return);
+		//Note `git branch --show-current` requires git 2.22+
+		exec('git symbolic-ref --short HEAD', $output, $return);
 		if ($return != 0) {
 			throw new Exception($errorMessage);
 		}


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3665
`git branch --show-current` requires git 2.22+
https://stackoverflow.com/questions/1417957/show-just-the-current-branch-in-git
Needed for e.g. current Debian and derivatives such as current Raspberry Pi OS
