### PR TITLE
Improved German translation of "related tags"

### DIFF
--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -27,7 +27,7 @@ return array(
 			'display_authors' => 'Autoren',
 			'entry' => 'Artikel-Symbole',
 			'publication_date' => 'Datum der Veröffentlichung',
-			'related_tags' => 'Verwandte Tags',
+			'related_tags' => 'Hashtags',
 			'sharing' => 'Teilen',
 			'summary' => 'Zusammenfassung',
 			'top_line' => 'Kopfzeile',

--- a/app/i18n/de/index.php
+++ b/app/i18n/de/index.php
@@ -57,7 +57,7 @@ return array(
 	),
 	'share' => 'Teilen',
 	'tag' => array(
-		'related' => 'Verwandte Tags',
+		'related' => 'Hashtags',
 	),
 	'tos' => array(
 		'title' => 'Nutzungsbedingungen',


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/1645099/144120213-f2a07d16-31c7-409b-9130-c6b24ed87d69.png)


Changes proposed in this pull request:

- better translation in German for the article tags. "Verwandte Tags" is not a good translation. The word "Tag"/"Tags" is quite difficult because it looks like "Tag"(=Day). I would suggest to use the word "Hashtag" that makes it more clear


How to test the feature manually:

1. see at the end of article.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
