### PR TITLE
Improvement:  No break in labels in mobile view

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1380,6 +1380,7 @@ input:checked + .slide-container .properties {
 
 	.form-group .group-name {
 		float: none;
+		width: auto;
 	}
 
 	.form-group .group-controls {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1380,6 +1380,7 @@ input:checked + .slide-container .properties {
 
 	.form-group .group-name {
 		float: none;
+		width: auto;
 	}
 
 	.form-group .group-controls {


### PR DESCRIPTION
in mobile view:

Before:
max width 200px for labels
![grafik](https://user-images.githubusercontent.com/1645099/146050033-0339b9aa-fe0a-441d-aa8d-74d0554085b1.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/146050390-b4abcb0a-1b4e-4f7c-98a9-7a85a8d036bb.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. view in mobile view
2. go to subscription management and edit a feed

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested