### PR TITLE
Fix issue with mark-all-as-read-button in anonym. mode

### DIFF
--- a/app/views/helpers/pagination.phtml
+++ b/app/views/helpers/pagination.phtml
@@ -17,15 +17,19 @@
 	);
 ?>
 
+<?php
+$hasAccess = FreshRSS_Auth::hasAccess();
+if ($url_mark_read && $hasAccess) { ?>
 <form id="mark-read-pagination" method="post">
 <input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+<?php }?>
 <ul class="pagination">
 	<li class="item pager-next">
 	<?php if (FreshRSS_Context::$next_id) { ?>
 		<a id="load_more" href="<?= Minz_Url::display($url_next) ?>">
 			<?= _t('gen.pagination.load_more') ?>
 		</a>
-	<?php } elseif ($url_mark_read && FreshRSS_Auth::hasAccess()) { ?>
+	<?php } elseif ($url_mark_read && $hasAccess) { ?>
 		<button id="bigMarkAsRead"
 			class="as-link <?= FreshRSS_Context::$user_conf->reading_confirm ? 'confirm" disabled="disabled' : '' ?>"
 			form="mark-read-pagination"
@@ -42,4 +46,6 @@
 	<?php } ?>
 	</li>
 </ul>
+<?php if ($url_mark_read && $hasAccess) { ?>
 </form>
+<?php }?>

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1547,7 +1547,7 @@ function load_more_posts() {
 
 		const bigMarkAsRead = document.getElementById('bigMarkAsRead');
 		const readAll = document.querySelector('#nav_menu_read_all .read_all');
-		if (bigMarkAsRead.tagName.toLowerCase == 'button' && readAll) {
+		if (readAll && bigMarkAsRead && bigMarkAsRead.formAction) {
 			if (context.display_order === 'ASC') {
 				readAll.formAction = bigMarkAsRead.formAction;
 			} else {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1532,11 +1532,12 @@ function load_more_posts() {
 		formPagination.replaceChild(paginationNew, paginationOld);
 
 		const bigMarkAsRead = document.getElementById('bigMarkAsRead');
-		if (bigMarkAsRead) {
+		const readAll = document.querySelector('#nav_menu_read_all .read_all');
+		if (bigMarkAsRead.tagName.toLowerCase == 'button' && readAll) {
 			if (context.display_order === 'ASC') {
-				document.querySelector('#nav_menu_read_all .read_all').formAction = bigMarkAsRead.formAction;
+				readAll.formAction = bigMarkAsRead.formAction;
 			} else {
-				bigMarkAsRead.formAction = document.querySelector('#nav_menu_read_all .read_all').formAction;
+				bigMarkAsRead.formAction = readAll.formAction;
 			}
 		}
 


### PR DESCRIPTION
Improves PR #3871
Reference to #3897

Changes proposed in this pull request:
- in anonym. mode there is no mark-all-as-read-button, so the `<form>` is not needed
- while onload the page the JavaScript searches for the mark-all-as-read-button. In anonym. mode it throw an error (as in #3897 below described.


How to test the feature manually:
1. user is not logged in
2. no error in the console.


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
