### PR TITLE
fix #3763 Backlink on error message

### DIFF
--- a/app/views/error/index.phtml
+++ b/app/views/error/index.phtml
@@ -3,7 +3,11 @@
 		<h1 class="alert-head"><?= $this->code ?></h1>
 		<p>
 			<?= htmlspecialchars($this->errorMessage, ENT_NOQUOTES, 'UTF-8') ?><br />
+			<?php if (FreshRSS_Auth::hasAccess()) {?>
 			<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
+			<?php } else { ?>
+			<a class="signin" href="<?= _url('auth', 'login') ?>"><?= _t('gen.auth.login') ?></a>
+			<?php } ?>
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
Closes #3763

Changes proposed in this pull request:

- login link, if user is not logged in
![grafik](https://user-images.githubusercontent.com/1645099/129270556-4e89038a-75cd-47a5-a4dd-e8d1fb7d2498.png)

- back to RSS feed link if the user is logged in


How to test the feature manually:
1. login
2. delete the session cookie
3. navigate to a page

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
