### PR TITLE
Fixed: "My labels" in aside navigation when it is empty

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -49,7 +49,7 @@
 			$t_active = FreshRSS_Context::isCurrentGet('T');
 			$t_show = ($t_active && in_array(FreshRSS_Context::$user_conf->display_categories, [ 'active', 'remember' ])) || FreshRSS_Context::$user_conf->display_categories === 'all';
 		?>
-		<li id="tags" class="tree-folder category tags<?= $t_active ? ' active' : '' ?>">
+		<li id="tags" class="tree-folder category tags<?= $t_active ? ' active' : '' ?>" data-unread="<?= format_number($this->nbUnreadTags) ?>">
 			<div class="tree-folder-title">
 				<a class="dropdown-toggle" href="#"><?= _i($t_active ? 'up' : 'down') ?></a>
 				<a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter_fav ?>"><?= _t('index.menu.tags') ?></a>


### PR DESCRIPTION
Closes #2256

Before:
No subnavigation of "my labels" (because there are no articles)
![grafik](https://user-images.githubusercontent.com/1645099/145890984-e81850e3-6090-4369-bfa3-8051ad1ec973.png)

After some times: "My labels" disappears
![grafik](https://user-images.githubusercontent.com/1645099/145891132-af9ad4fd-dc63-4733-8fdc-a45b3b88abb8.png)

After:
Fixed. "My labels" will not shown, when there is no articles  



Changes proposed in this pull request:

- added "data-unread" to the menu item


How to test the feature manually:

1. go to normal/reader view
2. check how "my labels" is shown or not


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested

