### PR TITLE
HTML5: main + nav in configuration and subscription pages

### DIFF
--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -1,50 +1,52 @@
-<ul class="nav nav-list aside">
-	<li class="nav-header"><?= _t('gen.menu.configuration') ?></li>
-	<li class="item<?= Minz_Request::actionName() === 'display' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'display') ?>"><?= _t('gen.menu.display') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() === 'reading' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'reading') ?>"><?= _t('gen.menu.reading') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() === 'archiving' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'archiving') ?>"><?= _t('gen.menu.archiving') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() === 'integration' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'integration') ?>"><?= _t('gen.menu.sharing') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() === 'shortcut' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'shortcut') ?>"><?= _t('gen.menu.shortcuts') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() === 'queries' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'queries') ?>"><?= _t('gen.menu.queries') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">
-		<a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::controllerName() === 'extension' ? ' active' : '' ?>">
-		<a href="<?= _url('extension', 'index') ?>"><?= _t('gen.menu.extensions') ?></a>
-	</li>
-	<?= Minz_ExtensionManager::callHook('menu_configuration_entry') ?>
+<nav class="nav nav-list aside">
+	<ul>
+		<li class="nav-header"><?= _t('gen.menu.configuration') ?></li>
+		<li class="item<?= Minz_Request::actionName() === 'display' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'display') ?>"><?= _t('gen.menu.display') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() === 'reading' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'reading') ?>"><?= _t('gen.menu.reading') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() === 'archiving' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'archiving') ?>"><?= _t('gen.menu.archiving') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() === 'integration' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'integration') ?>"><?= _t('gen.menu.sharing') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() === 'shortcut' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'shortcut') ?>"><?= _t('gen.menu.shortcuts') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() === 'queries' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'queries') ?>"><?= _t('gen.menu.queries') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">
+			<a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::controllerName() === 'extension' ? ' active' : '' ?>">
+			<a href="<?= _url('extension', 'index') ?>"><?= _t('gen.menu.extensions') ?></a>
+		</li>
+		<?= Minz_ExtensionManager::callHook('menu_configuration_entry') ?>
 
-	<?php if (FreshRSS_Auth::hasAccess('admin')) { ?>
-	<li class="nav-header"><?= _t('gen.menu.admin') ?></li>
-	<li class="item<?= Minz_Request::actionName() === 'system' ? ' active' : '' ?>">
-		<a href="<?= _url('configure', 'system') ?>"><?= _t('gen.menu.system') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'manage' ? ' active' : '' ?>">
-		<a href="<?= _url('user', 'manage') ?>"><?= _t('gen.menu.user_management') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::controllerName() === 'auth' ? ' active' : '' ?>">
-		<a href="<?= _url('auth', 'index') ?>"><?= _t('gen.menu.authentication') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'checkInstall' ? ' active' : '' ?>">
-		<a href="<?= _url('update', 'checkInstall') ?>"><?= _t('gen.menu.check_install') ?></a>
-	</li>
-	<?php if (!Minz_Configuration::get('system')->disable_update) { ?>
-	<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
-		<a href="<?= _url('update', 'index') ?>"><?= _t('gen.menu.update') ?></a>
-	</li>
-	<?php } ?>
-	<?= Minz_ExtensionManager::callHook('menu_admin_entry') ?>
-	<?php } ?>
-</ul>
+		<?php if (FreshRSS_Auth::hasAccess('admin')) { ?>
+		<li class="nav-header"><?= _t('gen.menu.admin') ?></li>
+		<li class="item<?= Minz_Request::actionName() === 'system' ? ' active' : '' ?>">
+			<a href="<?= _url('configure', 'system') ?>"><?= _t('gen.menu.system') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'manage' ? ' active' : '' ?>">
+			<a href="<?= _url('user', 'manage') ?>"><?= _t('gen.menu.user_management') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::controllerName() === 'auth' ? ' active' : '' ?>">
+			<a href="<?= _url('auth', 'index') ?>"><?= _t('gen.menu.authentication') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'checkInstall' ? ' active' : '' ?>">
+			<a href="<?= _url('update', 'checkInstall') ?>"><?= _t('gen.menu.check_install') ?></a>
+		</li>
+		<?php if (!Minz_Configuration::get('system')->disable_update) { ?>
+		<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
+			<a href="<?= _url('update', 'index') ?>"><?= _t('gen.menu.update') ?></a>
+		</li>
+		<?php } ?>
+		<?= Minz_ExtensionManager::callHook('menu_admin_entry') ?>
+		<?php } ?>
+	</ul>
+</nav>

--- a/app/layout/aside_stats.phtml
+++ b/app/layout/aside_stats.phtml
@@ -1,12 +1,14 @@
-<ul class="nav nav-list aside">
-	<li class="nav-header"><?= _t('admin.stats') ?></li>
-	<li class="item<?= Minz_Request::actionName() == 'index' ? ' active' : '' ?>">
-		<a href="<?= _url('stats', 'index') ?>"><?= _t('admin.stats.menu.main') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() == 'idle' ? ' active' : '' ?>">
-		<a href="<?= _url('stats', 'idle') ?>"><?= _t('admin.stats.menu.idle') ?></a>
-	</li>
-	<li class="item<?= Minz_Request::actionName() == 'repartition' ? ' active' : '' ?>">
-		<a href="<?= _url('stats', 'repartition') ?>"><?= _t('admin.stats.menu.repartition') ?></a>
-	</li>
-</ul>
+<nav class="nav nav-list aside">
+	<ul>
+		<li class="nav-header"><?= _t('admin.stats') ?></li>
+		<li class="item<?= Minz_Request::actionName() == 'index' ? ' active' : '' ?>">
+			<a href="<?= _url('stats', 'index') ?>"><?= _t('admin.stats.menu.main') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() == 'idle' ? ' active' : '' ?>">
+			<a href="<?= _url('stats', 'idle') ?>"><?= _t('admin.stats.menu.idle') ?></a>
+		</li>
+		<li class="item<?= Minz_Request::actionName() == 'repartition' ? ' active' : '' ?>">
+			<a href="<?= _url('stats', 'repartition') ?>"><?= _t('admin.stats.menu.repartition') ?></a>
+		</li>
+	</ul>
+</nav>

--- a/app/layout/aside_subscription.phtml
+++ b/app/layout/aside_subscription.phtml
@@ -1,23 +1,25 @@
-<ul class="nav nav-list aside">
-	<li class="nav-header"><?= _t('sub.menu.subscription_management') ?></li>
+<nav class="nav nav-list aside">
+	<ul>
+		<li class="nav-header"><?= _t('sub.menu.subscription_management') ?></li>
 
-	<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'add' ? ' active' : '' ?>">
-		<a href="<?= _url('subscription', 'add') ?>"><?= _t('sub.menu.add') ?></a>
-	</li>
+		<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'add' ? ' active' : '' ?>">
+			<a href="<?= _url('subscription', 'add') ?>"><?= _t('sub.menu.add') ?></a>
+		</li>
 
-	<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
-		<a href="<?= _url('subscription', 'index') ?>"><?= _t('sub.menu.subscription_management') ?></a>
-	</li>
+		<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
+			<a href="<?= _url('subscription', 'index') ?>"><?= _t('sub.menu.subscription_management') ?></a>
+		</li>
 
-	<li class="item<?= Minz_Request::controllerName() === 'tag' ? ' active' : '' ?>">
-		<a href="<?= _url('tag', 'index') ?>"><?= _t('sub.menu.label_management') ?></a>
-	</li>
+		<li class="item<?= Minz_Request::controllerName() === 'tag' ? ' active' : '' ?>">
+			<a href="<?= _url('tag', 'index') ?>"><?= _t('sub.menu.label_management') ?></a>
+		</li>
 
-	<li class="item<?= Minz_Request::controllerName() === 'importExport' ? ' active' : '' ?>">
-		<a href="<?= _url('importExport', 'index') ?>"><?= _t('sub.menu.import_export') ?></a>
-	</li>
+		<li class="item<?= Minz_Request::controllerName() === 'importExport' ? ' active' : '' ?>">
+			<a href="<?= _url('importExport', 'index') ?>"><?= _t('sub.menu.import_export') ?></a>
+		</li>
 
-	<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'bookmarklet' ? ' active' : '' ?>">
-		<a href="<?= _url('subscription', 'bookmarklet') ?>"><?= _t('sub.menu.subscription_tools') ?></a>
-	</li>
-</ul>
+		<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'bookmarklet' ? ' active' : '' ?>">
+			<a href="<?= _url('subscription', 'bookmarklet') ?>"><?= _t('sub.menu.subscription_tools') ?></a>
+		</li>
+	</ul>
+</nav>

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -46,7 +46,7 @@ if (_t('gen.dir') === 'rtl') {
 	$this->partial('header');
 ?>
 
-<div id="global">
+<main id="global">
 	<?php
 		flush();
 		if (isset($this->callbackBeforeFeeds)) {
@@ -54,7 +54,7 @@ if (_t('gen.dir') === 'rtl') {
 		}
 		$this->render();
 	?>
-</div>
+</main>
 
 <?php
 	$msg = '';


### PR DESCRIPTION
Closes #3643

Changes proposed in this pull request:

- configuration and subscription page now with `<main>` and `<nav>`


How to test the feature manually:
no new feature. Just HTML changes.

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated


