### PR TITLE
Fallback for feeds with empty title

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -470,10 +470,11 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 			}
 
 			if ($simplePie != null) {
-				if (trim($feed->name()) == '') {
+				if ($feed->name(true) == '') {
 					//HTML to HTML-PRE	//ENT_COMPAT except '&'
 					$name = strtr(html_only_entity_decode($simplePie->get_title()), array('<' => '&lt;', '>' => '&gt;', '"' => '&quot;'));
-					$feedProperties['name'] = $name == '' ? $feed->url() : $name;
+					$feed->_name($name);
+					$feedProperties['name'] = $feed->name(false);
 				}
 				if (trim($feed->website()) == '') {
 					$website = html_only_entity_decode($simplePie->get_link());

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -75,8 +75,8 @@ class FreshRSS_Feed extends Minz_Model {
 		$simplePie = $this->load(false, true);
 		return $simplePie == null ? [] : iterator_to_array($this->loadEntries($simplePie));
 	}
-	public function name() {
-		return $this->name;
+	public function name($raw = false) {
+		return $raw || $this->name != '' ? $this->name : preg_replace('%^https?://%i', '', $this->url);
 	}
 	public function website() {
 		return $this->website;
@@ -198,7 +198,7 @@ class FreshRSS_Feed extends Minz_Model {
 		$this->category = $value >= 0 ? $value : 0;
 	}
 	public function _name($value) {
-		$this->name = $value === null ? '' : $value;
+		$this->name = $value === null ? '' : trim($value);
 	}
 	public function _website($value, $validate = true) {
 		if ($validate) {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -76,7 +76,7 @@ class FreshRSS_Feed extends Minz_Model {
 		return $simplePie == null ? [] : iterator_to_array($this->loadEntries($simplePie));
 	}
 	public function name($raw = false) {
-		return $raw || $this->name != '' ? $this->name : preg_replace('%^https?://%i', '', $this->url);
+		return $raw || $this->name != '' ? $this->name : preg_replace('%^https?://(www[.])?%i', '', $this->url);
 	}
 	public function website() {
 		return $this->website;

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -23,7 +23,7 @@
 		<div class="form-group">
 			<label class="group-name" for="name"><?= _t('sub.feed.title') ?></label>
 			<div class="group-controls">
-				<input type="text" name="name" id="name" class="extend" value="<?= $this->feed->name() ?>" />
+				<input type="text" name="name" id="name" class="extend" value="<?= $this->feed->name(true) ?>" />
 			</div>
 		</div>
 		<div class="form-group">


### PR DESCRIPTION
Fallback to (part of) URL for feeds with empty name/title, which might happen when importing OPMLs with invalid URLs.
#fix https://github.com/FreshRSS/FreshRSS/issues/3776
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/3071 / https://github.com/FreshRSS/FreshRSS/issues/3067
