### PR TITLE
fix global view template

### DIFF
--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -57,7 +57,9 @@
 		?>
 	<div id="noArticlesToShow" class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<?php if (FreshRSS_Auth::hasAccess()) { ?>
 		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+		<?php } ?>
 	</div>
 	<?php } ?>
 </main>


### PR DESCRIPTION
After #4042 and #4040 were merged the global view needs also an update

Changes proposed in this pull request:

- do not show "Add feeds" link in anonym. mode in the global view


How to test the feature manually:

1. anyonm. mode
2. go to global view
3. mark all articles as read
4. see the "No articles to show" alert without the link to add new feeds

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested