### PR TITLE
About page: link "Back to RSS feeds"

### DIFF
--- a/app/views/index/about.phtml
+++ b/app/views/index/about.phtml
@@ -1,7 +1,9 @@
 <div class="post content">
+	<?php if (FreshRSS_Auth::hasAccess()) {?>
 	<div class="link-back-wrapper">
 		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
 	</div>
+	<?php } ?>
 
 	<h1><?= _t('index.about') ?></h1>
 


### PR DESCRIPTION
Closes #3766 

Changes proposed in this pull request:

- show the link "Back to RSS feeds" only, when user is logged in
- if not logged in: do not show the link

How to test the feature manually:

1. user is not logged in: click on login page "About FreshRSS" and see the about page without a link
2. as a logged in user: open in the settings menue: "About" and see the link "Back to RSS feeds"

About page when the user is not logged in:
![grafik](https://user-images.githubusercontent.com/1645099/130291088-7b00cea8-d2de-42d9-bf92-f9737c41558f.png)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
