### PR TITLE
fix: incorrect translations

### DIFF
--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -68,7 +68,7 @@ return array(
 			'main_stream' => '在首页中显示',
 			'normal' => '在分类中显示',
 		),
-		'proxy' => '获取原文时的代理',
+		'proxy' => '获取订阅源时的代理',
 		'proxy_help' => '选择协议（例：SOCKS5）和代理地址（例：<kbd>127.0.0.1:1080</kbd>）',
 		'selector_preview' => array(
 			'show_raw' => '显示源码',


### PR DESCRIPTION
The original translation "获取原文时的代理" means "Set a proxy for fetching the original article" which is incorrect. This proxy setting actually sets the proxy for fetching the feed itself rather than the original article. The updated translation "获取订阅源时的代理"  means "Set a proxy for fetching this feed".

Changes proposed in this pull request:

- fixed an incorrect Chinese translation

How to test the feature manually:

1. Go to subscription management
2. Choose one feeds
3. Check "Advanced -> Proxy"

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
