### PR TITLE
Fix: loading wheel

### DIFF
--- a/app/views/helpers/pagination.phtml
+++ b/app/views/helpers/pagination.phtml
@@ -23,7 +23,7 @@ if ($url_mark_read && $hasAccess) { ?>
 <form id="mark-read-pagination" method="post">
 <input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 <?php } else { ?>
-	<div id="mark-read-pagination">
+<div id="mark-read-pagination">
 <?php }?>
 <ul class="pagination">
 	<li class="item pager-next">

--- a/app/views/helpers/pagination.phtml
+++ b/app/views/helpers/pagination.phtml
@@ -22,6 +22,8 @@ $hasAccess = FreshRSS_Auth::hasAccess();
 if ($url_mark_read && $hasAccess) { ?>
 <form id="mark-read-pagination" method="post">
 <input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+<?php } else { ?>
+	<div id="mark-read-pagination">
 <?php }?>
 <ul class="pagination">
 	<li class="item pager-next">
@@ -48,4 +50,6 @@ if ($url_mark_read && $hasAccess) { ?>
 </ul>
 <?php if ($url_mark_read && $hasAccess) { ?>
 </form>
+<?php } else {?>
+</div>
 <?php }?>

--- a/p/scripts/global_view.js
+++ b/p/scripts/global_view.js
@@ -19,7 +19,7 @@ function load_panel(link) {
 			return;
 		}
 		const html = this.response;
-		const foreign = html.querySelectorAll('.nav_menu, #stream .day, #stream .flux, #stream .pagination, #stream.prompt');
+		const foreign = html.querySelectorAll('.nav_menu, #stream .day, #stream .flux, #stream #mark-read-pagination, #stream.prompt');
 		const panel = document.getElementById('panel');
 		foreign.forEach(function (el) {
 			panel.appendChild(document.adoptNode(el));

--- a/p/scripts/global_view.js
+++ b/p/scripts/global_view.js
@@ -19,7 +19,7 @@ function load_panel(link) {
 			return;
 		}
 		const html = this.response;
-		const foreign = html.querySelectorAll('.nav_menu, #stream .day, #stream .flux, #stream #mark-read-pagination, #stream.prompt');
+		const foreign = html.querySelectorAll('.nav_menu, #stream .day, #stream .flux, #mark-read-pagination, #stream.prompt');
 		const panel = document.getElementById('panel');
 		foreign.forEach(function (el) {
 			panel.appendChild(document.adoptNode(el));


### PR DESCRIPTION
Closes #4047 
Ref.  #3944

Changes proposed in this pull request:

- fixed template, to give the ID back
- fixed JavaScript, to use the ID instead of pagination class

How to test the feature manually:
Does the next articles load?
1. check anonym. user: check all views (normal, reader, global)
2. check with login unser: check the global view


Pull request checklist:

- [x ] clear commit messages
- [ x] code manually tested