### PR TITLE
fix: Theme slider on small screens

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1180,7 +1180,7 @@ br {
 .nav label {
 	padding: 0;
 	display: none;
-	width: 10%;
+	width: 20%;
 	height: 100%;
 	color: #fff;
 	font-family: "Varela Round", sans-serif;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1187,7 +1187,7 @@ br {
 .nav label {
 	padding: 0;
 	display: none;
-	width: 20%;
+	width: 65px;
 	height: 100%;
 	color: #fff;
 	font-family: "Varela Round", sans-serif;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1180,7 +1180,7 @@ br {
 .nav label {
 	padding: 0;
 	display: none;
-	width: 10%;
+	width: 20%;
 	height: 100%;
 	color: #fff;
 	font-family: "Varela Round", sans-serif;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1187,7 +1187,7 @@ br {
 .nav label {
 	padding: 0;
 	display: none;
-	width: 20%;
+	width: 65px;
 	height: 100%;
 	color: #fff;
 	font-family: "Varela Round", sans-serif;


### PR DESCRIPTION
Theme slider

before:
the right arrow overflows the box on small screens
![grafik](https://user-images.githubusercontent.com/1645099/131724142-6756c84a-5f8c-4a8f-ba37-44e883552877.png)

after:
![grafik](https://user-images.githubusercontent.com/1645099/131724258-52de35d6-ad43-4f32-988b-8f275cfedba2.png)


Changes proposed in this pull request:
- CSS (width of the arrows improved)

How to test the feature manually:
1. on smaller screens

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested