### PR TITLE
Fix: global view does not show "no articles to show" alert

### DIFF
--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -53,7 +53,7 @@
 		}
 	}
 
-	if ($unreadArticles < 1) { 
+	if ($unreadArticles < 1) {
 		?>
 	<div id="noArticlesToShow" class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>

--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -20,11 +20,14 @@
 		'params' => $params,
 	);
 
+	$unreadArticles = 0;
+
 	foreach ($this->categories as $cat) {
 		$feeds = $cat->feeds();
 		$url_base['params']['get'] = 'c_' . $cat->id();
 
 		if (!empty($feeds)) {
+			$unreadArticles += $cat->nbNotRead();
 ?>
 	<div class="box category" data-unread="<?= $cat->nbNotRead() ?>">
 		<div class="box-title"><a class="title" data-unread="<?= format_number($cat->nbNotRead()) ?>"
@@ -49,7 +52,14 @@
 <?php
 		}
 	}
-?>
+
+	if ($unreadArticles < 1) { 
+		?>
+	<div id="noArticlesToShow" class="prompt alert alert-warn">
+		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+	</div>
+	<?php } ?>
 </main>
 
 <div id="overlay">

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1481,9 +1481,11 @@ function refreshUnreads() {
 		}
 		const isAll = document.querySelector('.category.all.active');
 		let new_articles = false;
+		let nbUnreadFeeds = 0;
 
 		Object.keys(json.feeds).forEach(function (feed_id) {
 			const nbUnreads = json.feeds[feed_id];
+			nbUnreadFeeds += nbUnreads;
 			feed_id = 'f_' + feed_id;
 			const elem = document.getElementById(feed_id);
 			const feed_unreads = elem ? str2int(elem.getAttribute('data-unread')) : 0;
@@ -1496,6 +1498,11 @@ function refreshUnreads() {
 				new_articles = true;
 			}
 		});
+
+		let noArticlesToShow_div = document.getElementById('noArticlesToShow');
+		if (nbUnreadFeeds > 0 && noArticlesToShow_div) {
+			noArticlesToShow_div.classList.add('hide');
+		}
 
 		let nbUnreadTags = 0;
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1499,7 +1499,7 @@ function refreshUnreads() {
 			}
 		});
 
-		let noArticlesToShow_div = document.getElementById('noArticlesToShow');
+		const noArticlesToShow_div = document.getElementById('noArticlesToShow');
 		if (nbUnreadFeeds > 0 && noArticlesToShow_div) {
 			noArticlesToShow_div.classList.add('hide');
 		}

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -434,6 +434,10 @@ a.btn {
 	margin: 5px 20px;
 }
 
+.alert.hide {
+	display: none;
+}
+
 /*=== Icons */
 .icon {
 	display: inline-block;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -434,6 +434,10 @@ a.btn {
 	margin: 5px 20px;
 }
 
+.alert.hide {
+	display: none;
+}
+
 /*=== Icons */
 .icon {
 	display: inline-block;


### PR DESCRIPTION
Before:
no information when there is no articles to show in global view
![grafik](https://user-images.githubusercontent.com/1645099/145110437-7068a9b4-296c-4710-9c6e-315c56308c7f.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/145110569-e1b4f3c7-6832-44ac-97ea-de802c56e0ae.png)

When new articles are found in background the alert will disappear/hide.
![grafik](https://user-images.githubusercontent.com/1645099/145110641-8fff8309-f5d6-4a74-a2ca-f2e28d4d8501.png)


Changes proposed in this pull request:

- added the alert
- Javascript will hide the alert, when new articles are found

How to test the feature manually:

1. go to global view
2. mark all feeds as read
3. see the alert
4. wait for new articles
5. new articles = alert will disappear

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
