### PR TITLE
Fix label management

### DIFF
--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -90,7 +90,7 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 
 		$name = Minz_Request::param('name');
 		$tagDAO = FreshRSS_Factory::createTagDao();
-		if (null === $tagDAO->searchByName($name) && strlen($name) > 0) {
+		if (strlen($name) > 0 && null === $tagDAO->searchByName($name)) {
 			$tagDAO->addTag(['name' => $name]);
 			Minz_Request::good(_t('feedback.tag.created', $name), ['c' => 'tag', 'a' => 'index'], true);
 		}

--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -106,13 +106,19 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 		$targetName = Minz_Request::param('name');
 		$sourceId = Minz_Request::param('id_tag');
 
-		$tagDAO = FreshRSS_Factory::createTagDao();
+		if ($targetName == '' || $sourceId == '') {
+			return Minz_Error::error(400);
+		}
 
-		$sourceName = $tagDAO->searchById($sourceId)->name();
+		$tagDAO = FreshRSS_Factory::createTagDao();
+		$sourceTag = $tagDAO->searchById($sourceId);
+		$sourceName = $sourceTag == null ? null : $sourceTag->name();
 		$targetTag = $tagDAO->searchByName($targetName);
-		if (null === $targetTag) {
+		if ($targetTag == null) {
+			// There is no existing tag with the same target name
 			$tagDAO->updateTag($sourceId, ['name' => $targetName]);
 		} else {
+			// There is an existing tag with the same target name
 			$tagDAO->updateEntryTag($sourceId, $targetTag->id());
 			$tagDAO->deleteTag($sourceId);
 		}

--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -90,7 +90,7 @@ class FreshRSS_tag_Controller extends Minz_ActionController {
 
 		$name = Minz_Request::param('name');
 		$tagDAO = FreshRSS_Factory::createTagDao();
-		if (null === $tagDAO->searchByName($name)) {
+		if (null === $tagDAO->searchByName($name) && strlen($name) > 0) {
 			$tagDAO->addTag(['name' => $name]);
 			Minz_Request::good(_t('feedback.tag.created', $name), ['c' => 'tag', 'a' => 'index'], true);
 		}

--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -25,12 +25,17 @@
 	</form>
 
 	<h2><?= _t('sub.title.rename_label') ?></h2>
+	<?php
+	$disabled = '';
+	if (count($this->tags) < 1) {
+		$disabled = ' disabled';
+	} ?>
 	<form id="rename_tag" method="post" action="<?= _url('tag', 'rename') ?>" autocomplete="off">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<div class="form-group">
 			<label class="group-name" for="id_tag"><?= _t('sub.tag.old_name') ?></label>
 			<div class="group-controls">
-				<select name="id_tag" id="id_tag">
+				<select name="id_tag" id="id_tag"<?= $disabled?>>
 					<?php foreach ($this->tags as $tag): ?>
 						<option value="<?= $tag->id() ?>"><?= $tag->name() ?></option>
 					<?php endforeach; ?>
@@ -40,13 +45,15 @@
 		<div class="form-group">
 			<label class="group-name" for="rename_new_name"><?= _t('sub.tag.new_name') ?></label>
 			<div class="group-controls">
-				<input id="rename_new_name" name="name" type="text" autocomplete="off"/>
+				<input id="rename_new_name" name="name" type="text" autocomplete="off"<?= $disabled?>/>
 			</div>
 		</div>
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
+				<?php if (!$disabled) { ?>
 				<button type="submit" class="btn btn-attention confirm"><?= _t('gen.action.rename') ?></button>
+				<?php } ?>
 			</div>
 		</div>
 	</form>
@@ -57,7 +64,7 @@
 		<div class="form-group">
 			<label class="group-name" for="id_tag_delete"><?= _t('sub.tag.name') ?></label>
 			<div class="group-controls">
-				<select name="id_tag" id="id_tag_delete">
+				<select name="id_tag" id="id_tag_delete"<?= $disabled?>>
 					<?php foreach ($this->tags as $tag): ?>
 						<option value="<?= $tag->id() ?>"><?= $tag->name() ?></option>
 					<?php endforeach; ?>
@@ -67,7 +74,9 @@
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
+				<?php if (!$disabled) { ?>
 				<button type="submit" class="btn btn-attention confirm"><?= _t('gen.action.remove') ?></button>
+				<?php } ?>
 			</div>
 		</div>
 	</form>

--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -13,7 +13,7 @@
 		<div class="form-group">
 			<label class="group-name" for="new_label_name"><?= _t('sub.tag.name') ?></label>
 			<div class="group-controls">
-				<input id="new_label_name" name="name" type="text" autocomplete="off"/>
+				<input id="new_label_name" name="name" type="text" autocomplete="off" required/>
 			</div>
 		</div>
 

--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -13,7 +13,7 @@
 		<div class="form-group">
 			<label class="group-name" for="new_label_name"><?= _t('sub.tag.name') ?></label>
 			<div class="group-controls">
-				<input id="new_label_name" name="name" type="text" autocomplete="off" required/>
+				<input id="new_label_name" name="name" type="text" autocomplete="off" required="required" />
 			</div>
 		</div>
 

--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -28,7 +28,7 @@
 	<?php
 	$disabled = '';
 	if (count($this->tags) < 1) {
-		$disabled = ' disabled';
+		$disabled = ' disabled="disabled"';
 	} ?>
 	<form id="rename_tag" method="post" action="<?= _url('tag', 'rename') ?>" autocomplete="off">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />


### PR DESCRIPTION
Closes #3815

After:
![grafik](https://user-images.githubusercontent.com/1645099/140299328-1a3382c0-a56d-4f64-8f79-69fd544d50c3.png)


Changes proposed in this pull request:
- when no labels: rename and remove inputs are disabled and buttons are hidden

How to test the feature manually:

1. go to label management page
2. delete all labels
3. disabled rename and remove forms

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
