### PR TITLE
Improved HTML: Show password button as <button>

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -585,7 +585,7 @@ function printStep3() {
 				<div class="stick">
 					<input type="password" id="passwordPlain" name="passwordPlain" pattern=".{7,}"
 						autocomplete="off" <?= $auth_type === 'form' ? ' required="required"' : '' ?> tabindex="5" />
-					<a class="btn toggle-password" data-toggle="passwordPlain"><?= FreshRSS_Themes::icon('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="passwordPlain"><?= FreshRSS_Themes::icon('key') ?></button>
 				</div>
 				<p class="help"><?= _i('help') ?> <?= _t('install.auth.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>

--- a/app/views/auth/formLogin.phtml
+++ b/app/views/auth/formLogin.phtml
@@ -18,7 +18,7 @@
 			<label for="passwordPlain"><?= _t('gen.auth.password') ?></label>
 			<div class="stick">
 				<input type="password" id="passwordPlain" required="required" />
-				<a class="btn toggle-password" data-toggle="passwordPlain"><?= _i('key') ?></a>
+				<button type="button" class="btn toggle-password" data-toggle="passwordPlain"><?= _i('key') ?></button>
 			</div>
 			<input type="hidden" id="challenge" name="challenge" />
 			<noscript><strong><?= _t('gen.js.should_be_activated') ?></strong></noscript>

--- a/app/views/auth/register.phtml
+++ b/app/views/auth/register.phtml
@@ -34,7 +34,7 @@
 			<label for="new_user_passwordPlain"><?= _t('gen.auth.password') ?></label>
 			<div class="stick">
 				<input type="password" id="new_user_passwordPlain" name="new_user_passwordPlain" required="required" autocomplete="new-password" pattern=".{7,}" />
-				<a class="btn toggle-password" data-toggle="new_user_passwordPlain"><?= _i('key') ?></a>
+				<button type="button" class="btn toggle-password" data-toggle="new_user_passwordPlain"><?= _i('key') ?></button>
 			</div>
 			<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>
 			<p class="help"><?= _i('help') ?> <?= _t('gen.auth.password.format') ?></p>

--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -76,7 +76,7 @@
 			<div class="group-controls">
 				<div class="stick">
 					<input type="password" name="http_pass" id="http_pass" class="extend" value="<?= $auth['password'] ?>" autocomplete="new-password" />
-					<a class="btn toggle-password" data-toggle="http_user"><?= _i('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="http_user"><?= _i('key') ?></button>
 				</div>
 			</div>
 		</div>

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -143,7 +143,7 @@
 				<div class="stick">
 					<input type="password" name="http_pass_feed<?= $this->feed->id() ?>" id="http_pass_feed<?= $this->feed->id() ?>" value="<?=
 						$auth['password'] ?>" autocomplete="new-password" />
-					<a class="btn toggle-password" data-toggle="http_pass_feed<?= $this->feed->id() ?>"><?= _i('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="http_pass_feed<?= $this->feed->id() ?>"><?= _i('key') ?></button>
 				</div>
 			</div>
 		</div>

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -65,7 +65,7 @@
 				<div class="group-controls">
 					<div class="stick">
 						<input id="http_pass" name="http_pass" type="password" value="" autocomplete="new-password" />
-						<a class="btn toggle-password" data-toggle="http_pass"><?= _i('key') ?></a>
+						<button type="button" class="btn toggle-password" data-toggle="http_pass"><?= _i('key') ?></button>
 					</div>
 				</div>
 			</div>

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -60,7 +60,7 @@
 			<div class="group-controls">
 				<div class="stick">
 					<input type="password" id="new_user_passwordPlain" name="new_user_passwordPlain" autocomplete="new-password" pattern=".{7,}" />
-					<a class="btn toggle-password" data-toggle="new_user_passwordPlain"><?= _i('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="new_user_passwordPlain"><?= _i('key') ?></button>
 				</div>
 				<p class="help"><?= _i('help') ?> <?= _t('admin.user.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>

--- a/app/views/user/profile.phtml
+++ b/app/views/user/profile.phtml
@@ -44,7 +44,7 @@
 				<div class="stick">
 					<input type="password" id="newPasswordPlain" name="newPasswordPlain" autocomplete="new-password"
 						pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
-					<a class="btn toggle-password" data-toggle="newPasswordPlain"><?= _i('key') ?></a>
+					<button type="button" class="btn toggle-password" data-toggle="newPasswordPlain"><?= _i('key') ?></button>
 				</div>
 				<p class="help"><?= _i('help') ?> <?= _t('conf.profile.password_format') ?></p>
 				<noscript><b><?= _t('gen.js.should_be_activated') ?></b></noscript>
@@ -84,7 +84,7 @@
 					<div class="stick">
 						<input type="password" id="apiPasswordPlain" name="apiPasswordPlain" autocomplete="new-password"
 							pattern=".{7,}" <?= cryptAvailable() ? '' : 'disabled="disabled" ' ?>/>
-						<a class="btn toggle-password" data-toggle="apiPasswordPlain"><?= _i('key') ?></a>
+						<button type="button" class="btn toggle-password" data-toggle="apiPasswordPlain"><?= _i('key') ?></button>
 					</div>
 					<p class="help"><?= _i('help') ?> <kbd><a href="../api/"><?= Minz_Url::display('/api/', 'html', true) ?></a></kbd></p>
 				</div>
@@ -109,7 +109,10 @@
 		<div class="form-group">
 			<label class="group-name" for="passwordPlain"><?= _t('gen.auth.password') ?></label>
 			<div class="group-controls">
+				<div class="stick">
 					<input type="password" id="passwordPlain" required="required" />
+					<button type="button" class="btn toggle-password" data-toggle="passwordPlain"><?= _i('key') ?></button>
+				</div>
 					<input type="hidden" id="challenge" name="challenge" /><br />
 					<noscript><strong><?= _t('gen.js.should_be_activated') ?></strong></noscript>
 			</div>


### PR DESCRIPTION
Changes proposed in this pull request:
- changed all show password buttons from `<a>` to `<button>`
- no visual change, no function change
- in the user account delete form: added the show-password-button

How to test the feature manually:
1. use the show password button as usual


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
