### PR TITLE
Fix docs link to dev themes

### DIFF
--- a/docs/en/admins/11_Themes.md
+++ b/docs/en/admins/11_Themes.md
@@ -14,4 +14,4 @@ or a similar method to add their theme to their FreshRSS instance.
 
 # Creating themes
 
-Information on creating themes can be found in [the developer documentation.](../../developers/04_Frontend/02_Design.md)
+Information on creating themes can be found in [the developer documentation.](../developers/04_Frontend/02_Design.md)

--- a/docs/en/admins/11_Themes.md
+++ b/docs/en/admins/11_Themes.md
@@ -14,4 +14,4 @@ or a similar method to add their theme to their FreshRSS instance.
 
 # Creating themes
 
-Information on creating themes can be found in [the developer documentation.](/docs/en/developers/04_Frontend/02_Design)
+Information on creating themes can be found in [the developer documentation.](../../developers/04_Frontend/02_Design.md)


### PR DESCRIPTION
Changes proposed in this pull request:
- fix the documentation
 
![grafik](https://user-images.githubusercontent.com/1645099/128248063-16a59af5-6e00-4734-89d3-8e3360bd4bce.png)

How to test the feature manually:

click on the link "the developer documentation" and it should not send you to 404 anymore. It should open the page http://freshrss.github.io/FreshRSS/en/developers/04_Frontend/02_Design.html

Pull request checklist:
- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
