### PR TITLE
Improve: Aside slider: close slider when click on the outside of slider

### DIFF
--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -1,5 +1,6 @@
 <nav class="nav nav-list aside" id="aside_feed">
 	<a class="toggle_aside" href="#close"><?= _i('close') ?></a>
+	
 	<ul>
 		<li class="nav-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8')?></li>	
 		<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">
@@ -61,6 +62,7 @@
 		</li>
 	</ul>
 </nav>
+<a class="close-aside" href="#close">❌</a>
 <nav class="nav_menu nav_mobile">
 	<a class="btn toggle_aside" href="#aside_feed"><?= _i('category') ?></a>
 </nav>

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -14,7 +14,7 @@
 		$state_filter_cat = '&state=' . $state_filter_cat;
 	}
 ?>
-<nav class="aside aside_feed<?= $class ?>" id="aside_feed">
+<nav class="nav aside aside_feed<?= $class ?>" id="aside_feed">
 	<a class="toggle_aside" href="#close"><?= _i('close') ?></a>
 
 	<?php if (FreshRSS_Auth::hasAccess()) { ?>
@@ -116,6 +116,7 @@
 	</ul>
 	</form>
 </nav>
+<a class="close-aside" href="#close">❌</a>
 
 <div id="first_load" class="loading"></div>
 <?php flush(); ?>

--- a/app/layout/aside_subscription.phtml
+++ b/app/layout/aside_subscription.phtml
@@ -35,6 +35,7 @@
 
 	</ul>
 </nav>
+<a class="close-aside" href="#close">❌</a>
 <nav class="nav_menu nav_mobile">
 	<a class="btn toggle_aside" href="#aside_feed"><?= _i('category') ?></a>
 </nav>

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -670,6 +670,7 @@ input[type="search"] {
 
 .aside:target + .close-aside {
 	display: block;
+	background:rgba(0, 0, 0, 0.2);
 	font-size: 0;
 	position: fixed;
 	top: 0; 
@@ -677,7 +678,7 @@ input[type="search"] {
 	left: 0;
 	right: 0;
 	cursor: pointer;
-	z-index: 1;
+	z-index: 99;
 }
 
 /*=== Aside main page */

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -664,6 +664,22 @@ input[type="search"] {
 	vertical-align: top;
 }
 
+.aside + .close-aside {
+	display: none;
+}
+
+.aside:target + .close-aside {
+	display: block;
+	font-size: 0;
+	position: fixed;
+	top: 0; 
+	bottom: 0;
+	left: 0;
+	right: 0;
+	cursor: pointer;
+	z-index: 1;
+}
+
 /*=== Aside main page */
 .aside_feed .category .title {
 	width: calc(100% - 35px);

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -668,19 +668,6 @@ input[type="search"] {
 	display: none;
 }
 
-.aside:target + .close-aside {
-	display: block;
-	background:rgba(0, 0, 0, 0.2);
-	font-size: 0;
-	position: fixed;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	cursor: pointer;
-	z-index: 99;
-}
-
 /*=== Aside main page */
 .aside_feed .category .title {
 	width: calc(100% - 35px);
@@ -1442,6 +1429,19 @@ input:checked + .slide-container .properties {
 	.nav_menu .search,
 	#panel .close img {
 		display: inline-block;
+	}
+
+	.aside:target + .close-aside {
+		background: rgba(0, 0, 0, 0.2);
+		display: block;
+		font-size: 0;
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		cursor: pointer;
+		z-index: 99;
 	}
 
 	.nav_mobile {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -673,7 +673,7 @@ input[type="search"] {
 	background:rgba(0, 0, 0, 0.2);
 	font-size: 0;
 	position: fixed;
-	top: 0; 
+	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -670,6 +670,7 @@ input[type="search"] {
 
 .aside:target + .close-aside {
 	display: block;
+	background:rgba(0, 0, 0, 0.2);
 	font-size: 0;
 	position: fixed;
 	top: 0; 
@@ -677,7 +678,7 @@ input[type="search"] {
 	left: 0;
 	right: 0;
 	cursor: pointer;
-	z-index: 1;
+	z-index: 99;
 }
 
 /*=== Aside main page */

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -664,6 +664,22 @@ input[type="search"] {
 	vertical-align: top;
 }
 
+.aside + .close-aside {
+	display: none;
+}
+
+.aside:target + .close-aside {
+	display: block;
+	font-size: 0;
+	position: fixed;
+	top: 0; 
+	bottom: 0;
+	left: 0;
+	right: 0;
+	cursor: pointer;
+	z-index: 1;
+}
+
 /*=== Aside main page */
 .aside_feed .category .title {
 	width: calc(100% - 35px);

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -668,19 +668,6 @@ input[type="search"] {
 	display: none;
 }
 
-.aside:target + .close-aside {
-	display: block;
-	background:rgba(0, 0, 0, 0.2);
-	font-size: 0;
-	position: fixed;
-	top: 0;
-	bottom: 0;
-	right: 0;
-	left: 0;
-	cursor: pointer;
-	z-index: 99;
-}
-
 /*=== Aside main page */
 .aside_feed .category .title {
 	width: calc(100% - 35px);
@@ -1442,6 +1429,19 @@ input:checked + .slide-container .properties {
 	.nav_menu .search,
 	#panel .close img {
 		display: inline-block;
+	}
+
+	.aside:target + .close-aside {
+		background: rgba(0, 0, 0, 0.2);
+		display: block;
+		font-size: 0;
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		right: 0;
+		left: 0;
+		cursor: pointer;
+		z-index: 99;
 	}
 
 	.nav_mobile {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -675,8 +675,8 @@ input[type="search"] {
 	position: fixed;
 	top: 0;
 	bottom: 0;
-	left: 0;
 	right: 0;
+	left: 0;
 	cursor: pointer;
 	z-index: 99;
 }

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -673,7 +673,7 @@ input[type="search"] {
 	background:rgba(0, 0, 0, 0.2);
 	font-size: 0;
 	position: fixed;
-	top: 0; 
+	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;


### PR DESCRIPTION
Before:
When the left hand slider in mobile view is open, than it does not close when you click outside of the slider.

After:
the slider closes.
![grafik](https://user-images.githubusercontent.com/1645099/145731787-2ee4f2de-2e91-4a01-ad23-3910f432da05.png)




Changes proposed in this pull request:

- CSS and phtml


How to test the feature manually:

1. use mobile view
2. open a left hand side slider (f.e. in config, normal view/reader view, subscription management
3. click on the right to close the slider

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested