### PR TITLE
fix the height of select

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -34,19 +34,13 @@ textarea {
 }
 
 input, select, textarea {
-	padding: 5px;
+	padding: 7px;
 	background: #fdfdfd;
 	color: #666;
 	border: 1px solid #bbb;
 	border-radius: 3px;
 	box-shadow: 0 2px 2px #eee inset;
-	min-height: 25px;
-	line-height: 25px;
 	vertical-align: middle;
-}
-
-select {
-	height: 37px;
 }
 
 option {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -45,6 +45,10 @@ input, select, textarea {
 	vertical-align: middle;
 }
 
+select {
+	height: 37px;
+}
+
 option {
 	padding: 0 .5em;
 }

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -34,19 +34,13 @@ textarea {
 }
 
 input, select, textarea {
-	padding: 5px;
+	padding: 7px;
 	background: #fdfdfd;
 	color: #666;
 	border: 1px solid #bbb;
 	border-radius: 3px;
 	box-shadow: 0 2px 2px #eee inset;
-	min-height: 25px;
-	line-height: 25px;
 	vertical-align: middle;
-}
-
-select {
-	height: 37px;
 }
 
 option {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -45,6 +45,10 @@ input, select, textarea {
 	vertical-align: middle;
 }
 
+select {
+	height: 37px;
+}
+
 option {
 	padding: 0 .5em;
 }


### PR DESCRIPTION
Closes #3726

Changes proposed in this pull request:
- same height of `<select>` like `<input>`

![grafik](https://user-images.githubusercontent.com/1645099/127060843-9534e803-cf68-438f-98f2-b33264f84d75.png)


How to test the feature manually:
Go to i/?c=configure&a=archiving (Configure: Archiving)

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested (with Firefox and Microsoft Edge)
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

