### PR TITLE
Darken bright elements in adark.css

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -64,11 +64,11 @@ table {
 
 tr, th, td {
 	padding: 0.5em;
-	border: 1px solid #ddd;
+	border: 1px solid #333;
 }
 
 th {
-	background: #f6f6f6;
+	background: #262626;
 }
 
 form td,
@@ -455,7 +455,7 @@ a.btn {
 .box .box-title {
 	margin: 0;
 	padding: 5px 10px;
-	background: #f6f6f6;
+	background: #262626;
 	border: 1px solid #292929;
 	border-radius: 5px 5px 0 0;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -64,11 +64,11 @@ table {
 
 tr, th, td {
 	padding: 0.5em;
-	border: 1px solid #ddd;
+	border: 1px solid #333;
 }
 
 th {
-	background: #f6f6f6;
+	background: #262626;
 }
 
 form td,
@@ -455,7 +455,7 @@ a.btn {
 .box .box-title {
 	margin: 0;
 	padding: 5px 10px;
-	background: #f6f6f6;
+	background: #262626;
 	border: 1px solid #292929;
 	border-radius: 5px 5px 0 0;
 }


### PR DESCRIPTION
- Table headers and box titles on the subscription management page use bright white backgrounds. This modifies these elements to use a dark background in order to be consistent with the rest of the theme.

Changes proposed in this pull request:

- Darken bright elements in adark.css

How to test the feature manually:

1. Load the adark.css theme and modify the stylesheet accordingly using the browser's stylesheet editor.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
