### PR TITLE
fixed: margin around <figure>

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -96,6 +96,15 @@ img.favicon {
 	vertical-align: middle;
 }
 
+.content.thin figure,
+.content.medium figure {
+	margin: 8px 0px;
+}
+
+.content figure figcaption{
+	font-style: italic;
+}
+
 .feed.mute::before {
 	content: '🔇';
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -101,7 +101,7 @@ img.favicon {
 	margin: 8px 0px;
 }
 
-.content figure figcaption{
+.content figure figcaption {
 	font-style: italic;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -96,6 +96,15 @@ img.favicon {
 	vertical-align: middle;
 }
 
+.content.thin figure,
+.content.medium figure {
+	margin: 8px 0px;
+}
+
+.content figure figcaption{
+	font-style: italic;
+}
+
 .feed.mute::before {
 	content: '🔇';
 }

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -101,7 +101,7 @@ img.favicon {
 	margin: 8px 0px;
 }
 
-.content figure figcaption{
+.content figure figcaption {
 	font-style: italic;
 }
 


### PR DESCRIPTION
Closes #3732

Changes proposed in this pull request:
- no/less margin around `<figure>`, when thin/narrow or medium content width
- italics font in the `<figcaption>`


How to test the feature manually:
1. find a fee with `<figure>` inside

before:
![grafik](https://user-images.githubusercontent.com/1645099/132402879-f03eef53-c6df-4286-86af-27191fcd43e7.png)

after:
![grafik](https://user-images.githubusercontent.com/1645099/132402827-925d09e3-0820-4cbd-bee7-6314d89f8720.png)


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
