### PR TITLE
fixed: Left navigation with long category names

### DIFF
--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -264,8 +264,12 @@
 }
 
 /*=== Aside main page (categories) */
+.aside_feed .tree-folder-title > .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 35px);
+}
+
 .aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
-	margin: -0.5rem 1rem 0 0;
+	margin: -0.25rem 1rem 0 0;
 	padding: 0 0.75rem;
 	background: $sid-pills;
 	border-radius: 12px;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -741,8 +741,12 @@ form th {
 }
 
 /*=== Aside main page (categories) */
+.aside_feed .tree-folder-title > .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 35px);
+}
+
 .aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
-	margin: -0.5rem 1rem 0 0;
+	margin: -0.25rem 1rem 0 0;
 	padding: 0 0.75rem;
 	background: rgba(35, 35, 0, 0.15);
 	border-radius: 12px;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -741,8 +741,12 @@ form th {
 }
 
 /*=== Aside main page (categories) */
+.aside_feed .tree-folder-title > .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 35px);
+}
+
 .aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
-	margin: -0.5rem 0 0 1rem;
+	margin: -0.25rem 0 0 1rem;
 	padding: 0 0.75rem;
 	background: rgba(35, 35, 0, 0.15);
 	border-radius: 12px;

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -262,8 +262,12 @@
 }
 
 /*=== Aside main page (categories) */
+.aside_feed .tree-folder-title > .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 35px);
+}
+
 .aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
-	margin: -0.5rem 1rem 0 0;
+	margin: -0.25rem 1rem 0 0;
 	padding: 0 0.75rem;
 	background: $sid-pills;
 	border-radius: 12px;

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -744,8 +744,12 @@ form th {
 }
 
 /*=== Aside main page (categories) */
+.aside_feed .tree-folder-title > .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 35px);
+}
+
 .aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
-	margin: -0.5rem 1rem 0 0;
+	margin: -0.25rem 1rem 0 0;
 	padding: 0 0.75rem;
 	background: rgba(0, 0, 0, 0.25);
 	border-radius: 12px;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -744,8 +744,12 @@ form th {
 }
 
 /*=== Aside main page (categories) */
+.aside_feed .tree-folder-title > .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 35px);
+}
+
 .aside_feed .tree-folder-title > .title:not([data-unread="0"])::after {
-	margin: -0.5rem 0 0 1rem;
+	margin: -0.25rem 0 0 1rem;
 	padding: 0 0.75rem;
 	background: rgba(0, 0, 0, 0.25);
 	border-radius: 12px;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -579,15 +579,11 @@ a.btn {
 
 .tree-folder-title .title {
 	display: inline-block;
+	width: 100%;
+	vertical-align: middle;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-}
-
-.tree-folder-title .title {
-	display: inline-block;
-	width: 100%;
-	vertical-align: middle;
 }
 
 .tree-folder-items > .item {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -577,8 +577,8 @@ a.btn {
 	transition: max-height .3s linear;
 }
 
-.tree-folder-title {
-	display: block;
+.tree-folder-title .title {
+	display: inline-block;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
@@ -667,6 +667,10 @@ input[type="search"] {
 /*=== Aside main page */
 .aside_feed .category .title {
 	width: calc(100% - 35px);
+}
+
+.aside_feed .category .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 20px);
 }
 
 .aside_feed .tree-folder-title .icon {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -579,15 +579,11 @@ a.btn {
 
 .tree-folder-title .title {
 	display: inline-block;
+	width: 100%;
+	vertical-align: middle;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-}
-
-.tree-folder-title .title {
-	display: inline-block;
-	width: 100%;
-	vertical-align: middle;
 }
 
 .tree-folder-items > .item {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -577,8 +577,8 @@ a.btn {
 	transition: max-height .3s linear;
 }
 
-.tree-folder-title {
-	display: block;
+.tree-folder-title .title {
+	display: inline-block;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
@@ -667,6 +667,10 @@ input[type="search"] {
 /*=== Aside main page */
 .aside_feed .category .title {
 	width: calc(100% - 35px);
+}
+
+.aside_feed .category .title:not([data-unread="0"]) {
+	width: calc(100% - 35px - 20px);
 }
 
 .aside_feed .tree-folder-title .icon {


### PR DESCRIPTION
Before:
Categories with long name
![grafik](https://user-images.githubusercontent.com/1645099/145687428-5c4b4a51-7835-4398-b5e1-12cf7cbaf38c.png)

the category names are not displayed
![grafik](https://user-images.githubusercontent.com/1645099/145687439-833d2540-4a26-4239-9b1e-d27db79d6cfe.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/145687446-5ddfbd17-c4fe-49d2-80d3-840e67c34d84.png)




Changes proposed in this pull request:

- CSS fixed


How to test the feature manually:

1. create long category names
2. check with unread articles (show the numbers) and all-read articles (no numbers are shown)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested