### PR TITLE
Docker with Debian 11 Bullseye

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim
+FROM debian:11-slim
 
 ENV TZ UTC
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -1,7 +1,7 @@
 # Only relevant for Docker Hub or QEMU multi-architecture builds.
 # Prefer the normal `Dockerfile` if you are building manually on the targeted architecture.
 
-FROM arm32v7/debian:10-slim
+FROM arm32v7/debian:11-slim
 
 # Requires ./hooks/*
 COPY ./Docker/qemu-arm-* /usr/bin/


### PR DESCRIPTION
PHP 7.4.21, Apache/2.4.48
https://www.debian.org/News/2021/20210814
No significant change for us, apparently