### PR TITLE
Subscription tools: Switch from<pre> to <kbd>

### DIFF
--- a/app/views/subscription/bookmarklet.phtml
+++ b/app/views/subscription/bookmarklet.phtml
@@ -16,9 +16,9 @@
 		<?= _t('sub.firefox.obsolete_63', $this->default_category->name()) ?>
 	</p>
 	<p><?= _t('sub.firefox.documentation') ?></p>
-	<pre>browser.contentHandlers.types.number.uri → <?= Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss=%s</pre>
+	<kbd>browser.contentHandlers.types.number.uri → <?= Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss=%s</kbd>
 
 	<h2><?= _t('sub.api.title') ?></h2>
 	<p><?= _t('sub.api.documentation') ?></p>
-	<pre><?= Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss=%s</pre>
+	<kbd><?= Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss=%s</kbd>
 </div>


### PR DESCRIPTION
before:
![grafik](https://user-images.githubusercontent.com/1645099/131742111-483d3c44-3c12-4025-8c66-e1b6e4fe64ef.png)


after:
![grafik](https://user-images.githubusercontent.com/1645099/131742206-a43f979a-b3e2-4777-a518-0e6adff1267b.png)



Changes proposed in this pull request:
- changed from `<pre>` to `<kbd>`

How to test the feature manually:
1. go to subscription tools page


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
