### PR TITLE
Update details.phtml

### DIFF
--- a/app/views/user/details.phtml
+++ b/app/views/user/details.phtml
@@ -59,7 +59,7 @@
 				<div class="stick">
 					<input type="password" id="newPasswordPlain" name="newPasswordPlain" autocomplete="new-password"
 						pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
-					<a class="btn toggle-password" data-toggle="password-<?= $this->username; ?>"><?= _i('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="newPasswordPlain"><?= _i('key') ?></button>
 				</div>
 				<p class="help"><?= _i('help'); ?> <?= _t('admin.user.password_format') ?></p>
 			</div>


### PR DESCRIPTION
Closes #

Manage users: details page:

The "show password" button did not work.
![grafik](https://user-images.githubusercontent.com/1645099/140820135-a8367809-dfa4-4601-9d50-f367efdb0e49.png)


Changes proposed in this pull request:
- button works now
- instead of `<a>` a real `<button>` is used (as @Frenzie prefers, see: https://github.com/FreshRSS/FreshRSS/pull/3962#discussion_r744143922)


How to test the feature manually:
1. go to "manage users" in the settings
2. chose a user
3. type something in the password input
4. click the show-password-button
5. the password is shown

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
