### PR TITLE
Docker fix missing .htaccess

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -29,3 +29,7 @@ ServerTokens OS
 <Directory /var/www/FreshRSS/p/i>
 	IncludeOptional /var/www/FreshRSS/p/i/.htaccess
 </Directory>
+
+<Directory /var/www/FreshRSS/p/themes>
+	Include /var/www/FreshRSS/p/themes/.htaccess
+</Directory>

--- a/p/.htaccess
+++ b/p/.htaccess
@@ -7,10 +7,7 @@ AddDefaultCharset	UTF-8
 
 <IfModule mod_mime.c>
 	AddType application/json .map
-	AddType application/font-woff .woff
-	AddType application/font-woff2 .woff2
 
-	AddCharset	UTF-8	.css
 	AddCharset	UTF-8	.html
 	AddCharset	UTF-8	.js
 </IfModule>

--- a/p/themes/.htaccess
+++ b/p/themes/.htaccess
@@ -1,5 +1,6 @@
 <IfModule mod_mime.c>
 	AddType application/font-woff .woff
+	AddType application/font-woff2 .woff2
 
 	AddCharset	UTF-8	.css
 	AddCharset	UTF-8	.svg


### PR DESCRIPTION
Related to https://github.com/FreshRSS/FreshRSS/issues/4073
In our Docker configuration, `.htaccess` files are included only once at startup. The one for themes was missing.
