### PR TITLE
Update PHPMailer to 6.5.1

### DIFF
--- a/lib/PHPMailer/PHPMailer/Exception.php
+++ b/lib/PHPMailer/PHPMailer/Exception.php
@@ -35,6 +35,6 @@ class Exception extends \Exception
      */
     public function errorMessage()
     {
-        return '<strong>' . htmlspecialchars($this->getMessage()) . "</strong><br />\n";
+        return '<strong>' . htmlspecialchars($this->getMessage(), ENT_COMPAT | ENT_HTML401) . "</strong><br />\n";
     }
 }

--- a/lib/PHPMailer/PHPMailer/SMTP.php
+++ b/lib/PHPMailer/PHPMailer/SMTP.php
@@ -35,7 +35,7 @@ class SMTP
      *
      * @var string
      */
-    const VERSION = '6.3.0';
+    const VERSION = '6.5.1';
 
     /**
      * SMTP line break constant.
@@ -186,6 +186,7 @@ class SMTP
         'Amazon_SES' => '/[\d]{3} Ok (.*)/',
         'SendGrid' => '/[\d]{3} Ok: queued as (.*)/',
         'CampaignMonitor' => '/[\d]{3} 2.0.0 OK:([a-zA-Z\d]{48})/',
+        'Haraka' => '/[\d]{3} Message Queued \((.*)\)/',
     ];
 
     /**
@@ -553,6 +554,8 @@ class SMTP
                 }
                 //Send encoded username and password
                 if (
+                    //Format from https://tools.ietf.org/html/rfc4616#section-2
+                    //We skip the first field (it's forgery), so the string starts with a null byte
                     !$this->sendCommand(
                         'User & Password',
                         base64_encode("\0" . $username . "\0" . $password),


### PR DESCRIPTION
Closes #3976

Changes proposed in this pull request:

- Upgraded PHPMailer to 6.5.1 

Since the last upgrade to 6.3.0 the following changes have been made upstream:

https://github.com/PHPMailer/PHPMailer/compare/v6.3.0...v6.5.1

Release log:
https://github.com/PHPMailer/PHPMailer/releases


The minimum PHP requirement did not change.

How to test the feature manually:

 - Checkout this Branch
 - Setup SMTP in data/config.php
 - Test email sending such as by sharing an article


Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [] unit tests written (optional if too hard) 
- [x] documentation updated


