### PR TITLE
i18n: DE - switched from informal designation to formal

### DIFF
--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -154,7 +154,7 @@ return array(
 			'number' => 'Eingeloggt bleiben für',
 		),
 		'force_email_validation' => 'E-Mail Adressvalidierung erzwingen',
-		'instance-name' => 'Dein Reader Name',
+		'instance-name' => 'Bezeichnung',
 		'max-categories' => 'Anzahl erlaubter Kategorien pro Benutzer',
 		'max-feeds' => 'Anzahl erlaubter Feeds pro Benutzer',
 		'registration' => array(

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -60,7 +60,7 @@ return array(
 		'api' => 'API-Verwaltung',
 		'delete' => array(
 			'_' => 'Accountlöschung',
-			'warn' => 'Dein Account und alle damit bezogenen Daten werden gelöscht.',
+			'warn' => 'Ihr Account und alle damit bezogenen Daten werden gelöscht.',
 		),
 		'email' => 'E-Mail-Adresse',
 		'password_api' => 'Passwort-API<br /><small>(z.B. für mobile Anwendungen)</small>',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -60,7 +60,7 @@ return array(
 		'api' => 'API-Verwaltung',
 		'delete' => array(
 			'_' => 'Accountlöschung',
-			'warn' => 'Ihr Account und alle damit bezogenen Daten werden gelöscht.',
+			'warn' => 'Dieser Account und alle damit bezogenen Daten werden gelöscht.',
 		),
 		'email' => 'E-Mail-Adresse',
 		'password_api' => 'Passwort-API<br /><small>(z.B. für mobile Anwendungen)</small>',


### PR DESCRIPTION
In German we have 2 types of "you":
- informal ("Du")
- formal ("Sie")

The German translation uses in common the formal designation, except 2 pieces of labels, that are now fixed too

Changes proposed in this pull request:
- i18n/de


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested