### PR TITLE
Improved HTML: No articles alert

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -114,9 +114,11 @@ $today = @strtotime('today');
 	else:
 		ob_end_clean();	//Discard the articles headers, as we have no articles
 ?>
-<main id="stream" class="prompt alert alert-warn normal">
-	<h2><?= _t('index.feed.empty') ?></h2>
-	<a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a><br /><br />
+<main id="stream" class="normal">
+	<div class="prompt alert alert-warn">
+		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+	</div>
 </main>
 <?php endif; ?>
 

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -82,8 +82,10 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 	else:
 		ob_end_clean();	//Discard the articles headers, as we have no articles
 ?>
-<main id="stream" class="prompt alert alert-warn reader">
-	<h2><?= _t('index.feed.empty') ?></h2>
-	<a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a><br /><br />
+<main id="stream" class="reader">
+	<div class="prompt alert alert-warn">
+		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+	</div>
 </main>
 <?php endif; ?>


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/143134907-7df8263a-fc5b-4678-9a5c-2fa0b68b8cef.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/143134845-e1604d5f-c7ab-43f2-9f43-23b75a06c712.png)


Changes proposed in this pull request:
- better HTML (alert message is now inside of `<main>`)

How to test the feature manually:
1. go to normal view or reading view
2. chose a filter that has no feed articles
3. see the alert message

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
