### PR TITLE
Message boxes: Better contrast

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -220,7 +220,7 @@ a.btn {
 
 .btn-attention {
 	background: #e95b57;
-	background: linear-gradient(to bottom, #e95b57, #bd362f);
+	background: linear-gradient(to bottom, #ea4a46, #911811);
 	color: #fff;
 	border: 1px solid #c44742;
 	text-shadow: 0px -1px 0px #666;
@@ -422,14 +422,14 @@ a.btn {
 }
 
 .alert-warn {
-	background: #ffe;
-	color: #c95;
+	background: #ffffe0;
+	color: #77501c;
 	border: 1px solid #eeb;
 }
 
 .alert-success {
-	background: #dfd;
-	color: #484;
+	background: #e8ffe8;
+	color: #2f602f;
 	border: 1px solid #cec;
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -220,7 +220,7 @@ a.btn {
 
 .btn-attention {
 	background: #e95b57;
-	background: linear-gradient(to bottom, #e95b57, #bd362f);
+	background: linear-gradient(to bottom, #ea4a46, #911811);
 	color: #fff;
 	border: 1px solid #c44742;
 	text-shadow: 0px -1px 0px #666;
@@ -422,14 +422,14 @@ a.btn {
 }
 
 .alert-warn {
-	background: #ffe;
-	color: #c95;
+	background: #ffffe0;
+	color: #77501c;
 	border: 1px solid #eeb;
 }
 
 .alert-success {
-	background: #dfd;
-	color: #484;
+	background: #e8ffe8;
+	color: #2f602f;
 	border: 1px solid #cec;
 }
 


### PR DESCRIPTION
Closes #3313

Changes proposed in this pull request:
- darker font color to improve contast up to 7:1
- yellow and green text boxes
- red button

result:
![grafik](https://user-images.githubusercontent.com/1645099/127044727-d88c5bd8-826e-4b1c-9f03-46c9bce7e2df.png)


How to test the feature manually:
1. different text boxes, f.e. install routine step 2


Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
