### PR TITLE
Search on article IDs

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -732,6 +732,29 @@ SQL;
 				}
 				$sub_search = '';
 
+				if ($filter->getEntryIds()) {
+					foreach ($filter->getEntryIds() as $entry_ids) {
+						$sub_search .= 'AND ' . $alias . 'id IN (';
+						foreach ($entry_ids as $entry_id) {
+							$sub_search .= '?,';
+							$values[] = $entry_id;
+						}
+						$sub_search = rtrim($sub_search, ',');
+						$sub_search .= ') ';
+					}
+				}
+				if ($filter->getNotEntryIds()) {
+					foreach ($filter->getNotEntryIds() as $entry_ids) {
+						$sub_search .= 'AND ' . $alias . 'id NOT IN (';
+						foreach ($entry_ids as $entry_id) {
+							$sub_search .= '?,';
+							$values[] = $entry_id;
+						}
+						$sub_search = rtrim($sub_search, ',');
+						$sub_search .= ') ';
+					}
+				}
+
 				if ($filter->getMinDate()) {
 					$sub_search .= 'AND ' . $alias . 'id >= ? ';
 					$values[] = "{$filter->getMinDate()}000000";

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -89,10 +89,10 @@ class FreshRSS_Search {
 	}
 
 	public function getEntryIds() {
-		return $this->feed_ids;
+		return $this->entry_ids;
 	}
 	public function getNotEntryIds() {
-		return $this->not_feed_ids;
+		return $this->not_entry_ids;
 	}
 
 	public function getFeedIds() {
@@ -200,7 +200,7 @@ class FreshRSS_Search {
 	}
 
 	/**
-	 * Parse the search string to find feed IDs.
+	 * Parse the search string to find entry (article) IDs.
 	 *
 	 * @param string $input
 	 * @return string
@@ -225,12 +225,12 @@ class FreshRSS_Search {
 		if (preg_match_all('/[!-]e:(?P<search>[0-9,]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
-			$this->not_feed_ids = [];
+			$this->not_entry_ids = [];
 			foreach ($ids_lists as $ids_list) {
 				$entry_ids = explode(',', $ids_list);
 				$entry_ids = self::removeEmptyValues($entry_ids);
 				if (!empty($entry_ids)) {
-					$this->not_feed_ids[] = $entry_ids;
+					$this->not_entry_ids[] = $entry_ids;
 				}
 			}
 		}

--- a/docs/en/users/03_Main_view.md
+++ b/docs/en/users/03_Main_view.md
@@ -227,6 +227,7 @@ You can use the search field to further refine results:
 * by custom label ID `L:12` or multiple label IDs: `L:12,13,14` or with any label: `L:*`
 * by custom label name `label:label`, `label:"my label"` or any label name from a list (*or*): `labels:"my label,my other label"`
 * by several label names (*and*): `label:"my label" label:"my other label"`
+* by entry (article) ID: `e:1639310674957894` or multiple entry IDs  (*or*): `e:1639310674957894,1639310674957893`
 
 Be careful not to enter a space between the operator and the search value.
 

--- a/docs/fr/users/03_Main_view.md
+++ b/docs/fr/users/03_Main_view.md
@@ -251,6 +251,7 @@ Il est possible d’utiliser le champ de recherche pour raffiner les résultats
 * par ID d’étiquette : `L:12` ou de plusieurs étiquettes : `L:12,13,14` ou avec n’importe quelle étiquette : `L:*`
 * par nom d’étiquette : `label:étiquette`, `label:"mon étiquette"` ou d’une étiquette parmis une liste (*ou*) : `labels:"mon étiquette,mon autre étiquette"`
 * par plusieurs noms d’étiquettes (*et*) : `label:"mon étiquette" label:"mon autre étiquette"`
+* par ID d’article (entrée) : `e:1639310674957894` ou de plusieurs articles (*ou*): `e:1639310674957894,1639310674957893`
 
 Attention à ne pas introduire d’espace entre l’opérateur et la valeur
 recherchée.


### PR DESCRIPTION
Partial implementation of https://github.com/FreshRSS/FreshRSS/issues/4053

New search keyword:

* by entry (article) ID: `e:1639310674957894` or multiple entry IDs  (*or*): `e:1639310674957894,1639310674957893`
