### PR TITLE
Use environment variables 

### DIFF
--- a/Docker/.env
+++ b/Docker/.env
@@ -1,0 +1,25 @@
+# Environment file for docker-compose
+# In this file you need to define the different settings
+
+
+# ====================================
+# Database
+# ====================================
+
+
+# Database to use for freshrss
+POSTGRES_DB=freshrss
+
+# User in the freshrss database
+POSTGRES_USER=freshrss
+
+# Password for the defined user
+POSTGRES_PASSWORD=freshrss
+
+
+# ====================================
+# FreshRSS
+# ====================================
+
+# Exposed port for the docker-container
+EXPOSED_PORT=8080

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -308,11 +308,16 @@ A [docker-compose.yml](docker-compose.yml) file is given as an example, using Po
 - In the `postgresql` service:
     * `container_name` directive. Whatever you set this to will be the value you put in the "Host" field during the "Database Configuration" step of installation;
 	* the `volumes` section. Be careful to keep the path `/var/lib/postgresql/data` for the container. If the path is wrong, you will not get any error but your db will be gone at the next run;
-	* the `POSTGRES_PASSWORD` in the `environment` section;
+	* the `POSTGRES_PASSWORD` in the `.env` file;
+	* the `POSTGRES_DB ` in the `.env` file;
+	* the `POSTGRES_USER` in the `.env` file;
 - In the `freshrss` service:
 	* the `volumes` section;
 	* options under the `labels` section are specific to [Træfik](https://traefik.io/), a reverse proxy. If you are not using it, feel free to delete this section. If you are using it, adapt accordingly to your config, especially the `traefik.frontend.rule` option.
 	* the `environment` section to adapt the strategy to update feeds.
+    * the `EXPOSED_PORT` variable in the `.env` file;
+
+If you don't want to use the `.env` file you can also directly edit the `docker-compose.yml` file. It's highly recommended to change the password. If you don't change it, it will use the default option.
 
 You can then launch the stack (FreshRSS + PostgreSQL) with:
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -315,7 +315,7 @@ A [docker-compose.yml](docker-compose.yml) file is given as an example, using Po
 	* the `volumes` section;
 	* options under the `labels` section are specific to [Træfik](https://traefik.io/), a reverse proxy. If you are not using it, feel free to delete this section. If you are using it, adapt accordingly to your config, especially the `traefik.frontend.rule` option.
 	* the `environment` section to adapt the strategy to update feeds.
-    * the `EXPOSED_PORT` variable in the `.env` file;
+	* the `EXPOSED_PORT` variable in the `.env` file;
 
 If you don't want to use the `.env` file you can also directly edit the `docker-compose.yml` file. It's highly recommended to change the password. If you don't change it, it will use the default option.
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -9,9 +9,9 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: freshrss
-      POSTGRES_PASSWORD: freshrss
-      POSTGRES_DB: freshrss
+      POSTGRES_USER: ${POSTGRES_USER:-freshrss}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-freshrss}
+      POSTGRES_DB: ${POSTGRES_DB:-freshrss}
 
   freshrss-app:
     image: freshrss/freshrss:latest
@@ -19,7 +19,7 @@ services:
     hostname: freshrss-app
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "${EXPOSED_PORT:-8080}:80"
     depends_on:
       - freshrss-db
     volumes:


### PR DESCRIPTION
Closes #3755

Changes proposed in this pull request:

- Add environment variables to a separate file for docker-compose

How to test the feature manually:

1. Clone the newest commit
2. Run `docker-compose config` in the directory to see how the docker-compose file will be used.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [X] documentation updated
