### PR TITLE
Fix 3881 and 4002: config menu triangle

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -527,7 +527,6 @@ a.btn {
 @supports (scrollbar-width: thin) {
 	#sidebar,
 	.scrollbar-thin {
-		overflow-y: auto;
 		scrollbar-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.05);
 		scrollbar-width: thin;
 	}

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -527,7 +527,6 @@ a.btn {
 @supports (scrollbar-width: thin) {
 	#sidebar,
 	.scrollbar-thin {
-		overflow-y: auto;
 		scrollbar-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.05);
 		scrollbar-width: thin;
 	}


### PR DESCRIPTION
Partially #4002

Changes proposed in this pull request:

- delete `overflow-y: auto` that is handled different from Firefox and Chrome


How to test the feature manually:
(Test it with Firefox and Chrome)
1. open config dropdown menu
2. see the triangle

possible side effect:
check the scrolling behavior of the left sidebar

![grafik](https://user-images.githubusercontent.com/1645099/143920426-bed6d09a-36a9-474a-b15d-1725c09b99e7.png)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
