### PR TITLE
Fix: Swage theme

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -71,7 +71,7 @@ img.icon:hover {
 	background: none;
 }
 
-div#stream {
+main#stream {
 	margin-top: 35px;
 }
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -71,7 +71,7 @@ img.icon:hover {
 	background: none;
 }
 
-div#stream {
+main#stream {
 	margin-top: 35px;
 }
 

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -89,7 +89,7 @@ img {
 	}
 }
 
-div#stream {
+main#stream {
 	margin-top: 35px;
 }
 


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/145087856-9445c776-4cd8-4d43-abf1-abb40f7d8333.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/145087871-393181ed-92c8-4fc1-b865-70164168dcbd.png)

Reason for the fix: the margin is fixed to `<div>`, that changed to `<main>`.

Changes proposed in this pull request:

- CSS

How to test the feature manually:

1. use Swage theme

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
