### PR TITLE
Settings: Display - icons table in mobile view fixed

### DIFF
--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -77,62 +77,64 @@
 
 		<div class="form-group">
 			<label class="group-name"><?= _t('conf.display.icon.entry') ?></label>
-			<table>
-				<thead>
-					<tr>
-						<th> </th>
-						<th title="<?= _t('gen.action.mark_read') ?>"><?= _i('read') ?></th>
-						<th title="<?= _t('gen.action.mark_favorite') ?>"><?= _i('bookmark') ?></th>
-						<th><?= _t('conf.display.icon.related_tags') ?></th>
-						<th><?= _t('conf.display.icon.sharing') ?></th>
-						<th><?= _t('conf.display.icon.display_authors') ?></th>
-						<th><?= _t('conf.display.icon.publication_date') ?></th>
-						<th><?= _i('link') ?></th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th><?= _t('conf.display.icon.top_line') ?></th>
-						<td><input type="checkbox" name="topline_read" value="1"<?=
-							FreshRSS_Context::$user_conf->topline_read ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_read ?>"/></td>
-						<td><input type="checkbox" name="topline_favorite" value="1"<?=
-							FreshRSS_Context::$user_conf->topline_favorite ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_favorite ?>"/></td>
-						<td><input type="checkbox" disabled="disabled" /></td>
-						<td><input type="checkbox" disabled="disabled" /></td>
-						<td><input type="checkbox" name="topline_display_authors" value="1"<?=
-							FreshRSS_Context::$user_conf->topline_display_authors ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_display_authors ?>"/></td>
-						<td><input type="checkbox" name="topline_date" value="1"<?=
-							FreshRSS_Context::$user_conf->topline_date ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_date ?>"/></td>
-						<td><input type="checkbox" name="topline_link" value="1"<?= FreshRSS_Context::$user_conf->topline_link ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_link ?>"/></td>
-					</tr><tr>
-						<th><?= _t('conf.display.icon.bottom_line') ?></th>
-						<td><input type="checkbox" name="bottomline_read" value="1"<?=
-							FreshRSS_Context::$user_conf->bottomline_read ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_read ?>"/></td>
-						<td><input type="checkbox" name="bottomline_favorite" value="1"<?=
-							FreshRSS_Context::$user_conf->bottomline_favorite ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_favorite ?>"/></td>
-						<td><input type="checkbox" name="bottomline_tags" value="1"<?=
-							FreshRSS_Context::$user_conf->bottomline_tags ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_tags ?>"/></td>
-						<td><input type="checkbox" name="bottomline_sharing" value="1"<?=
-							FreshRSS_Context::$user_conf->bottomline_sharing ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_sharing ?>"/></td>
-						<td><input type="checkbox" disabled="disabled" /></td>
-						<td><input type="checkbox" name="bottomline_date" value="1"<?=
-							FreshRSS_Context::$user_conf->bottomline_date ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_date ?>"/></td>
-						<td><input type="checkbox" name="bottomline_link" value="1"<?=
-							FreshRSS_Context::$user_conf->bottomline_link ? ' checked="checked"' : '' ?>
-							data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_link ?>"/></td>
-					</tr>
-				</tbody>
-			</table><br />
+			<div class="group-controls">
+				<table class="config-articleicons">
+					<thead>
+						<tr>
+							<th> </th>
+							<th title="<?= _t('gen.action.mark_read') ?>"><?= _i('read') ?></th>
+							<th title="<?= _t('gen.action.mark_favorite') ?>"><?= _i('bookmark') ?></th>
+							<th><?= _t('conf.display.icon.related_tags') ?></th>
+							<th><?= _t('conf.display.icon.sharing') ?></th>
+							<th><?= _t('conf.display.icon.display_authors') ?></th>
+							<th><?= _t('conf.display.icon.publication_date') ?></th>
+							<th><?= _i('link') ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<th><?= _t('conf.display.icon.top_line') ?></th>
+							<td><input type="checkbox" name="topline_read" value="1"<?=
+								FreshRSS_Context::$user_conf->topline_read ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_read ?>"/></td>
+							<td><input type="checkbox" name="topline_favorite" value="1"<?=
+								FreshRSS_Context::$user_conf->topline_favorite ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_favorite ?>"/></td>
+							<td><input type="checkbox" disabled="disabled" /></td>
+							<td><input type="checkbox" disabled="disabled" /></td>
+							<td><input type="checkbox" name="topline_display_authors" value="1"<?=
+								FreshRSS_Context::$user_conf->topline_display_authors ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_display_authors ?>"/></td>
+							<td><input type="checkbox" name="topline_date" value="1"<?=
+								FreshRSS_Context::$user_conf->topline_date ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_date ?>"/></td>
+							<td><input type="checkbox" name="topline_link" value="1"<?= FreshRSS_Context::$user_conf->topline_link ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->topline_link ?>"/></td>
+						</tr><tr>
+							<th><?= _t('conf.display.icon.bottom_line') ?></th>
+							<td><input type="checkbox" name="bottomline_read" value="1"<?=
+								FreshRSS_Context::$user_conf->bottomline_read ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_read ?>"/></td>
+							<td><input type="checkbox" name="bottomline_favorite" value="1"<?=
+								FreshRSS_Context::$user_conf->bottomline_favorite ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_favorite ?>"/></td>
+							<td><input type="checkbox" name="bottomline_tags" value="1"<?=
+								FreshRSS_Context::$user_conf->bottomline_tags ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_tags ?>"/></td>
+							<td><input type="checkbox" name="bottomline_sharing" value="1"<?=
+								FreshRSS_Context::$user_conf->bottomline_sharing ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_sharing ?>"/></td>
+							<td><input type="checkbox" disabled="disabled" /></td>
+							<td><input type="checkbox" name="bottomline_date" value="1"<?=
+								FreshRSS_Context::$user_conf->bottomline_date ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_date ?>"/></td>
+							<td><input type="checkbox" name="bottomline_link" value="1"<?=
+								FreshRSS_Context::$user_conf->bottomline_link ? ' checked="checked"' : '' ?>
+								data-leave-validation="<?= FreshRSS_Context::$user_conf->bottomline_link ?>"/></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 		</div>
 
 		<div class="form-group">

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -100,10 +100,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -100,10 +100,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Ansum/_forms.scss
+++ b/p/themes/Ansum/_forms.scss
@@ -143,10 +143,6 @@ input.extend {
 		line-height: 2.0em;
 	}
 
-	table {
-		margin: 10px 0 0 220px;
-	}
-
 	&.form-actions {
 		margin: 15px 0 25px;
 		padding: 5px 0;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -182,9 +182,6 @@ input.extend {
 .form-group .group-controls .control {
 	line-height: 2em;
 }
-.form-group table {
-	margin: 10px 0 0 220px;
-}
 .form-group.form-actions {
 	margin: 15px 0 25px;
 	padding: 5px 0;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -182,9 +182,6 @@ input.extend {
 .form-group .group-controls .control {
 	line-height: 2em;
 }
-.form-group table {
-	margin: 10px 220px 0 0;
-}
 .form-group.form-actions {
 	margin: 15px 0 25px;
 	padding: 5px 0;

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -113,10 +113,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 button.as-link[disabled] {
 	color: #555 !important;

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -113,10 +113,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 button.as-link[disabled] {
 	color: #555 !important;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -123,10 +123,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 button.as-link[disabled] {
 	color: #445 !important;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -123,10 +123,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 button.as-link[disabled] {
 	color: #445 !important;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -141,10 +141,6 @@ form th {
 	line-height: 2.0em;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -141,10 +141,6 @@ form th {
 	line-height: 2.0em;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Mapco/_forms.scss
+++ b/p/themes/Mapco/_forms.scss
@@ -143,10 +143,6 @@ input.extend {
 		line-height: 2.0em;
 	}
 
-	table {
-		margin: 10px 0 0 220px;
-	}
-
 	&.form-actions {
 		margin: 15px 0 25px;
 		padding: 5px 0;

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -183,9 +183,6 @@ input.extend {
 .form-group .group-controls .control {
 	line-height: 2em;
 }
-.form-group table {
-	margin: 10px 0 0 220px;
-}
 .form-group.form-actions {
 	margin: 15px 0 25px;
 	padding: 5px 0;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -183,9 +183,6 @@ input.extend {
 .form-group .group-controls .control {
 	line-height: 2em;
 }
-.form-group table {
-	margin: 10px 220px 0 0;
-}
 .form-group.form-actions {
 	margin: 15px 0 25px;
 	padding: 5px 0;

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -111,10 +111,6 @@ form th {
 	padding: 8px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -111,10 +111,6 @@ form th {
 	padding: 8px 0;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -109,10 +109,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -109,10 +109,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -112,10 +112,6 @@ form th {
 
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -112,10 +112,6 @@ form th {
 
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -113,10 +113,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 button.as-link[disabled] {
 	color: #555 !important;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -113,10 +113,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 220px 0 0;
-}
-
 /*=== Buttons */
 button.as-link[disabled] {
 	color: #555 !important;

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -179,10 +179,6 @@ form th {
 .form-group .group-controls .control {
 	line-height: 2em;
 }
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 .stick {
 	vertical-align: middle;
 	font-size: 0;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -179,9 +179,6 @@ form th {
 .form-group .group-controls .control {
 	line-height: 2em;
 }
-.form-group table {
-	margin: 10px 220px 0 0;
-}
 
 .stick {
 	vertical-align: middle;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -222,10 +222,6 @@ form {
 			line-height: 2.0em;
 		}
 	}
-
-	table {
-		margin: 10px 0 0 220px;
-	}
 }
 
 .form-group::after {

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -95,10 +95,6 @@ form th {
 	padding: 5px 0;
 }
 
-.form-group table {
-	margin: 10px 0 0 220px;
-}
-
 /*=== Buttons */
 .stick {
 	vertical-align: middle;


### PR DESCRIPTION
Closes this issue in mobile view:
![grafik](https://user-images.githubusercontent.com/1645099/130351478-e3df9f0f-b8fe-4aae-bd02-a4ed40e71aef.png)


Changes proposed in this pull request:
- changed template and added a standard wrapper around the table
- deleted the CSS in every theme

How to test the feature manually:

1. open the settings "Display" in mobile view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
