### PR TITLE
delete firefox 63 information (#3820)

### DIFF
--- a/app/i18n/cz/sub.php
+++ b/app/i18n/cz/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'URL webové stránky',
 		'websub' => 'Okamžité oznámení s WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Follow the steps described <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> to add FreshRSS to Firefox feed reader list.',	// TODO - Translation
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',	// TODO - Translation
-		'title' => 'Firefox feed reader',	// TODO - Translation
-	),
 	'import_export' => array(
 		'export' => 'Export',	// TODO - Translation
 		'export_labelled' => 'Export your labelled articles',	// TODO - Translation

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Webseiten-URL',
 		'websub' => 'Sofortbenachrichtigung mit WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Folge den <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">hier</a> beschriebenen Schritten um FreshRSS zu Deiner Firefox RSS-Reader Liste hinzuzufügen.',
-		'obsolete_63' => 'Seit Version 63 hat Firefox die Möglichkeit entfernt, Dienste hinzuzufügen, die keine eigenständigen Anwendungen sind.',
-		'title' => 'Firefox RSS-Reader',
-	),
 	'import_export' => array(
 		'export' => 'Exportieren',
 		'export_labelled' => 'Artikel mit Labeln exportieren',

--- a/app/i18n/en-us/sub.php
+++ b/app/i18n/en-us/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Website URL',
 		'websub' => 'Instant notification with WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Follow the steps described <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> to add FreshRSS to Firefox feed reader list.',
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',
-		'title' => 'Firefox feed reader',
-	),
 	'import_export' => array(
 		'export' => 'Export',
 		'export_labelled' => 'Export your labeled articles',

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Website URL',
 		'websub' => 'Instant notification with WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Follow the steps described <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> to add FreshRSS to Firefox feed reader list.',
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',
-		'title' => 'Firefox feed reader',
-	),
 	'import_export' => array(
 		'export' => 'Export',
 		'export_labelled' => 'Export your labelled articles',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Web de la URL',
 		'websub' => 'Notificación inmedaiata con WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Follow the steps described <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> to add FreshRSS to Firefox feed reader list.',	// TODO - Translation
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',	// TODO - Translation
-		'title' => 'Firefox feed reader',	// TODO - Translation
-	),
 	'import_export' => array(
 		'export' => 'Exportar',
 		'export_labelled' => 'Export your labelled articles',	// TODO - Translation

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'URL du site',
 		'websub' => 'Notification instantanée par WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Suivre les étapes décrites <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">ici</a> pour ajouter FreshRSS à la liste des lecteurs de flux dans Firefox.',
-		'obsolete_63' => 'À partir de la version 63, Firefox ne supporte plus l’ajout de services d’abonnements.',
-		'title' => 'Lecteur de flux dans Firefox',
-	),
 	'import_export' => array(
 		'export' => 'Exporter',
 		'export_labelled' => 'Exporter les articles étiquetés',

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'אתר URL',
 		'websub' => 'Instant notification with WebSub',	// TODO - Translation
 	),
-	'firefox' => array(
-		'documentation' => 'Follow the steps described <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> to add FreshRSS to Firefox feed reader list.',	// TODO - Translation
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',	// TODO - Translation
-		'title' => 'Firefox feed reader',	// TODO - Translation
-	),
 	'import_export' => array(
 		'export' => 'ייצוא',
 		'export_labelled' => 'Export your labelled articles',	// TODO - Translation

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'URL del sito',
 		'websub' => 'Notifica istantanea con WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Follow the steps described <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> to add FreshRSS to Firefox feed reader list.',	// TODO - Translation
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',	// TODO - Translation
-		'title' => 'Firefox feed reader',	// TODO - Translation
-	),
 	'import_export' => array(
 		'export' => 'Esporta',
 		'export_labelled' => 'Export your labelled articles',	// TODO - Translation

--- a/app/i18n/kr/sub.php
+++ b/app/i18n/kr/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => '웹사이트 URL',
 		'websub' => 'WebSub을 사용한 즉시 알림',
 	),
-	'firefox' => array(
-		'documentation' => 'FreshRSS를 Firefox 피드 리더에 추가하기 위해서는 <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">여기</a>의 설명을 따르세요.',
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',	// TODO - Translation
-		'title' => 'Firefox 피드 리더',
-	),
 	'import_export' => array(
 		'export' => '내보내기',
 		'export_labelled' => '라벨이 표시된 글들 내보내기',

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Website-url',
 		'websub' => 'Directe notificaties met WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Volg de stappen die <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">hier</a> beschreven worden om FreshRSS aan de Firefox-nieuwslezerlijst toe te voegen.',
-		'obsolete_63' => 'Vanaf versie 63 en nieuwer, heeft Firefox de mogelijkheid om zelf niewslezers toe te voegen verwijderd voor online diensten.',
-		'title' => 'Firefox-nieuwslezer',
-	),
 	'import_export' => array(
 		'export' => 'Exporteer',
 		'export_labelled' => 'Exporteer gelabelde artikels',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'URL del site',
 		'websub' => 'Notificaciones instantáneas amb WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Seguissètz las etapas descrichas <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">aquí</a> per ajustar FreshRSS a la lista dels lectors de flux de Firefox.',
-		'obsolete_63' => 'A partir de la version 63 e las seguentas, Firefox permet pas mai d’ajustar vòstres pròpris servicis d’abonament.',
-		'title' => 'Lector de flux de Firefox',
-	),
 	'import_export' => array(
 		'export' => 'Exportar',
 		'export_labelled' => 'Exportar los articles etiquetats',

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Adres strony',
 		'websub' => 'Instant notification with WebSub',	// TODO - Translation
 	),
-	'firefox' => array(
-		'documentation' => 'Wykonaj kroki opisane <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">tutaj</a>, by dodać FreshRSS do listy czytników kanałów w przeglądarce Firefox.',
-		'obsolete_63' => 'Możliwość dodawania własnych serwisów subskrypcji kanałów, które nie są osobnymi programami, została usunięta w Firefoksie 63.',
-		'title' => 'Czytnik kanałów w Firefoksie',
-	),
 	'import_export' => array(
 		'export' => 'Eksport',
 		'export_labelled' => 'Eksportuj wiadomości z etykietami',

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'URL do site',
 		'websub' => 'Notificação instantânea com WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Siga as instruções descritas em <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">here</a> para adicionar o FreshRSS para o seu leitor de Feed do Firefox.',
-		'obsolete_63' => 'A partir da versão 63, o Firefox removeu a capacidade de adicionar seus próprios serviços de assinatura que não são programas autônomos.',
-		'title' => 'Leitor de feed do Firefox',
-	),
 	'import_export' => array(
 		'export' => 'Exportar',
 		'export_labelled' => 'Exportar seus artigos etiquetados',

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'URL сайта',
 		'websub' => 'Моментальные оповещения посредством WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Выполните шаги, описанные <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">здесь</a>, чтобы добавить FreshRSS в список читалок лент Firefox.',
-		'obsolete_63' => 'Начиная с версии 63, Firefox убрал возможность добавлять собственные сервисы подписок, которые не являются отдельными программами.',
-		'title' => 'Читалка лент Firefox',
-	),
 	'import_export' => array(
 		'export' => 'Экспорт',
 		'export_labelled' => 'Экспортировать ваши помеченные статьи',

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Odkaz webovej stránky',
 		'websub' => 'Okamžité oznámenia cez WebSub',
 	),
-	'firefox' => array(
-		'documentation' => 'Pridajte RSS kanály do Firefoxu <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">pomocou tohto návodu</a>.',
-		'obsolete_63' => 'From version 63 and onwards, Firefox has removed the ability to add your own subscription services that are not standalone programs.',	// TODO - Translation
-		'title' => 'RSS čítačka vo Firefoxe',
-	),
 	'import_export' => array(
 		'export' => 'Exportovať',
 		'export_labelled' => 'Exportovať vaše označené články',

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => 'Site URL',
 		'websub' => 'WebSub ile anlık bildirim',
 	),
-	'firefox' => array(
-		'documentation' => 'FreshRSS\'i Firefox akış okuma listesine eklemek için <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">buradaki</a> adımları takip edin.',
-		'obsolete_63' => 'Sürüm 63 itibari ile Firefox bağımsız uygulamaların aboneliklerinize olan izni kaldırdı.',
-		'title' => 'Firefox akış okuyucu',
-	),
 	'import_export' => array(
 		'export' => 'Dışa aktar',
 		'export_labelled' => 'Etiketli makaleleri dışarı aktar',

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -96,11 +96,6 @@ return array(
 		'website' => '网站地址',
 		'websub' => 'WebSub 即时通知',
 	),
-	'firefox' => array(
-		'documentation' => '按照 <a href="https://developer.mozilla.org/en-US/Firefox/Releases/2/Adding_feed_readers_to_Firefox#Adding_a_new_feed_reader_manually">这里</a> 描述的步骤可将 FreshRSS 添加到火狐阅读器列表',
-		'obsolete_63' => '从火狐63版本开始取消了添加自己非独立程序的订阅服务功能',
-		'title' => '火狐 RSS 阅读器',
-	),
 	'import_export' => array(
 		'export' => '导出',
 		'export_labelled' => '导出有标签的文章',

--- a/app/views/subscription/bookmarklet.phtml
+++ b/app/views/subscription/bookmarklet.phtml
@@ -11,13 +11,6 @@
 		Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss='+encodeURIComponent(url);})();"><?= _t('sub.bookmarklet.label') ?></a></p>
 	<?= _t('sub.bookmarklet.documentation') ?>
 
-	<h2><?= _t('sub.firefox.title') ?></h2>
-	<p class="alert alert-warn">
-		<?= _t('sub.firefox.obsolete_63', $this->default_category->name()) ?>
-	</p>
-	<p><?= _t('sub.firefox.documentation') ?></p>
-	<kbd>browser.contentHandlers.types.number.uri → <?= Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss=%s</kbd>
-
 	<h2><?= _t('sub.api.title') ?></h2>
 	<p><?= _t('sub.api.documentation') ?></p>
 	<kbd><?= Minz_Url::display(array('c' => 'feed', 'a' => 'add'), 'html', true) ?>&amp;url_rss=%s</kbd>


### PR DESCRIPTION
Closes #3820

after:
![grafik](https://user-images.githubusercontent.com/1645099/131907303-8c735a30-e10e-4497-b7eb-ec4ff6c0e2b5.png)


Changes proposed in this pull request:
- delete paragraph
- delete i18n

How to test the feature manually:
1. go to subscription tools page
2. firefox paragraph deleted

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
