### PR TITLE
fix i18n translation

### DIFF
--- a/app/i18n/de/install.php
+++ b/app/i18n/de/install.php
@@ -104,7 +104,7 @@ return array(
 	'fix_errors_before' => 'Bitte den Fehler korrigieren, bevor zum nächsten Schritt gesprungen wird.',
 	'javascript_is_better' => 'FreshRSS ist ansprechender mit aktiviertem JavaScript',
 	'js' => array(
-		'confirm_reinstall' => 'Du wirst deine vorherige Konfiguration (Daten) verlieren FreshRSS. Bist du sicher, dass du fortfahren willst?',
+		'confirm_reinstall' => 'Die vorherige Konfiguration (Daten) geht verloren während FreshRSS neu installiert wird. Sind Sie sich sicher fortzufahren?',
 	),
 	'language' => array(
 		'_' => 'Sprache',


### PR DESCRIPTION

fixed the German translation 

(without issue ticket)

Changes proposed in this pull request:
- better translation of "You will lose your previous configuration by reinstalling FreshRSS. Are you sure you want to continue?"


How to test the feature manually:

1. run the install routine till the last step
2. rerun the install routine
3. step 1: chose German
4. go to step 2
5. press the red button "Neuinstallation von FreshRSS

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
