### PR TITLE
Correct cron example

### DIFF
--- a/docs/en/admins/08_FeedUpdates.md
+++ b/docs/en/admins/08_FeedUpdates.md
@@ -18,7 +18,7 @@ It's advisable that you run the Cron job as your Web server user (often `www-dat
 
 To run the updater script every hour, and 10 minutes past the hour:
 
-Run `sudo crontab -e` and copy the following line into the crontab:
+Edit `/etc/crontab` and append the following line:
 ```text
 10 * * * * www-data php -f /usr/share/FreshRSS/app/actualize_script.php > /tmp/FreshRSS.log 2>&1
 ```


### PR DESCRIPTION
The old example was inaccurate. crontab on Debian does not support a user name, but files in /etc/cron.d and /etc/crontab do ([crontab manpage](https://manpages.debian.org/bullseye/cron/crontab.5.en.html))

According to [cron manpage](https://manpages.debian.org/bullseye/cron/cron.8.en.html): 

> In general, the system administrator should not use /etc/cron.d/, but use the standard system crontab /etc/crontab so I propose to append the line to this file

Changes proposed in this pull request:

Append the line to /etc/crontab instead of editing root's crontab

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
