### PR TITLE
New article text banner: fix line-height

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -743,6 +743,7 @@ a.btn {
 	background: #0084cc;
 	text-align: center;
 	font-size: 0.9em;
+	padding: 1em;
 }
 
 #new-article:hover {
@@ -750,7 +751,6 @@ a.btn {
 }
 
 #new-article > a {
-	line-height: 3em;
 	color: #fff;
 	font-weight: bold;
 }

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -740,10 +740,10 @@ a.btn {
 
 /*=== New article notification */
 #new-article {
+	padding: 1em;
 	background: #0084cc;
 	text-align: center;
 	font-size: 0.9em;
-	padding: 1em;
 }
 
 #new-article:hover {


### PR DESCRIPTION
Theme: Origine

before (big gap between the lines):
![grafik](https://user-images.githubusercontent.com/1645099/127389027-826c3350-1186-4426-b373-a78d0136bb2c.png)

after:
![grafik](https://user-images.githubusercontent.com/1645099/127389060-06070a49-54a4-4173-b851-324fba7f5246.png)



How to test the feature manually:

1. wait till the feeds get an update

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

