### PR TITLE
Fix: Thumbnails alt text overflow

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -803,11 +803,11 @@ input[type="search"] {
 }
 
 .flux .item.thumbnail img {
+	background: repeating-linear-gradient( -45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
+	display: inline-block;
 	width: 100%;
 	height: 100%;
-	display: inline-block;
 	overflow: hidden;
-	background: repeating-linear-gradient( -45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
 	object-fit: cover;
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -805,6 +805,9 @@ input[type="search"] {
 .flux .item.thumbnail img {
 	width: 100%;
 	height: 100%;
+	display: inline-block;
+	overflow: hidden;
+	background: repeating-linear-gradient( -45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
 	object-fit: cover;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -807,7 +807,7 @@ input[type="search"] {
 	height: 100%;
 	display: inline-block;
 	overflow: hidden;
-	background: repeating-linear-gradient( -45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
+	background: repeating-linear-gradient( 45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
 	object-fit: cover;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -805,6 +805,9 @@ input[type="search"] {
 .flux .item.thumbnail img {
 	width: 100%;
 	height: 100%;
+	display: inline-block;
+	overflow: hidden;
+	background: repeating-linear-gradient( -45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
 	object-fit: cover;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -803,11 +803,11 @@ input[type="search"] {
 }
 
 .flux .item.thumbnail img {
+	background: repeating-linear-gradient( 45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
+	display: inline-block;
 	width: 100%;
 	height: 100%;
-	display: inline-block;
 	overflow: hidden;
-	background: repeating-linear-gradient( 45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
 	object-fit: cover;
 }
 


### PR DESCRIPTION
References #4078 (partially fix)

Changes proposed in this pull request:

- CSS: hide text overflow
- CSS: striped background for thumbnails

How to test the feature manually:

1. enable the thumbnail view
2. change the src of thumbnail to a broken URL
3. see striped background and a boxed alt text

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested