### PR TITLE
Modify bright elements in adark.css mobile view

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -276,8 +276,8 @@ a.btn {
 .nav-head {
 	margin: 0;
 	background: #fff;
-	background: linear-gradient(to bottom, #fff, #f0f0f0);
-	border-bottom: 1px solid #ddd;
+	background: #262626;
+	border-bottom: 1px solid #333;
 	text-align: right;
 }
 
@@ -1125,11 +1125,11 @@ a.btn {
 
 	.aside .toggle_aside,
 	#panel .close {
-		background: #f6f6f6;
+		background: #262626;
 		display: block;
 		width: 100%;
 		height: 50px;
-		border-bottom: 1px solid #ddd;
+		border-bottom: 1px solid #333;
 		line-height: 50px;
 		text-align: center;
 	}


### PR DESCRIPTION
Elements with bright backgrounds in mobile view now have a dark background.

Changes proposed in this pull request:

- Style certain elements to be more compatible with the dark theme

How to test the feature manually:

Open your browser's developer tools and implement the styles shown here.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
