### PR TITLE
[docs] fix the cron container terminates upon start

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -245,7 +245,7 @@ docker run -d --restart unless-stopped --log-opt max-size=10m \
   -e 'CRON_MIN=17,47' \
   --net freshrss-network \
   --name freshrss_cron freshrss/freshrss \
-  cron
+  cron -f
 ```
 
 #### For the Alpine image


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- `cron -f` rather than `cron` to stay in the foreground mode
-
-

How to test the feature manually:

1. Run the proposed container creation command
2. The container won't terminate immediately upon starting


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
