### PR TITLE
improved HTML: 404 error alert

### DIFF
--- a/app/views/error/index.phtml
+++ b/app/views/error/index.phtml
@@ -2,11 +2,13 @@
 	<div class="alert alert-error">
 		<h1 class="alert-head"><?= $this->code ?></h1>
 		<p>
-			<?= htmlspecialchars($this->errorMessage, ENT_NOQUOTES, 'UTF-8') ?><br />
-			<?php if (FreshRSS_Auth::hasAccess()) {?>
+			<?= htmlspecialchars($this->errorMessage, ENT_NOQUOTES, 'UTF-8') ?>
+		</p>
+		<p>	
+			<?php if (FreshRSS_Auth::hasAccess()) {?>	
 			<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
 			<?php } else { ?>
-			<a class="signin" href="<?= _url('auth', 'login') ?>"><?= _t('gen.auth.login') ?></a>
+			<a href="<?= _url('auth', 'login') ?>"><?= _t('gen.auth.login') ?></a>
 			<?php } ?>
 		</p>
 	</div>


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/143136807-b8c2d140-1089-4c6c-9a4e-ac5aa225a912.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/143136779-62845c3f-eda7-4cb9-8cbb-7c244c89fe18.png)


Changes proposed in this pull request:

- HTML improved. Now the "Login" link does not stick to the text above


How to test the feature manually:
1. Go to a page
2. logout the session in a second tab
3. open f.e. the submission page
4. 404 error appears

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
