### PR TITLE
Fix JS error: #new-article missed

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -115,6 +115,9 @@ $today = @strtotime('today');
 		ob_end_clean();	//Discard the articles headers, as we have no articles
 ?>
 <main id="stream" class="normal">
+	<div id="new-article">
+		<a href="<?= Minz_Url::display(Minz_Request::currentRequest()) ?>"><?= _t('gen.js.new_article'); /* TODO: move string in JS*/ ?></a>
+	</div>
 	<div class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
 		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -83,6 +83,9 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 		ob_end_clean();	//Discard the articles headers, as we have no articles
 ?>
 <main id="stream" class="reader">
+	<div id="new-article">
+		<a href="<?= Minz_Url::display(Minz_Request::currentRequest()) ?>"><?= _t('gen.js.new_article'); /* TODO: move string in JS*/ ?></a>
+	</div>
 	<div class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
 		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/143688152-c332b0de-b997-4431-8d88-6dd9fcbde698.png)

This `<div id="new-article">` is missed, when no article is in the list and only the alert is shown.
This blue alert is shown, when articles are listed
![grafik](https://user-images.githubusercontent.com/1645099/143688176-7fa34ee2-8425-4fd8-938c-f28ac7d6f788.png)



Changes proposed in this pull request:

- added the missed `<div>` into the section with the alert


How to test the feature manually:

1. go to normal view or reader view
2. all articles are read
3. wait till new articles in background are fetched (maybe a cron job is needed)
4. see the blue alert

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
