### PR TITLE
Improve install routine: database password input with "show password" button

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -588,7 +588,7 @@ function printStep3() {
 				<div class="stick">
 					<input type="password" id="passwordPlain" name="passwordPlain" pattern=".{7,}"
 						autocomplete="off" <?= $auth_type === 'form' ? ' required="required"' : '' ?> tabindex="5" />
-					<a class="btn toggle-password" data-toggle="passwordPlain"><?= FreshRSS_Themes::icon('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="passwordPlain"><?= FreshRSS_Themes::icon('key') ?></button>
 				</div>
 				<p class="help"><?= _i('help') ?> <?= _t('install.auth.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>

--- a/app/install.php
+++ b/app/install.php
@@ -503,8 +503,11 @@ function printStep2() {
 		<div class="form-group">
 			<label class="group-name" for="pass"><?= _t('install.bdd.password') ?></label>
 			<div class="group-controls">
-				<input type="password" id="pass" name="pass" value="<?=
-					isset($_SESSION['bd_password']) ? $_SESSION['bd_password'] : '' ?>" tabindex="4" autocomplete="off" />
+				<div class="stick">
+					<input type="password" id="pass" name="pass" value="<?=
+						isset($_SESSION['bd_password']) ? $_SESSION['bd_password'] : '' ?>" tabindex="4" autocomplete="off" />
+					<a class="btn toggle-password" data-toggle="pass" tabindex="5"><?= FreshRSS_Themes::icon('key') ?></a>
+				</div>
 			</div>
 		</div>
 
@@ -512,7 +515,7 @@ function printStep2() {
 			<label class="group-name" for="base"><?= _t('install.bdd') ?></label>
 			<div class="group-controls">
 				<input type="text" id="base" name="base" maxlength="64" pattern="[0-9A-Za-z_-]{1,64}" value="<?=
-					isset($_SESSION['bd_base']) ? $_SESSION['bd_base'] : '' ?>" tabindex="5" />
+					isset($_SESSION['bd_base']) ? $_SESSION['bd_base'] : '' ?>" tabindex="6" />
 			</div>
 		</div>
 
@@ -520,17 +523,17 @@ function printStep2() {
 			<label class="group-name" for="prefix"><?= _t('install.bdd.prefix') ?></label>
 			<div class="group-controls">
 				<input type="text" id="prefix" name="prefix" maxlength="16" pattern="[0-9A-Za-z_]{1,16}" value="<?=
-					isset($_SESSION['bd_prefix']) ? $_SESSION['bd_prefix'] : $system_default_config->db['prefix'] ?>" tabindex="6" />
+					isset($_SESSION['bd_prefix']) ? $_SESSION['bd_prefix'] : $system_default_config->db['prefix'] ?>" tabindex="7" />
 			</div>
 		</div>
 		</div>
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button type="submit" class="btn btn-important" tabindex="7" ><?= _t('gen.action.submit') ?></button>
-				<button type="reset" class="btn" tabindex="8" ><?= _t('gen.action.cancel') ?></button>
+				<button type="submit" class="btn btn-important" tabindex="8" ><?= _t('gen.action.submit') ?></button>
+				<button type="reset" class="btn" tabindex="9" ><?= _t('gen.action.cancel') ?></button>
 				<?php if ($s2['all'] == 'ok') { ?>
-				<a class="btn btn-important next-step" href="?step=3" tabindex="9" ><?= _t('install.action.next_step') ?></a>
+				<a class="btn btn-important next-step" href="?step=3" tabindex="10" ><?= _t('install.action.next_step') ?></a>
 				<?php } ?>
 			</div>
 		</div>

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -47,7 +47,7 @@ option {
 	padding: 0 .5em;
 }
 
-input:focus, select:focus, textarea:focus, input[type="password"]:focus + a.toggle-password {
+input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggle-password {
 	color: #0062be;
 	border-color: #3bf;
 	box-shadow: 0 2px 2px #ddf inset;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -47,10 +47,11 @@ option {
 	padding: 0 .5em;
 }
 
-input:focus, select:focus, textarea:focus {
+input:focus, select:focus, textarea:focus, input[type="password"]:focus + a.toggle-password {
 	color: #0062be;
 	border-color: #3bf;
 	box-shadow: 0 2px 2px #ddf inset;
+	outline: none;
 }
 
 input:invalid, select:invalid {
@@ -114,8 +115,9 @@ form th {
 	padding: 0;
 }
 
-.form-group .group-controls input,
-.form-group .group-controls select {
+.form-group .group-controls > input,
+.form-group .group-controls > select,
+.form-group .group-controls .stick {
 	margin: -5px 0;
 }
 
@@ -163,6 +165,11 @@ form th {
 .stick .btn + .dropdown > .btn {
 	border-left: none;
 	border-radius: 0 3px 3px 0;
+}
+
+.stick .btn.toggle-password {
+	padding-top: 2px;
+	padding-bottom: 2px;
 }
 
 .btn {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -121,6 +121,11 @@ form th {
 	margin: -5px 0;
 }
 
+.form-group .group-controls .stick .btn {
+	padding-top: 2px;
+	padding-bottom: 2px;
+}
+
 /*=== Buttons */
 .stick {
 	vertical-align: middle;
@@ -165,11 +170,6 @@ form th {
 .stick .btn + .dropdown > .btn {
 	border-left: none;
 	border-radius: 0 3px 3px 0;
-}
-
-.stick .btn.toggle-password {
-	padding-top: 2px;
-	padding-bottom: 2px;
 }
 
 .btn {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -47,7 +47,7 @@ option {
 	padding: 0 .5em;
 }
 
-input:focus, select:focus, textarea:focus, input[type="password"]:focus + a.toggle-password {
+input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggle-password {
 	color: #0062be;
 	border-color: #3bf;
 	box-shadow: 0 2px 2px #ddf inset;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -47,10 +47,11 @@ option {
 	padding: 0 .5em;
 }
 
-input:focus, select:focus, textarea:focus {
+input:focus, select:focus, textarea:focus, input[type="password"]:focus + a.toggle-password {
 	color: #0062be;
 	border-color: #3bf;
 	box-shadow: 0 2px 2px #ddf inset;
+	outline: none;
 }
 
 input:invalid, select:invalid {
@@ -114,9 +115,15 @@ form th {
 	padding: 0;
 }
 
-.form-group .group-controls input,
-.form-group .group-controls select {
+.form-group .group-controls > input,
+.form-group .group-controls > select,
+.form-group .group-controls .stick {
 	margin: -5px 0;
+}
+
+.form-group .group-controls .stick .btn {
+	padding-top: 2px;
+	padding-bottom: 2px;
 }
 
 /*=== Buttons */


### PR DESCRIPTION
before:
![grafik](https://user-images.githubusercontent.com/1645099/140612993-1d44018b-6d98-4e37-b2af-9cc37d201f60.png)

after:
![grafik](https://user-images.githubusercontent.com/1645099/140613003-04b9f93e-89af-483e-9ee5-06e8a6456916.png)


How to test the feature manually:
1. install routine step 3: database configuration
2. database password: click on button shows the plain password

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] CSS: RTL