### PR TITLE
Fix: Subscription management: drag&drop insert marker broken

### DIFF
--- a/p/scripts/category.js
+++ b/p/scripts/category.js
@@ -74,7 +74,7 @@ function init_draggable() {
 		}
 	};
 
-	dropSection.onddragleave = function (ev) {
+	dropSection.ondragleave = function (ev) {
 		const li = ev.target.closest ? ev.target.closest(dropzone) : null;
 		if (li) {
 			const scroll_top = document.documentElement.scrollTop;


### PR DESCRIPTION
References #3892

Before:
While dragging the insert marker does not disappear when you drag to next element. The insert marker stay also after dropping
![grafik](https://user-images.githubusercontent.com/1645099/139535307-7af162c0-092e-4eb1-be1f-4930f44b6d38.png)

After:
fixed. Only one actual insert marker. The insert marker disappear after dropping

Changes proposed in this pull request:
- fix a typo in event name


How to test the feature manually:
1. subscription management page
2. drag and drop a feed
3. watch the insert marker

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
