### PR TITLE
fever: fix warning of unset array key

### DIFF
--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -508,7 +508,7 @@ class FeverAPI
 			}
 		} elseif (isset($_REQUEST['with_ids'])) {
 			$entry_ids = explode(',', $_REQUEST['with_ids']);
-		} else {
+		} elseif (isset($_REQUEST['since_id'])) {
 			// use the since_id argument to request the next $item_limit items
 			$since_id = '' . $_REQUEST['since_id'];
 			if (!ctype_digit($since_id)) {


### PR DESCRIPTION
fixes warning in the log:
```
WARNING: [pool www] child 16647 said into stderr: "[11-Dec-2021 01:40:37 Europe/Berlin] PHP Warning:  Undefined array key "since_id" in /var/www/virtual/stunkym/html/freshrss/p/api/fever.php on line 513"
```

Changes proposed in this pull request:

- the [documentation of fever-api](https://feedafever.com/api) defines the `since_id` optional. Currently it is spamming my log. To remove the warning it could be first checked, before reading it.

How to test the feature manually:

1. request to `https://freshrss.example.net/api/fever.php?api&items` without `since_id`


Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
