### PR TITLE
Fix: Verification email: use language of new user

### DIFF
--- a/app/Mailers/UserMailer.php
+++ b/app/Mailers/UserMailer.php
@@ -5,6 +5,8 @@
  */
 class FreshRSS_User_Mailer extends Minz_Mailer {
 	public function send_email_need_validation($username, $user_config) {
+		Minz_Translate::reset($user_config->language);
+
 		$this->view->_path('user_mailer/email_need_validation.txt.php');
 
 		$this->view->username = $username;


### PR DESCRIPTION
Closes #3978

Changes proposed in this pull request:

- use the language of the new user


How to test the feature manually:

1. create a new user with email verification
2. chose as language another language than the default user's language


Pull request checklist:

- [x ] clear commit messages
- [ x] code manually tested
