### PR TITLE
Keep <noscript> while fetching the news

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -199,7 +199,7 @@ function customSimplePie($attributes = array()) {
 	$simplePie->strip_htmltags(array(
 		'base', 'blink', 'body', 'doctype', 'embed',
 		'font', 'form', 'frame', 'frameset', 'html',
-		'link', 'input', 'marquee', 'meta', 'noscript',
+		'link', 'input', 'marquee', 'meta',
 		'object', 'param', 'plaintext', 'script', 'style',
 		'svg',	//TODO: Support SVG after sanitizing and URL rewriting of xlink:href
 	));


### PR DESCRIPTION
Closes #3688

Changes proposed in this pull request:

- deleted noscript from the strip_htmltags array


How to test the feature manually:
see #3688

Pull request checklist:

- [ ] clear commit messages
- [x] code manually tested: used this configuration since July 12th daily. It works fine
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

