### PR TITLE
Remove: Show cog wheel icon on hover in the settings

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -470,16 +470,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1106,11 +1096,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -470,16 +470,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1106,11 +1096,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Ansum/_components.scss
+++ b/p/themes/Ansum/_components.scss
@@ -233,7 +233,6 @@
 				width: 1.75rem;
 				height: 1.75rem;
 				border-radius: 2px;
-				visibility: visible;
 				margin-right: 0.5rem;
 
 				.icon {
@@ -246,10 +245,6 @@
 					background: url("icons/cog-white.svg") no-repeat 4px 4px $main-first;
 				}
 			}
-		}
-
-		.configure {
-			visibility: hidden;
 		}
 
 		form {
@@ -296,7 +291,6 @@
 				width: 1.75rem;
 				height: 1.75rem;
 				border-radius: 2px;
-				visibility: hidden;
 				margin-right: 0.5rem;
 
 				.icon {
@@ -311,9 +305,6 @@
 				}
 			}
 
-			&:hover .configure {
-				visibility: visible;
-			}
 		}
 
 		.item:last-child {

--- a/p/themes/Ansum/_mobile.scss
+++ b/p/themes/Ansum/_mobile.scss
@@ -41,11 +41,6 @@
 		text-align: left;
 	}
 
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
-	}
-
 	.aside {
 
 		@include transition(all, 0.2s, ease-in-out);

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -402,7 +402,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: visible;
 	margin-right: 0.5rem;
 }
 .box .box-title:hover .configure .icon {
@@ -412,9 +411,6 @@ form th {
 }
 .box .box-title:hover .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #ca7227;
-}
-.box .box-title .configure {
-	visibility: hidden;
 }
 .box .box-title form input {
 	width: 85%;
@@ -449,7 +445,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: hidden;
 	margin-right: 0.5rem;
 }
 .box .box-content .item .configure .icon {
@@ -459,9 +454,6 @@ form th {
 }
 .box .box-content .item .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #ca7227;
-}
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 .box .box-content .item:last-child {
 	border-bottom: none;
@@ -1475,11 +1467,6 @@ form th {
 
 	.form-group .group-name {
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -402,7 +402,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: visible;
 	margin-left: 0.5rem;
 }
 .box .box-title:hover .configure .icon {
@@ -412,9 +411,6 @@ form th {
 }
 .box .box-title:hover .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #ca7227;
-}
-.box .box-title .configure {
-	visibility: hidden;
 }
 .box .box-title form input {
 	width: 85%;
@@ -449,7 +445,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: hidden;
 	margin-left: 0.5rem;
 }
 .box .box-content .item .configure .icon {
@@ -459,9 +454,6 @@ form th {
 }
 .box .box-content .item .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #ca7227;
-}
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 .box .box-content .item:last-child {
 	border-bottom: none;
@@ -1475,11 +1467,6 @@ form th {
 
 	.form-group .group-name {
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -547,16 +547,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1268,11 +1258,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.header {

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -547,16 +547,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1268,11 +1258,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.header {

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -499,16 +499,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1134,11 +1124,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -499,16 +499,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1134,11 +1124,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -500,21 +500,11 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
 .box .box-title .configure .icon,
 .box .box-content .item .configure .icon {
 	vertical-align: middle;
 	background-color: #95a5a6;
 	border-radius: 3px;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 
 /*=== Tree */
@@ -1122,11 +1112,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -500,21 +500,11 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
 .box .box-title .configure .icon,
 .box .box-content .item .configure .icon {
 	vertical-align: middle;
 	background-color: #95a5a6;
 	border-radius: 3px;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 
 /*=== Tree */
@@ -1122,11 +1112,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Mapco/_components.scss
+++ b/p/themes/Mapco/_components.scss
@@ -233,7 +233,6 @@
 				width: 1.75rem;
 				height: 1.75rem;
 				border-radius: 2px;
-				visibility: visible;
 				margin-right: 0.5rem;
 
 				.icon {
@@ -248,9 +247,6 @@
 			}
 		}
 
-		.configure {
-			visibility: hidden;
-		}
 
 		form {
 			input {
@@ -296,7 +292,6 @@
 				width: 1.75rem;
 				height: 1.75rem;
 				border-radius: 2px;
-				visibility: hidden;
 				margin-right: 0.5rem;
 
 				.icon {
@@ -311,9 +306,6 @@
 				}
 			}
 
-			&:hover .configure {
-				visibility: visible;
-			}
 		}
 
 		.item:last-child {

--- a/p/themes/Mapco/_mobile.scss
+++ b/p/themes/Mapco/_mobile.scss
@@ -40,11 +40,6 @@
 		text-align: left;
 	}
 
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
-	}
-
 	.aside {
 
 		@include transition(all, 0.2s, ease-in-out);

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -404,7 +404,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: visible;
 	margin-right: 0.5rem;
 }
 .box .box-title:hover .configure .icon {
@@ -414,9 +413,6 @@ form th {
 }
 .box .box-title:hover .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #36c;
-}
-.box .box-title .configure {
-	visibility: hidden;
 }
 .box .box-title form input {
 	width: 85%;
@@ -451,7 +447,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: hidden;
 	margin-right: 0.5rem;
 }
 .box .box-content .item .configure .icon {
@@ -461,9 +456,6 @@ form th {
 }
 .box .box-content .item .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #36c;
-}
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 .box .box-content .item:last-child {
 	border-bottom: none;
@@ -1483,11 +1475,6 @@ form th {
 
 	.form-group .group-name {
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -404,7 +404,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: visible;
 	margin-left: 0.5rem;
 }
 .box .box-title:hover .configure .icon {
@@ -414,9 +413,6 @@ form th {
 }
 .box .box-title:hover .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #36c;
-}
-.box .box-title .configure {
-	visibility: hidden;
 }
 .box .box-title form input {
 	width: 85%;
@@ -451,7 +447,6 @@ form th {
 	width: 1.75rem;
 	height: 1.75rem;
 	border-radius: 2px;
-	visibility: hidden;
 	margin-left: 0.5rem;
 }
 .box .box-content .item .configure .icon {
@@ -461,9 +456,6 @@ form th {
 }
 .box .box-content .item .configure:hover {
 	background: url("icons/cog-white.svg") no-repeat 4px 4px #36c;
-}
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 .box .box-content .item:last-child {
 	border-bottom: none;
@@ -1483,11 +1475,6 @@ form th {
 
 	.form-group .group-name {
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -534,16 +534,6 @@ a.btn,
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1213,11 +1203,6 @@ a.btn,
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -534,16 +534,6 @@ a.btn,
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1213,11 +1203,6 @@ a.btn,
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -519,16 +519,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1141,11 +1131,6 @@ a.btn {
 		padding-bottom: 0;
 
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -519,16 +519,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1141,11 +1131,6 @@ a.btn {
 		padding-bottom: 0;
 
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -491,16 +491,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1128,11 +1118,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -491,16 +491,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1128,11 +1118,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.aside {

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -545,16 +545,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1257,11 +1247,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.header {

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -545,16 +545,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-title .configure,
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-title:hover .configure,
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;
@@ -1257,11 +1247,6 @@ a.btn {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.header {

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -469,15 +469,9 @@ form th {
 	font-size: 0.9rem;
 	line-height: 2.5em;
 }
-.box .box-content .item .configure {
-	visibility: hidden;
-}
 .box .box-content .item .configure .icon {
 	vertical-align: middle;
 	background-color: #e3e3e3;
-}
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 .box.category .box-title .title {
 	font-weight: normal;
@@ -920,12 +914,7 @@ form th {
 		padding-bottom: 0;
 		text-align: left;
 	}
-
-	.box .box-title .configure,
-.box .box-content .item .configure {
-		visibility: visible;
-	}
-
+	
 	.dropdown-header, .dropdown-menu > .item {
 		padding: 12px;
 	}

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -914,7 +914,7 @@ form th {
 		padding-bottom: 0;
 		text-align: left;
 	}
-	
+
 	.dropdown-header, .dropdown-menu > .item {
 		padding: 12px;
 	}

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -469,15 +469,9 @@ form th {
 	font-size: 0.9rem;
 	line-height: 2.5em;
 }
-.box .box-content .item .configure {
-	visibility: hidden;
-}
 .box .box-content .item .configure .icon {
 	vertical-align: middle;
 	background-color: #e3e3e3;
-}
-.box .box-content .item:hover .configure {
-	visibility: visible;
 }
 .box.category .box-title .title {
 	font-weight: normal;
@@ -919,11 +913,6 @@ form th {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: right;
-	}
-
-	.box .box-title .configure,
-.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.dropdown-header, .dropdown-menu > .item {

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -587,16 +587,10 @@ form {
 			line-height: 2.5em;
 
 			.configure {
-				visibility: hidden;
-
 				.icon {
 					vertical-align: middle;
 					background-color: darken( $color_light, 10%);
 				}
-			}
-
-			&:hover .configure {
-				visibility: visible;
 			}
 		}
 	}
@@ -1148,11 +1142,6 @@ form {
 	.form-group .group-name {
 		padding-bottom: 0;
 		text-align: left;
-	}
-
-	.box .box-title .configure,
-	.box .box-content .item .configure {
-		visibility: visible;
 	}
 
 	.dropdown-header, .dropdown-menu > .item {

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -390,14 +390,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -390,14 +390,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.box .box-content .item .configure {
-	visibility: hidden;
-}
-
-.box .box-content .item:hover .configure {
-	visibility: visible;
-}
-
 /*=== Tree */
 .tree {
 	margin: 10px 0;


### PR DESCRIPTION
Sub PR of #3827

Changes proposed in this pull request:
- the cog wheel icon is now always visible in the seeting (instead of on hover)

How to test the feature manually:
see
![grafik](https://user-images.githubusercontent.com/1645099/132392926-8dbec008-6107-46d4-bab9-aeaeb3d868ba.png)

The cog wheel icon in the category aside bar is not affected (still: gets visible while hovering)
![grafik](https://user-images.githubusercontent.com/1645099/132393043-180a6001-a0fb-4c2e-a0fc-136f9447dc2a.png)


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested

I already checked all themes