### PR TITLE
Additional HTTP error codes

### DIFF
--- a/app/Controllers/errorController.php
+++ b/app/Controllers/errorController.php
@@ -25,26 +25,37 @@ class FreshRSS_error_Controller extends Minz_ActionController {
 		case 200 :
 			header('HTTP/1.1 200 OK');
 			break;
+		case 400:
+			header('HTTP/1.1 400 Bad Request');
+			$this->view->code = 'Error 400 - Bad Request';
+			$this->view->errorMessage = '';
+			break;
 		case 403:
 			header('HTTP/1.1 403 Forbidden');
 			$this->view->code = 'Error 403 - Forbidden';
 			$this->view->errorMessage = _t('feedback.access.denied');
 			break;
-		case 500:
-			header('HTTP/1.1 500 Internal Server Error');
-			$this->view->code = 'Error 500 - Internal Server Error';
-			$this->view->errorMessage = 'Error 500 - Internal Server Error';
+		case 404:
+			header('HTTP/1.1 404 Not Found');
+			$this->view->code = 'Error 404 - Not found';
+			$this->view->errorMessage = _t('feedback.access.not_found');
+			break;
+		case 405:
+			header('HTTP/1.1 405 Method Not Allowed');
+			$this->view->code = 'Error 405 - Method Not Allowed';
+			$this->view->errorMessage = '';
 			break;
 		case 503:
 			header('HTTP/1.1 503 Service Unavailable');
 			$this->view->code = 'Error 503 - Service Unavailable';
 			$this->view->errorMessage = 'Error 503 - Service Unavailable';
 			break;
-		case 404:
+		case 500:
 		default:
-			header('HTTP/1.1 404 Not Found');
-			$this->view->code = 'Error 404 - Not found';
-			$this->view->errorMessage = _t('feedback.access.not_found');
+			header('HTTP/1.1 500 Internal Server Error');
+			$this->view->code = 'Error 500 - Internal Server Error';
+			$this->view->errorMessage = 'Error 500 - Internal Server Error';
+			break;
 		}
 
 		$error_message = trim(implode($error_logs));


### PR DESCRIPTION
We are using some HTTP error codes (400, 405), which were handled individually and defaulted to a confusing 404.
This PR adds more HTTP error codes, and changes the fallback to 500 (which should not happen).