### PR TITLE
Minz request avoid custom methods

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -152,7 +152,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 		Minz_View::appendScript(Minz_Url::display('/scripts/draggable.js?' . @filemtime(PUBLIC_PATH . '/scripts/draggable.js')));
 
 		if (Minz_Request::isPost()) {
-			$params = Minz_Request::fetchPOST();
+			$params = $_POST;
 			FreshRSS_Context::$user_conf->sharing = $params['share'];
 			FreshRSS_Context::$user_conf->save();
 			invalidateHttpCache();
@@ -406,7 +406,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 		foreach (FreshRSS_Context::$user_conf->queries as $key => $query) {
 			$queries[$key] = new FreshRSS_UserQuery($query, $feed_dao, $category_dao, $tag_dao);
 		}
-		$params = Minz_Request::fetchGET();
+		$params = $_GET;
 		unset($params['rid']);
 		$params['url'] = Minz_Url::display(array('params' => $params));
 		$params['name'] = _t('conf.query.number', count($queries) + 1);

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -566,7 +566,7 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		$url = Minz_Request::param('url');
 		$force = Minz_Request::param('force');
 		$maxFeeds = (int)Minz_Request::param('maxFeeds');
-		$noCommit = Minz_Request::fetchPOST('noCommit', 0) == 1;
+		$noCommit = ($_POST['noCommit'] ?? 0) == 1;
 
 		if ($id == -1 && !$noCommit) {	//Special request only to commit & refresh DB cache
 			$updated_feeds = 0;

--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -223,7 +223,7 @@ class FreshRSS_Auth {
 	public static function isCsrfOk($token = null) {
 		$csrf = Minz_Session::param('csrf');
 		if ($token === null) {
-			$token = Minz_Request::fetchPOST('_csrf');
+			$token = $_POST['_csrf'] ?? '';
 		}
 		return $token != '' && $token === $csrf;
 	}

--- a/app/views/entry/bookmark.phtml
+++ b/app/views/entry/bookmark.phtml
@@ -4,7 +4,7 @@ header('Content-Type: application/json; charset=UTF-8');
 $url = array(
 	'c' => Minz_Request::controllerName(),
 	'a' => Minz_Request::actionName(),
-	'params' => Minz_Request::fetchGET(),
+	'params' => $_GET,
 );
 
 $url['params']['is_favorite'] = Minz_Request::param('is_favorite', true) ? '0' : '1';

--- a/app/views/helpers/logs_pagination.phtml
+++ b/app/views/helpers/logs_pagination.phtml
@@ -1,7 +1,7 @@
 <?php
 	$c = Minz_Request::controllerName();
 	$a = Minz_Request::actionName();
-	$params = Minz_Request::fetchGET();
+	$params = $_GET;
 ?>
 
 <?php if ($this->nbPage > 1) { ?>

--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -11,7 +11,7 @@
 
 <main id="stream" class="global<?= $class ?>">
 <?php
-	$params = Minz_Request::fetchGET();
+	$params = $_GET;
 	unset($params['c']);
 	unset($params['a']);
 	$url_base = array(

--- a/lib/Minz/FrontController.php
+++ b/lib/Minz/FrontController.php
@@ -38,7 +38,7 @@ class Minz_FrontController {
 			$url = $this->buildUrl();
 			$url['params'] = array_merge (
 				$url['params'],
-				Minz_Request::fetchPOST ()
+				$_POST
 			);
 			Minz_Request::forward ($url);
 		} catch (Minz_Exception $e) {
@@ -56,15 +56,9 @@ class Minz_FrontController {
 	private function buildUrl() {
 		$url = array();
 
-		$url['c'] = Minz_Request::fetchGET(
-			'c',
-			Minz_Request::defaultControllerName()
-		);
-		$url['a'] = Minz_Request::fetchGET(
-			'a',
-			Minz_Request::defaultActionName()
-		);
-		$url['params'] = Minz_Request::fetchGET();
+		$url['c'] = $_GET['c'] ?? Minz_Request::defaultControllerName();
+		$url['a'] = $_GET['a'] ?? Minz_Request::defaultActionName();
+		$url['params'] = $_GET;
 
 		// post-traitement
 		unset($url['params']['c']);

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -136,11 +136,11 @@ class Minz_Request {
 	 * @return boolean
 	 */
 	public static function isHttps() {
-		$header = static::getHeader('HTTP_X_FORWARDED_PROTO');
-		if (null !== $header) {
+		$header = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '';
+		if ('' != $header) {
 			return 'https' === strtolower($header);
 		}
-		return 'on' === static::getHeader('HTTPS');
+		return 'on' === ($_SERVER['HTTPS'] ?? '');
 	}
 
 	/**
@@ -172,14 +172,14 @@ class Minz_Request {
 	 * @return string
 	 */
 	private static function extractHost() {
-		if (null !== $host = static::getHeader('HTTP_X_FORWARDED_HOST')) {
+		if ('' != $host = ($_SERVER['HTTP_X_FORWARDED_HOST'] ?? '')) {
 			return parse_url("http://{$host}", PHP_URL_HOST);
 		}
-		if (null !== $host = static::getHeader('HTTP_HOST')) {
+		if ('' != $host = ($_SERVER['HTTP_HOST'] ?? '')) {
 			// Might contain a port number, and mind IPv6 addresses
 			return parse_url("http://{$host}", PHP_URL_HOST);
 		}
-		if (null !== $host = static::getHeader('SERVER_NAME')) {
+		if ('' != $host = ($_SERVER['SERVER_NAME'] ?? '')) {
 			return $host;
 		}
 		return 'localhost';
@@ -189,13 +189,13 @@ class Minz_Request {
 	 * @return integer
 	 */
 	private static function extractPort() {
-		if (null !== $port = static::getHeader('HTTP_X_FORWARDED_PORT')) {
+		if ('' != $port = ($_SERVER['HTTP_X_FORWARDED_PORT'] ?? '')) {
 			return intval($port);
 		}
-		if (null !== $proto = static::getHeader('HTTP_X_FORWARDED_PROTO')) {
+		if ('' != $proto = ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '')) {
 			return 'https' === strtolower($proto) ? 443 : 80;
 		}
-		if (null !== $port = static::getHeader('SERVER_PORT')) {
+		if ('' != $port = ($_SERVER['SERVER_PORT'] ?? '')) {
 			return intval($port);
 		}
 		return static::isHttps() ? 443 : 80;
@@ -218,7 +218,7 @@ class Minz_Request {
 	 * @return string
 	 */
 	private static function extractPrefix() {
-		if (null !== $prefix = static::getHeader('HTTP_X_FORWARDED_PREFIX')) {
+		if ('' != $prefix = ($_SERVER['HTTP_X_FORWARDED_PREFIX'] ?? '')) {
 			return rtrim($prefix, '/ ');
 		}
 		return '';
@@ -228,7 +228,7 @@ class Minz_Request {
 	 * @return string
 	 */
 	private static function extractPath() {
-		if (null !== $path = static::getHeader('REQUEST_URI')) {
+		if ('' != $path = ($_SERVER['REQUEST_URI'] ?? '')) {
 			return '/' === substr($path, -1) ? substr($path, 0, -1) : dirname($path);
 		}
 		return '';
@@ -371,25 +371,6 @@ class Minz_Request {
 		Minz_Request::forward($url, true);
 	}
 
-
-	/**
-	 * Permet de récupérer une variable de type $_GET
-	 * @param $param nom de la variable
-	 * @param $default valeur par défaut à attribuer à la variable
-	 * @return string $_GET[$param]
-	 *         $_GET si $param = false
-	 *         $default si $_GET[$param] n'existe pas
-	 */
-	public static function fetchGET($param = false, $default = false) {
-		if (false === $param) {
-			return $_GET;
-		}
-		if (isset($_GET[$param])) {
-			return $_GET[$param];
-		}
-		return $default;
-	}
-
 	/**
 	 * Allows receiving POST data as application/json
 	 */
@@ -415,46 +396,21 @@ class Minz_Request {
 	 * @return string
 	 */
 	private static function extractContentType() {
-		return strtolower(trim(static::getHeader('CONTENT_TYPE', '')));
-	}
-
-	/**
-	 * Permet de récupérer une variable de type $_POST
-	 * @param $param nom de la variable
-	 * @param $default valeur par défaut à attribuer à la variable
-	 * @return string $_POST[$param]
-	 *         $_POST si $param = false
-	 *         $default si $_POST[$param] n'existe pas
-	 */
-	public static function fetchPOST($param = false, $default = false) {
-		if (false === $param) {
-			return $_POST;
-		}
-		if (isset($_POST[$param])) {
-			return $_POST[$param];
-		}
-		return $default;
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public static function getHeader($header, $default = null) {
-		return isset($_SERVER[$header]) ? $_SERVER[$header] : $default;
+		return strtolower(trim($_SERVER['CONTENT_TYPE'] ?? ''));
 	}
 
 	/**
 	 * @return boolean
 	 */
 	public static function isPost() {
-		return 'POST' === static::getHeader('REQUEST_METHOD');
+		return 'POST' === ($_SERVER['REQUEST_METHOD'] ?? '');
 	}
 
 	/**
 	 * @return array
 	 */
 	public static function getPreferredLanguages() {
-		if (preg_match_all('/(^|,)\s*(?P<lang>[^;,]+)/', static::getHeader('HTTP_ACCEPT_LANGUAGE', ''), $matches)) {
+		if (preg_match_all('/(^|,)\s*(?P<lang>[^;,]+)/', $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '', $matches)) {
 			return $matches['lang'];
 		}
 		return array('en');


### PR DESCRIPTION
Take advantage of PHP7+ null-coalescing operator `??` to make code more standard, shorter, and faster instead of custom functions with no extra functionality.

Allows code to be better tested and fix two PHPstan errors:

```
 ------ -----------------------------------------
  Line   app/Controllers/configureController.php
 ------ -----------------------------------------
  410    Cannot unset offset 'rid' on string.
 ------ -----------------------------------------

 ------ ------------------------------------
  Line   lib/Minz/FrontController.php
 ------ ------------------------------------
  70     Cannot unset offset 'c' on string.
  71     Cannot unset offset 'a' on string.
 ------ ------------------------------------
```

https://github.com/FreshRSS/FreshRSS/issues/4016