### PR TITLE
Fix: Anonym. mode: do not show "Add new feeds" link in No-Article-Alert

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -120,7 +120,9 @@ $today = @strtotime('today');
 	</div>
 	<div class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
-		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+		<?php if (FreshRSS_Auth::hasAccess()) { ?>
+			<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+		<?php } ?>
 	</div>
 </main>
 <?php endif; ?>

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -84,7 +84,9 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 	</div>
 	<div class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<?php if (FreshRSS_Auth::hasAccess()) { ?>
 		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+		<?php } ?>
 	</div>
 </main>
 <?php endif; ?>


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/145082482-3134daa2-6adc-4d2d-9845-d3821a78d4da.png)

the link leads to
![grafik](https://user-images.githubusercontent.com/1645099/145083988-1b13b589-f333-4001-aa45-7a7c7674ce9c.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/145083088-0bdf203a-cbf2-44ff-94f5-8f29b19a11b1.png)


Changes proposed in this pull request:

- do not show the link "Please add some feeds" in anonym. mode


How to test the feature manually:

1. use the anonym. mode (user is not logged in)
2. search for some random keywords to generate the alert "No articles to show"


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
