### PR TITLE
Form actions buttons improved style (mobile and desktop)

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -90,13 +90,14 @@ form th {
 /*===============*/
 /*=== Forms */
 .form-group.form-actions {
+	margin-bottom: 40px;
 	padding: 5px 0;
 	background: #f4f4f4;
 	border-top: 1px solid #ddd;
 }
 
 .form-group.form-actions .btn {
-	margin: 0 10px;
+	margin: 0 20px 0 0;
 }
 
 .form-group .group-name {
@@ -1193,6 +1194,13 @@ a.btn {
 
 	.nav_menu .search input:focus {
 		width: 400px;
+	}
+
+	.form-group.form-actions {
+		margin-left: -15px;
+		margin-right: -15px;
+		padding-left: 15px;
+		padding-right: 15px;
 	}
 
 	.day .name {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -90,13 +90,14 @@ form th {
 /*===============*/
 /*=== Forms */
 .form-group.form-actions {
+	margin-bottom: 40px;
 	padding: 5px 0;
 	background: #f4f4f4;
 	border-top: 1px solid #ddd;
 }
 
 .form-group.form-actions .btn {
-	margin: 0 10px;
+	margin: 0 20px 0 0;
 }
 
 .form-group .group-name {
@@ -1193,6 +1194,13 @@ a.btn {
 
 	.nav_menu .search input:focus {
 		width: 400px;
+	}
+
+	.form-group.form-actions {
+		margin-left: -15px;
+		margin-right: -15px;
+		padding-left: 15px;
+		padding-right: 15px;
 	}
 
 	.day .name {


### PR DESCRIPTION
Theme: Origine

before:
buttons are not in the line to the other input elements

desktop:
![grafik](https://user-images.githubusercontent.com/1645099/130516095-f2a3fc14-bda3-40d4-81ce-a821aafc915a.png)

mobile:
![grafik](https://user-images.githubusercontent.com/1645099/130516165-19286913-fdf4-4330-b509-3ab388fae5e0.png)
(in mobile view: the grey background has a gap to the window border)


In my opinion it does not look good

This PR improves to this better layout:

desktop:
![grafik](https://user-images.githubusercontent.com/1645099/130516384-749511bc-bd93-413f-942c-74e7953e054a.png)

mobile:
![grafik](https://user-images.githubusercontent.com/1645099/130516503-2a6a66cb-b3d0-4556-9f39-3721cbc31009.png)


Changes proposed in this pull request:

- CSS improved


How to test the feature manually:
see every button row


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
