### PR TITLE
Better catch when a user does not exists

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -14,6 +14,10 @@ class FreshRSS_user_Controller extends Minz_ActionController {
 		return preg_match('/^' . self::USERNAME_PATTERN . '$/', $username) === 1;
 	}
 
+	public static function userExists($username) {
+		return @file_exists(USERS_PATH . '/' . $username . '/config.php');
+	}
+
 	public static function updateUser($user, $email, $passwordPlain, $userConfigUpdated = array()) {
 		$userConfig = get_user_configuration($user);
 		if ($userConfig === null) {

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -60,7 +60,7 @@ class FreshRSS_Context {
 	/**
 	 * Initialize the context for the current user.
 	 */
-	public static function initUser($username = '') {
+	public static function initUser($username = '', $userMustExist = true) {
 		FreshRSS_Context::$user_conf = null;
 		if (!isset($_SESSION)) {
 			Minz_Session::init('FreshRSS');
@@ -70,7 +70,8 @@ class FreshRSS_Context {
 		if ($username == '') {
 			$username = Minz_Session::param('currentUser', '');
 		}
-		if ($username === '_' || FreshRSS_user_Controller::checkUsername($username)) {
+		if (($username === '_' || FreshRSS_user_Controller::checkUsername($username)) &&
+			(!$userMustExist || userExists($username))) {
 			try {
 				//TODO: Keep in session what we need instead of always reloading from disk
 				Minz_Configuration::register('user',

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -71,7 +71,7 @@ class FreshRSS_Context {
 			$username = Minz_Session::param('currentUser', '');
 		}
 		if (($username === '_' || FreshRSS_user_Controller::checkUsername($username)) &&
-			(!$userMustExist || userExists($username))) {
+			(!$userMustExist || FreshRSS_user_Controller::userExists($username))) {
 			try {
 				//TODO: Keep in session what we need instead of always reloading from disk
 				Minz_Configuration::register('user',

--- a/app/install.php
+++ b/app/install.php
@@ -71,7 +71,7 @@ function saveStep1() {
 
 		// First, we try to get previous configurations
 		FreshRSS_Context::initSystem();
-		FreshRSS_Context::initUser(FreshRSS_Context::$system_conf->default_user);
+		FreshRSS_Context::initUser(FreshRSS_Context::$system_conf->default_user, false);
 
 		// Then, we set $_SESSION vars
 		Minz_Session::_params([

--- a/cli/_cli.php
+++ b/cli/_cli.php
@@ -28,7 +28,7 @@ function cliInitUser($username) {
 		fail('FreshRSS error: invalid username: ' . $username . "\n");
 	}
 
-	if (!userExists($username)) {
+	if (!FreshRSS_user_Controller::userExists($username)) {
 		fail('FreshRSS error: user not found: ' . $username . "\n");
 	}
 

--- a/cli/_cli.php
+++ b/cli/_cli.php
@@ -28,8 +28,7 @@ function cliInitUser($username) {
 		fail('FreshRSS error: invalid username: ' . $username . "\n");
 	}
 
-	$usernames = listUsers();
-	if (!in_array($username, $usernames)) {
+	if (!userExists($username)) {
 		fail('FreshRSS error: user not found: ' . $username . "\n");
 	}
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -327,6 +327,7 @@ function listUsers() {
 	return $final_list;
 }
 
+
 /**
  * Return if the maximum number of registrations has been reached.
  *

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -327,10 +327,6 @@ function listUsers() {
 	return $final_list;
 }
 
-function userExists($username) {
-	return @file_exists(USERS_PATH . '/' . $username . '/config.php');
-}
-
 /**
  * Return if the maximum number of registrations has been reached.
  *

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -327,6 +327,9 @@ function listUsers() {
 	return $final_list;
 }
 
+function userExists($username) {
+	return @file_exists(USERS_PATH . '/' . $username . '/config.php');
+}
 
 /**
  * Return if the maximum number of registrations has been reached.


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3735
Before, we were relying on an exception during the first stages of user initalisation. Now the check is explicit and cleaner, producing a more appropriate HTTP response for the API.