### PR TITLE
Switch category - remember status filter

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -8,8 +8,12 @@
 	}
 
 	$state_filter = FreshRSS_Context::$user_conf->show_fav_unread ? '&state=3' : '';
-?>
 
+	$urlParamState= Minz_Request::param('state','');
+	if ($urlParamState) {
+		$urlParamState= '&state='.$urlParamState;
+	}
+?>
 <nav class="aside aside_feed<?= $class ?>" id="aside_feed">
 	<a class="toggle_aside" href="#close"><?= _i('close') ?></a>
 
@@ -28,7 +32,7 @@
 		<li class="tree-folder category all<?= FreshRSS_Context::isCurrentGet('a') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
 				<?= _i('all') ?> <a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>" href="<?=
-					_url('index', $actual_view) ?>"><?= _t('index.menu.main_stream') ?></a>
+					_url('index', $actual_view) . $urlParamState ?>"><?= _t('index.menu.main_stream') ?></a>
 			</div>
 		</li>
 
@@ -81,7 +85,7 @@
 			<div class="tree-folder-title">
 				<a class="dropdown-toggle" href="#"><?= _i($c_show ? 'up' : 'down') ?></a>
 				<a class="title<?= $cat->hasFeedsWithError() ? ' error' : '' ?>" data-unread="<?=
-					format_number($cat->nbNotRead()) ?>" href="<?= _url('index', $actual_view, 'get', 'c_' . $cat->id()) ?>"><?= $cat->name() ?></a>
+					format_number($cat->nbNotRead()) ?>" href="<?= _url('index', $actual_view, 'get', 'c_' . $cat->id()) . $urlParamState?>"><?= $cat->name() ?></a>
 			</div>
 
 			<ul class="tree-folder-items<?= $c_show ? ' active' : '' ?>">
@@ -99,7 +103,7 @@
 					</div>
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
 					<a class="item-title" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?=
-						_url('index', $actual_view, 'get', 'f_' . $feed->id()) ?>"><?= $feed->name() ?></a>
+						_url('index', $actual_view, 'get', 'f_' . $feed->id()). $urlParamState?>"><?= $feed->name() ?></a>
 				</li>
 				<?php } ?>
 			</ul>

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -9,9 +9,9 @@
 
 	$state_filter = FreshRSS_Context::$user_conf->show_fav_unread ? '&state=3' : '';
 
-	$urlParamState= Minz_Request::param('state','');
+	$urlParamState = Minz_Request::param('state', '');
 	if ($urlParamState) {
-		$urlParamState= '&state='.$urlParamState;
+		$urlParamState = '&state=' . $urlParamState;
 	}
 ?>
 <nav class="aside aside_feed<?= $class ?>" id="aside_feed">

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -7,11 +7,11 @@
 		$class = ' state_unread';
 	}
 
-	$state_filter = FreshRSS_Context::$user_conf->show_fav_unread ? '&state=3' : '';
+	$state_filter_fav = FreshRSS_Context::$user_conf->show_fav_unread ? '&state=3' : '';
 
-	$urlParamState = Minz_Request::param('state', '');
-	if ($urlParamState) {
-		$urlParamState = '&state=' . $urlParamState;
+	$state_filter_cat = Minz_Request::param('state', '');
+	if ($state_filter_cat) {
+		$state_filter_cat = '&state=' . $state_filter_cat;
 	}
 ?>
 <nav class="aside aside_feed<?= $class ?>" id="aside_feed">
@@ -32,14 +32,14 @@
 		<li class="tree-folder category all<?= FreshRSS_Context::isCurrentGet('a') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
 				<?= _i('all') ?> <a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>" href="<?=
-					_url('index', $actual_view) . $urlParamState ?>"><?= _t('index.menu.main_stream') ?></a>
+					_url('index', $actual_view) . $state_filter_cat ?>"><?= _t('index.menu.main_stream') ?></a>
 			</div>
 		</li>
 
 		<li class="tree-folder category favorites<?= FreshRSS_Context::isCurrentGet('s') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
 				<?= _i('bookmark') ?>
-				<a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') . $state_filter ?>">
+				<a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') . $state_filter_fav ?>">
 					<?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?>
 				</a>
 			</div>
@@ -52,7 +52,7 @@
 		<li id="tags" class="tree-folder category tags<?= $t_active ? ' active' : '' ?>">
 			<div class="tree-folder-title">
 				<a class="dropdown-toggle" href="#"><?= _i($t_active ? 'up' : 'down') ?></a>
-				<a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter ?>"><?= _t('index.menu.tags') ?></a>
+				<a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter_fav ?>"><?= _t('index.menu.tags') ?></a>
 			</div>
 			<ul class="tree-folder-items<?= $t_show ? ' active' : '' ?>">
 				<?php
@@ -65,7 +65,7 @@
 						<?php /* tag_config_template */ ?>
 					</div>
 					<?= FreshRSS_Themes::alt('label') ?> <a class="item-title" data-unread="<?= format_number($tag->nbUnread()) ?>" href="<?=
-						_url('index', $actual_view, 'get', 't_' . $tag->id()) . $state_filter ?>"><?= $tag->name() ?></a>
+						_url('index', $actual_view, 'get', 't_' . $tag->id()) . $state_filter_fav ?>"><?= $tag->name() ?></a>
 				</li>
 				<?php endforeach; ?>
 			</ul>
@@ -85,7 +85,7 @@
 			<div class="tree-folder-title">
 				<a class="dropdown-toggle" href="#"><?= _i($c_show ? 'up' : 'down') ?></a>
 				<a class="title<?= $cat->hasFeedsWithError() ? ' error' : '' ?>" data-unread="<?=
-					format_number($cat->nbNotRead()) ?>" href="<?= _url('index', $actual_view, 'get', 'c_' . $cat->id()) . $urlParamState?>"><?= $cat->name() ?></a>
+					format_number($cat->nbNotRead()) ?>" href="<?= _url('index', $actual_view, 'get', 'c_' . $cat->id()) . $state_filter_cat?>"><?= $cat->name() ?></a>
 			</div>
 
 			<ul class="tree-folder-items<?= $c_show ? ' active' : '' ?>">
@@ -103,7 +103,7 @@
 					</div>
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
 					<a class="item-title" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?=
-						_url('index', $actual_view, 'get', 'f_' . $feed->id()). $urlParamState?>"><?= $feed->name() ?></a>
+						_url('index', $actual_view, 'get', 'f_' . $feed->id()). $state_filter_cat?>"><?= $feed->name() ?></a>
 				</li>
 				<?php } ?>
 			</ul>


### PR DESCRIPTION
Normal view + Reading view

Before:
While switching the category the status filter will be lost (read/unread, favorite)

After:
remember the status

Changes proposed in this pull request:
- add the status to the category links

How to test the feature manually:
1. go to Normal view or Reading view
2. change the status filter
3. change the category (does not work on favorites)
4. the status will not be lost

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
