### PR TITLE
Fix: label management <label>

### DIFF
--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -9,9 +9,9 @@
 		<legend><?= _t('sub.title.add_label') ?></legend>
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<div class="form-group">
-			<label class="group-name" for="category"><?= _t('sub.tag.name') ?></label>
+			<label class="group-name" for="new_label_name"><?= _t('sub.tag.name') ?></label>
 			<div class="group-controls">
-				<input id="name" name="name" type="text" autocomplete="off"/>
+				<input id="new_label_name" name="name" type="text" autocomplete="off"/>
 			</div>
 		</div>
 
@@ -27,7 +27,7 @@
 		<legend><?= _t('sub.title.rename_label') ?></legend>
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<div class="form-group">
-			<label class="group-name" for="category"><?= _t('sub.tag.old_name') ?></label>
+			<label class="group-name" for="id_tag"><?= _t('sub.tag.old_name') ?></label>
 			<div class="group-controls">
 				<select name="id_tag" id="id_tag">
 					<?php foreach ($this->tags as $tag): ?>
@@ -37,9 +37,9 @@
 			</div>
 		</div>
 		<div class="form-group">
-			<label class="group-name" for="category"><?= _t('sub.tag.new_name') ?></label>
+			<label class="group-name" for="rename_new_name"><?= _t('sub.tag.new_name') ?></label>
 			<div class="group-controls">
-				<input id="name" name="name" type="text" autocomplete="off"/>
+				<input id="rename_new_name" name="name" type="text" autocomplete="off"/>
 			</div>
 		</div>
 
@@ -54,9 +54,9 @@
 		<legend><?= _t('sub.title.delete_label') ?></legend>
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<div class="form-group">
-			<label class="group-name" for="category"><?= _t('sub.tag.name') ?></label>
+			<label class="group-name" for="id_tag_delete"><?= _t('sub.tag.name') ?></label>
 			<div class="group-controls">
-				<select name="id_tag" id="id_tag">
+				<select name="id_tag" id="id_tag_delete">
 					<?php foreach ($this->tags as $tag): ?>
 						<option value="<?= $tag->id() ?>"><?= $tag->name() ?></option>
 					<?php endforeach; ?>


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/1645099/130776507-3df99da8-1167-4f74-acc6-d13bcbb85480.png)

The `<label>` were not proper connected to the inputs

Changes proposed in this pull request:
- renamed "for" and "id"

How to test the feature manually:
click on the label (left column) and it will mark the input element (right column)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
