### PR TITLE
Improved <kbd> line break

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -74,12 +74,12 @@ sup {
 
 kbd {
 	background-color: #eee;
-	padding: 2px 4px;
+	padding: 2px 4px 2px 24px;
 	display: inline-block;
 	color: #333;
 	border: 1px solid #b4b4b4;
 	border-radius: 3px;
-	white-space: nowrap;
+	text-indent: -20px;
 }
 
 /*=== Images */

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -80,6 +80,8 @@ kbd {
 	border: 1px solid #b4b4b4;
 	border-radius: 3px;
 	text-indent: -20px;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
 }
 
 /*=== Images */

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -74,12 +74,12 @@ sup {
 
 kbd {
 	background-color: #eee;
-	padding: 2px 4px;
+	padding: 2px 4px 2px 24px;
 	display: inline-block;
 	color: #333;
 	border: 1px solid #b4b4b4;
 	border-radius: 3px;
-	white-space: nowrap;
+	text-indent: -20px;
 }
 
 /*=== Images */

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -80,6 +80,8 @@ kbd {
 	border: 1px solid #b4b4b4;
 	border-radius: 3px;
 	text-indent: -20px;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
 }
 
 /*=== Images */


### PR DESCRIPTION


before:
`<kbd>` has no automatic line break. It leads to a horizontal scrolling on smaller screens
![grafik](https://user-images.githubusercontent.com/1645099/131655447-7a89ab32-1bea-453b-9e4a-d388bf170b2a.png)


![grafik](https://user-images.githubusercontent.com/1645099/131655475-306a9b2a-2449-4cbf-8b63-aa4bcc8ff0e9.png)

improved:
line break with text-indent.
![grafik](https://user-images.githubusercontent.com/1645099/131655821-d8880a43-4d1e-4c64-9a8c-a81dc8fd3321.png)


![grafik](https://user-images.githubusercontent.com/1645099/131655802-0939274e-ee6d-401c-b926-8ff9ad54c6b9.png)



Changes proposed in this pull request:
- CSS changed
-
-

How to test the feature manually:
go to the both pages as shown in the screenshots

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
