### PR TITLE
Themes incl javascript files

### DIFF
--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -96,20 +96,31 @@ class FreshRSS extends Minz_FrontController {
 		$theme = FreshRSS_Themes::load(FreshRSS_Context::$user_conf->theme);
 		if ($theme) {
 			foreach(array_reverse($theme['files']) as $file) {
-				if ($file[0] === '_') {
-					$theme_id = 'base-theme';
-					$filename = substr($file, 1);
-				} else {
-					$theme_id = $theme['id'];
-					$filename = $file;
+				switch (substr($file, -3)) {
+					case '.js':
+						$theme_id = $theme['id'];
+						$filename = $file;
+						$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
+						$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
+						Minz_View::prependScript(Minz_Url::display($url));
+						break;
+					case '.css':
+					default:
+						if ($file[0] === '_') {
+							$theme_id = 'base-theme';
+							$filename = substr($file, 1);
+						} else {
+							$theme_id = $theme['id'];
+							$filename = $file;
+						}
+						if (_t('gen.dir') === 'rtl') {
+							$filename = substr($filename, 0, -4);
+							$filename = $filename . '.rtl.css';
+						}
+						$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
+						$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
+						Minz_View::prependStyle(Minz_Url::display($url));
 				}
-				if (_t('gen.dir') === 'rtl') {
-					$filename = substr($filename, 0, -4);
-					$filename = $filename . '.rtl.css';
-				}
-				$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
-				$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
-				Minz_View::prependStyle(Minz_Url::display($url));
 			}
 		}
 		//Use prepend to insert before extensions. Added in reverse order.

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -92,6 +92,11 @@ class FreshRSS extends Minz_FrontController {
 		Minz_Translate::init($language);
 	}
 
+	private static function getThemeFileUrl($theme_id, $filename) {
+		$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
+		return '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
+	}
+
 	public static function loadStylesAndScripts() {
 		$theme = FreshRSS_Themes::load(FreshRSS_Context::$user_conf->theme);
 		if ($theme) {
@@ -100,9 +105,7 @@ class FreshRSS extends Minz_FrontController {
 					case '.js':
 						$theme_id = $theme['id'];
 						$filename = $file;
-						$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
-						$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
-						Minz_View::prependScript(Minz_Url::display($url));
+						Minz_View::prependScript(Minz_Url::display(FreshRSS::getThemeFileUrl($theme_id, $filename)));
 						break;
 					case '.css':
 					default:
@@ -117,9 +120,7 @@ class FreshRSS extends Minz_FrontController {
 							$filename = substr($filename, 0, -4);
 							$filename = $filename . '.rtl.css';
 						}
-						$filetime = @filemtime(PUBLIC_PATH . '/themes/' . $theme_id . '/' . $filename);
-						$url = '/themes/' . $theme_id . '/' . $filename . '?' . $filetime;
-						Minz_View::prependStyle(Minz_Url::display($url));
+						Minz_View::prependStyle(Minz_Url::display(FreshRSS::getThemeFileUrl($theme_id, $filename)));
 				}
 			}
 		}


### PR DESCRIPTION
Changes proposed in this pull request:
- now it is possible to include JavaScript files into the theme


How to test the feature manually:

1. add an JS file into the theme folder
2. add the js file name into metadata.json like the css files

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated