### PR TITLE
Fix: form group lines without an input

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -107,7 +107,16 @@ form th {
 
 .form-group .group-controls {
 	min-height: 25px;
-	padding: 5px 0;
+	padding: 10px 0;
+}
+
+.form-group .group-controls label {
+	padding: 0;
+}
+
+.form-group .group-controls input,
+.form-group .group-controls select {
+	margin: -5px 0;
 }
 
 /*=== Buttons */

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -107,7 +107,16 @@ form th {
 
 .form-group .group-controls {
 	min-height: 25px;
-	padding: 5px 0;
+	padding: 10px 0;
+}
+
+.form-group .group-controls label {
+	padding: 0;
+}
+
+.form-group .group-controls input,
+.form-group .group-controls select {
+	margin: -5px 0;
 }
 
 /*=== Buttons */


### PR DESCRIPTION
before:
![grafik](https://user-images.githubusercontent.com/1645099/132109542-cbb58000-ff80-4531-8c71-eee3531be91d.png)


![grafik](https://user-images.githubusercontent.com/1645099/132109535-cbd963fd-9261-44a0-958a-58dddbe66894.png)


after:
![grafik](https://user-images.githubusercontent.com/1645099/132109560-92146308-8763-41f9-a607-035caa9f290a.png)



Changes proposed in this pull request:
- CSS

How to test the feature manually:
1. use Theme "Origine"
2. look through the settings forms


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
