### PR TITLE
Detect enclosure as images using file extension

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -411,7 +411,7 @@ class FreshRSS_Feed extends Minz_Model {
 						$width = $enclosure->get_width();
 						$length = $enclosure->get_length();
 						if ($medium === 'image' || strpos($mime, 'image') === 0 ||
-							($mime == '' && $length == null && ($width != 0 || $height != 0 || preg_match('/[.](gif|jpe?g|png|svg)$/i', $elink)))) {
+							($mime == '' && $length == null && ($width != 0 || $height != 0 || preg_match('/[.](avif|gif|jpe?g|png|svg|webp)$/i', $elink)))) {
 							$enclosureContent .= '<p class="enclosure-content"><img src="' . $elink . '" alt="" /></p>';
 						} elseif ($medium === 'audio' || strpos($mime, 'audio') === 0) {
 							$enclosureContent .= '<p class="enclosure-content"><audio preload="none" src="' . $elink

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -410,7 +410,8 @@ class FreshRSS_Feed extends Minz_Model {
 						$height = $enclosure->get_height();
 						$width = $enclosure->get_width();
 						$length = $enclosure->get_length();
-						if ($medium === 'image' || strpos($mime, 'image') === 0 || ($mime == '' && $length == null && ($width != 0 || $height != 0))) {
+						if ($medium === 'image' || strpos($mime, 'image') === 0 ||
+							($mime == '' && $length == null && ($width != 0 || $height != 0 || preg_match('/[.](gif|jpe?g|png|svg)$/i', $elink)))) {
 							$enclosureContent .= '<p class="enclosure-content"><img src="' . $elink . '" alt="" /></p>';
 						} elseif ($medium === 'audio' || strpos($mime, 'audio') === 0) {
 							$enclosureContent .= '<p class="enclosure-content"><audio preload="none" src="' . $elink


### PR DESCRIPTION
Support e.g. https://www.sciencesetavenir.fr/atom.xml , which does not include any type hint:

```html
<link rel="enclosure" href="https://example.net/assets/img/ZZZ.jpg" title="YYY" />
```

Useful for https://github.com/FreshRSS/FreshRSS/pull/3805