### PR TITLE
Fix several PHP8.1 warnings

### DIFF
--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -42,6 +42,9 @@ class FreshRSS_Search {
 	private $not_tags;
 	private $not_search;
 
+	/**
+	 * @param string|null $input
+	 */
 	public function __construct($input) {
 		if ($input == '') {
 			return;
@@ -77,7 +80,7 @@ class FreshRSS_Search {
 		$input = $this->parseTagsSearch($input);
 
 		$input = $this->parseNotSearch($input);
-		$input = $this->parseSearch($input);
+		$this->parseSearch($input);
 	}
 
 	public function __toString() {
@@ -201,11 +204,8 @@ class FreshRSS_Search {
 
 	/**
 	 * Parse the search string to find entry (article) IDs.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseEntryIds($input) {
+	private function parseEntryIds(string $input): string {
 		if (preg_match_all('/\be:(?P<search>[0-9,]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
@@ -221,7 +221,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotEntryIds($input) {
+	private function parseNotEntryIds(string $input): string {
 		if (preg_match_all('/[!-]e:(?P<search>[0-9,]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
@@ -237,13 +237,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	/**
-	 * Parse the search string to find feed IDs.
-	 *
-	 * @param string $input
-	 * @return string
-	 */
-	private function parseFeedIds($input) {
+	private function parseFeedIds(string $input): string {
 		if (preg_match_all('/\bf:(?P<search>[0-9,]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
@@ -259,7 +253,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotFeedIds($input) {
+	private function parseNotFeedIds(string $input): string {
 		if (preg_match_all('/[!-]f:(?P<search>[0-9,]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
@@ -277,11 +271,8 @@ class FreshRSS_Search {
 
 	/**
 	 * Parse the search string to find tags (labels) IDs.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseLabelIds($input) {
+	private function parseLabelIds(string $input): string {
 		if (preg_match_all('/\b[lL]:(?P<search>[0-9,]+|[*])/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
@@ -301,7 +292,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotLabelIds($input) {
+	private function parseNotLabelIds(string $input): string {
 		if (preg_match_all('/[!-][lL]:(?P<search>[0-9,]+|[*])/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$ids_lists = $matches['search'];
@@ -323,11 +314,8 @@ class FreshRSS_Search {
 
 	/**
 	 * Parse the search string to find tags (labels) names.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseLabelNames($input) {
+	private function parseLabelNames(string $input): string {
 		$names_lists = [];
 		if (preg_match_all('/\blabels?:(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$names_lists = $matches['search'];
@@ -352,11 +340,8 @@ class FreshRSS_Search {
 
 	/**
 	 * Parse the search string to find tags (labels) names to exclude.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseNotLabelNames($input) {
+	private function parseNotLabelNames(string $input): string {
 		$names_lists = [];
 		if (preg_match_all('/[!-]labels?:(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$names_lists = $matches['search'];
@@ -380,14 +365,10 @@ class FreshRSS_Search {
 	}
 
 	/**
-	 * Parse the search string to find intitle keyword and the search related
-	 * to it.
+	 * Parse the search string to find intitle keyword and the search related to it.
 	 * The search is the first word following the keyword.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseIntitleSearch($input) {
+	private function parseIntitleSearch(string $input): string {
 		if (preg_match_all('/\bintitle:(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$this->intitle = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -400,7 +381,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotIntitleSearch($input) {
+	private function parseNotIntitleSearch(string $input): string {
 		if (preg_match_all('/[!-]intitle:(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$this->not_intitle = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -414,16 +395,11 @@ class FreshRSS_Search {
 	}
 
 	/**
-	 * Parse the search string to find author keyword and the search related
-	 * to it.
+	 * Parse the search string to find author keyword and the search related to it.
 	 * The search is the first word following the keyword except when using
-	 * a delimiter. Supported delimiters are single quote (') and double
-	 * quotes (").
-	 *
-	 * @param string $input
-	 * @return string
+	 * a delimiter. Supported delimiters are single quote (') and double quotes (").
 	 */
-	private function parseAuthorSearch($input) {
+	private function parseAuthorSearch(string $input): string {
 		if (preg_match_all('/\bauthor:(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$this->author = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -436,7 +412,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotAuthorSearch($input) {
+	private function parseNotAuthorSearch(string $input): string {
 		if (preg_match_all('/[!-]author:(?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$this->not_author = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -450,12 +426,8 @@ class FreshRSS_Search {
 	}
 
 	/**
-	 * Parse the search string to find inurl keyword and the search related
-	 * to it.
+	 * Parse the search string to find inurl keyword and the search related to it.
 	 * The search is the first word following the keyword.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
 	private function parseInurlSearch($input) {
 		if (preg_match_all('/\binurl:(?P<search>[^\s]*)/', $input, $matches)) {
@@ -466,7 +438,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotInurlSearch($input) {
+	private function parseNotInurlSearch(string $input): string {
 		if (preg_match_all('/[!-]inurl:(?P<search>[^\s]*)/', $input, $matches)) {
 			$this->not_inurl = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -476,14 +448,10 @@ class FreshRSS_Search {
 	}
 
 	/**
-	 * Parse the search string to find date keyword and the search related
-	 * to it.
+	 * Parse the search string to find date keyword and the search related to it.
 	 * The search is the first word following the keyword.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseDateSearch($input) {
+	private function parseDateSearch(string $input): string {
 		if (preg_match_all('/\bdate:(?P<search>[^\s]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
@@ -494,7 +462,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotDateSearch($input) {
+	private function parseNotDateSearch(string $input): string {
 		if (preg_match_all('/[!-]date:(?P<search>[^\s]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
@@ -507,14 +475,10 @@ class FreshRSS_Search {
 
 
 	/**
-	 * Parse the search string to find pubdate keyword and the search related
-	 * to it.
+	 * Parse the search string to find pubdate keyword and the search related to it.
 	 * The search is the first word following the keyword.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parsePubdateSearch($input) {
+	private function parsePubdateSearch(string $input): string {
 		if (preg_match_all('/\bpubdate:(?P<search>[^\s]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
@@ -525,7 +489,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotPubdateSearch($input) {
+	private function parseNotPubdateSearch(string $input): string {
 		if (preg_match_all('/[!-]pubdate:(?P<search>[^\s]*)/', $input, $matches)) {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
@@ -540,11 +504,8 @@ class FreshRSS_Search {
 	 * Parse the search string to find tags keyword (# followed by a word)
 	 * and the search related to it.
 	 * The search is the first word following the #.
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private function parseTagsSearch($input) {
+	private function parseTagsSearch(string $input): string {
 		if (preg_match_all('/#(?P<search>[^\s]+)/', $input, $matches)) {
 			$this->tags = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -554,7 +515,7 @@ class FreshRSS_Search {
 		return $input;
 	}
 
-	private function parseNotTagsSearch($input) {
+	private function parseNotTagsSearch(string $input): string {
 		if (preg_match_all('/[!-]#(?P<search>[^\s]+)/', $input, $matches)) {
 			$this->not_tags = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -568,10 +529,8 @@ class FreshRSS_Search {
 	 * Parse the search string to find search values.
 	 * Every word is a distinct search value, except when using a delimiter.
 	 * Supported delimiters are single quote (') and double quotes (").
-	 *
-	 * @param string $input
 	 */
-	private function parseSearch($input) {
+	private function parseSearch(string $input): void {
 		$input = self::cleanSearch($input);
 		if ($input == '') {
 			return;
@@ -591,17 +550,17 @@ class FreshRSS_Search {
 		}
 	}
 
-	private function parseNotSearch($input) {
+	private function parseNotSearch(string $input): string {
 		$input = self::cleanSearch($input);
 		if ($input == '') {
-			return;
+			return '';
 		}
 		if (preg_match_all('/[!-](?P<delim>[\'"])(?P<search>.*)(?P=delim)/U', $input, $matches)) {
 			$this->not_search = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
 		}
 		if ($input == '') {
-			return;
+			return '';
 		}
 		if (preg_match_all('/[!-](?P<search>[^\s]+)/', $input, $matches)) {
 			$this->not_search = array_merge(is_array($this->not_search) ? $this->not_search : array(), $matches['search']);
@@ -613,11 +572,8 @@ class FreshRSS_Search {
 
 	/**
 	 * Remove all unnecessary spaces in the search
-	 *
-	 * @param string $input
-	 * @return string
 	 */
-	private static function cleanSearch($input) {
+	private static function cleanSearch($input): string {
 		$input = preg_replace('/\s+/', ' ', $input);
 		return trim($input);
 	}

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -429,7 +429,7 @@ class FreshRSS_Search {
 	 * Parse the search string to find inurl keyword and the search related to it.
 	 * The search is the first word following the keyword.
 	 */
-	private function parseInurlSearch($input) {
+	private function parseInurlSearch(string $input): string {
 		if (preg_match_all('/\binurl:(?P<search>[^\s]*)/', $input, $matches)) {
 			$this->inurl = $matches['search'];
 			$input = str_replace($matches[0], '', $input);
@@ -573,7 +573,7 @@ class FreshRSS_Search {
 	/**
 	 * Remove all unnecessary spaces in the search
 	 */
-	private static function cleanSearch($input): string {
+	private static function cleanSearch(string $input): string {
 		$input = preg_replace('/\s+/', ' ', $input);
 		return trim($input);
 	}

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -529,8 +529,9 @@ class FreshRSS_Search {
 	 * Parse the search string to find search values.
 	 * Every word is a distinct search value, except when using a delimiter.
 	 * Supported delimiters are single quote (') and double quotes (").
+	 * @return void
 	 */
-	private function parseSearch(string $input): void {
+	private function parseSearch(string $input) {
 		$input = self::cleanSearch($input);
 		if ($input == '') {
 			return;

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -295,7 +295,7 @@ class Minz_ExtensionManager {
 	 * array keys.
 	 *
 	 * @param string $hook_name the hook to call.
-	 * @param mixed $args additional parameters (for signature, please see self::$hook_list).
+	 * @param mixed ...$args additional parameters (for signature, please see self::$hook_list).
 	 * @return mixed|null final result of the called hook.
 	 */
 	public static function callHook($hook_name, ...$args) {

--- a/lib/Minz/Migrator.php
+++ b/lib/Minz/Migrator.php
@@ -130,7 +130,7 @@ class Minz_Migrator
 	{
 		$this->applied_versions = [];
 
-		if (!is_dir($directory)) {
+		if ($directory == null || !is_dir($directory)) {
 			return;
 		}
 

--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -179,7 +179,7 @@ class Minz_Translate {
 	/**
 	 * Translate a key into its corresponding value based on selected language.
 	 * @param string $key the key to translate.
-	 * @param mixed $args additional parameters for variable keys.
+	 * @param mixed ...$args additional parameters for variable keys.
 	 * @return string value corresponding to the key.
 	 *         If no value is found, return the key itself.
 	 */
@@ -247,7 +247,7 @@ class Minz_Translate {
 /**
  * Alias for Minz_Translate::t()
  * @param string $key
- * @param mixed $args
+ * @param mixed ...$args
  */
 function _t($key, ...$args) {
 	return Minz_Translate::t($key, ...$args);

--- a/lib/Minz/Url.php
+++ b/lib/Minz/Url.php
@@ -121,7 +121,7 @@ class Minz_Url {
 /**
  * @param string $controller
  * @param string $action
- * @param string $args
+ * @param string ...$args
  */
 function _url ($controller, $action, ...$args) {
 	$nb_args = count($args);

--- a/lib/lib_phpQuery.php
+++ b/lib/lib_phpQuery.php
@@ -4068,9 +4068,11 @@ class phpQueryObject
 
 	// ITERATOR INTERFACE
 	/**
-   * @access private
+	 * @return void
+	 * @access private
 	 */
-	public function rewind(): void {
+	#[\ReturnTypeWillChange]
+	public function rewind() {
 		$this->debug('iterating foreach');
 //		phpQuery::selectDocument($this->getDocumentID());
 		$this->elementsBackup = $this->elements;
@@ -4083,15 +4085,19 @@ class phpQueryObject
 		$this->current = 0;
 	}
 	/**
-   * @access private
+	 * @return DOMElement
+	 * @access private
 	 */
-	public function current(): mixed {
+	#[\ReturnTypeWillChange]
+	public function current() {
 		return $this->elementsInterator[ $this->current ];
 	}
 	/**
-   * @access private
+	 * @return mixed
+	 * @access private
 	 */
-	public function key(): mixed {
+	#[\ReturnTypeWillChange]
+	public function key() {
 		return $this->current;
 	}
 	/**
@@ -4144,16 +4150,20 @@ class phpQueryObject
 		return $this->find($offset);
 	}
 	/**
-   * @access private
+	 * @return void
+	 * @access private
 	 */
-	public function offsetSet($offset, $value): void {
+	#[\ReturnTypeWillChange]
+	public function offsetSet($offset, $value) {
 //		$this->find($offset)->replaceWith($value);
 		$this->find($offset)->html($value);
 	}
 	/**
-   * @access private
+	 * @return void
+	 * @access private
 	 */
-	public function offsetUnset($offset): void {
+	#[\ReturnTypeWillChange]
+	public function offsetUnset($offset) {
 		// empty
 		throw new Exception("Can't do unset, use array interface only for calling queries and replacing HTML.");
 	}

--- a/lib/lib_phpQuery.php
+++ b/lib/lib_phpQuery.php
@@ -145,7 +145,7 @@ class DOMDocumentWrapper {
 	public $id;
 	/**
 	 * @todo Rewrite as method and quess if null.
-	 * @var unknown_type
+	 * @var string
 	 */
 	public $contentType = '';
 	public $xpath;
@@ -157,7 +157,6 @@ class DOMDocumentWrapper {
 	public $eventsGlobal = array();
 	/**
 	 * @TODO iframes support http://code.google.com/p/phpquery/issues/detail?id=28
-	 * @var unknown_type
 	 */
 	public $frames = array();
 	/**
@@ -475,7 +474,7 @@ class DOMDocumentWrapper {
 		return $contentType[1];
 	}
 	protected function charsetFromXML($markup) {
-		$matches;
+		$matches = array();
 		// find declaration
 		preg_match('@<'.'?xml[^>]+encoding\\s*=\\s*(["|\'])(.*?)\\1@i',
 			$markup, $matches
@@ -817,8 +816,8 @@ abstract class phpQueryEvents {
 	 * Trigger a type of event on every matched element.
 	 *
 	 * @param DOMNode|phpQueryObject|string $document
-	 * @param unknown_type $type
-	 * @param unknown_type $data
+	 * @param string $type
+	 * @param array<DOMEvent> $data
 	 *
 	 * @TODO exclusive events (with !)
 	 * @TODO global events (test)
@@ -1199,6 +1198,7 @@ class phpQueryObject
 	protected $elementsInterator = array();
 	/**
 	 * Iterator interface helper
+	 * @var bool
 	 * @access private
 	 */
 	protected $valid = false;
@@ -1709,12 +1709,11 @@ class phpQueryObject
 	 *
 	 * In the future, when PHP will support XLS 2.0, then we would do that this way:
 	 * contains(tokenize(@class, '\s'), "something")
-	 * @param unknown_type $class
-	 * @param unknown_type $node
-	 * @return boolean
+	 * @param string $class
+	 * @param DOMElement $node
 	 * @access private
 	 */
-	protected function matchClasses($class, $node) {
+	protected function matchClasses(string $class, object $node): bool {
 		// multi-class
 		if ( mb_strpos($class, '.', 1)) {
 			$classes = explode('.', substr($class, 1));
@@ -1904,7 +1903,7 @@ class phpQueryObject
 					if ($execute) {
 						$this->runQuery($XQuery, $s, 'is');
 						$XQuery = '';
-						if (! $this->length())
+						if (!$this->size())
 							break;
 					}
 				// CLASSES
@@ -1916,7 +1915,7 @@ class phpQueryObject
 					$XQuery .= '[@class]';
 					$this->runQuery($XQuery, $s, 'matchClasses');
 					$XQuery = '';
-					if (! $this->length() )
+					if (!$this->size() )
 						break;
 				// ~ General Sibling Selector
 				} else if ($s[0] == '~') {
@@ -1926,7 +1925,7 @@ class phpQueryObject
 						->siblings(
 							substr($s, 1)
 						)->elements;
-					if (! $this->length() )
+					if (!$this->size() )
 						break;
 				// + Adjacent sibling selectors
 				} else if ($s[0] == '+') {
@@ -1944,7 +1943,7 @@ class phpQueryObject
 						if ($test && $this->is($subSelector, $test))
 							$this->elements[] = $test;
 					}
-					if (! $this->length() )
+					if (!$this->size() )
 						break;
 				// PSEUDO CLASSES
 				} else if ($s[0] == ':') {
@@ -1953,10 +1952,10 @@ class phpQueryObject
 						$this->runQuery($XQuery);
 						$XQuery = '';
 					}
-					if (! $this->length())
+					if (!$this->size())
 						break;
 					$this->pseudoClasses($s);
-					if (! $this->length())
+					if (!$this->size())
 						break;
 				// DIRECT DESCENDANDS
 				} else if ($s == '>') {
@@ -2438,12 +2437,9 @@ class phpQueryObject
 		}
 	}
 	/**
-	 *
-	 * @param $value
-	 * @return unknown_type
 	 * @TODO implement in all methods using passed parameters
 	 */
-	protected static function unQuote($value) {
+	protected static function unQuote(string $value): string {
 		return $value[0] == '\'' || $value[0] == '"'
 			? substr($value, 1, -1)
 			: $value;
@@ -2619,7 +2615,7 @@ class phpQueryObject
 	 */
 	public function wrapAllOld($wrapper) {
 		$wrapper = pq($wrapper)->_clone();
-		if (! $wrapper->length() || ! $this->length() )
+		if (!$wrapper->size() || !$this->size() )
 			return $this;
 		$wrapper->insertBefore($this->elements[0]);
 		$deepest = $wrapper->elements[0];
@@ -2636,7 +2632,7 @@ class phpQueryObject
 	 * @return phpQueryObject|QueryTemplatesSource|QueryTemplatesParse|QueryTemplatesSourceQuery
 	 */
 	public function wrapAll($wrapper) {
-		if (! $this->length())
+		if (!$this->size())
 			return $this;
 		return phpQuery::pq($wrapper, $this->getDocumentID())
 			->clone()
@@ -2785,12 +2781,8 @@ class phpQueryObject
 			$this->elements[] = $oldStack[$num];
 		return $this->newInstance();
 	}
-	/**
-	 * Enter description here...
-	 *
-	 * @return phpQueryObject|QueryTemplatesSource|QueryTemplatesParse|QueryTemplatesSourceQuery
-	 */
-	public function size() {
+
+	public function size(): int {
 		return count($this->elements);
 	}
 	/**
@@ -2802,7 +2794,7 @@ class phpQueryObject
 	public function length() {
 		return $this->size();
 	}
-	public function count() {
+	public function count(): int {
 		return $this->size();
 	}
 	/**
@@ -3346,15 +3338,10 @@ class phpQueryObject
 		return $index;
 	}
 	/**
-	 * Enter description here...
-	 *
-	 * @param unknown_type $start
-	 * @param unknown_type $end
-	 *
-	 * @return phpQueryObject|QueryTemplatesSource|QueryTemplatesParse|QueryTemplatesSourceQuery
+	 * @return phpQueryObject
 	 * @testme
 	 */
-	public function slice($start, $end = null) {
+	public function slice(int $start, $end = null): object {
 //		$last = count($this->elements)-1;
 //		$end = $end
 //			? min($end, $last)
@@ -3370,11 +3357,9 @@ class phpQueryObject
 		);
 	}
 	/**
-	 * Enter description here...
-	 *
-	 * @return phpQueryObject|QueryTemplatesSource|QueryTemplatesParse|QueryTemplatesSourceQuery
+	 * @return phpQueryObject
 	 */
-	public function reverse() {
+	public function reverse(): object {
 		$this->elementsBackup = $this->elements;
 		$this->elements = array_reverse($this->elements);
 		return $this->newInstance();
@@ -3418,7 +3403,7 @@ class phpQueryObject
 	 * @return unknown_type
 	 */
 	public static function extend($class, $file = null) {
-		return $this->plugin($class, $file);
+		return phpQuery::plugin($class, $file);
 	}
 	/**
 	 *
@@ -4085,7 +4070,7 @@ class phpQueryObject
 	/**
    * @access private
 	 */
-	public function rewind(){
+	public function rewind(): void {
 		$this->debug('iterating foreach');
 //		phpQuery::selectDocument($this->getDocumentID());
 		$this->elementsBackup = $this->elements;
@@ -4100,13 +4085,13 @@ class phpQueryObject
 	/**
    * @access private
 	 */
-	public function current(){
+	public function current(): mixed {
 		return $this->elementsInterator[ $this->current ];
 	}
 	/**
    * @access private
 	 */
-	public function key(){
+	public function key(): mixed {
 		return $this->current;
 	}
 	/**
@@ -4120,6 +4105,7 @@ class phpQueryObject
 	 * @see phpQueryObject::_next()
 	 * @return phpQueryObject|QueryTemplatesSource|QueryTemplatesParse|QueryTemplatesSourceQuery
 	 */
+	#[\ReturnTypeWillChange]
 	public function next($cssSelector = null){
 //		if ($cssSelector || $this->valid)
 //			return $this->_next($cssSelector);
@@ -4137,7 +4123,7 @@ class phpQueryObject
 	/**
    * @access private
 	 */
-	public function valid(){
+	public function valid(): bool {
 		return $this->valid;
 	}
 	// ITERATOR INTERFACE END
@@ -4145,26 +4131,29 @@ class phpQueryObject
 	/**
    * @access private
 	 */
-	public function offsetExists($offset) {
+	public function offsetExists($offset): bool {
 		return $this->find($offset)->size() > 0;
 	}
 	/**
-   * @access private
+	 * @access private
+	 * @param mixed $offset
+	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset) {
 		return $this->find($offset);
 	}
 	/**
    * @access private
 	 */
-	public function offsetSet($offset, $value) {
+	public function offsetSet($offset, $value): void {
 //		$this->find($offset)->replaceWith($value);
 		$this->find($offset)->html($value);
 	}
 	/**
    * @access private
 	 */
-	public function offsetUnset($offset) {
+	public function offsetUnset($offset): void {
 		// empty
 		throw new Exception("Can't do unset, use array interface only for calling queries and replacing HTML.");
 	}
@@ -4277,7 +4266,7 @@ class phpQueryObject
 		$debug = phpQuery::$debug;
 		phpQuery::$debug = false;
 //		print __FILE__.':'.__LINE__."\n";
-		var_dump('length', $this->length());
+		var_dump('length', $this->size());
 		phpQuery::$debug = $debug;
 		return $this;
 	}
@@ -4437,8 +4426,6 @@ abstract class phpQuery {
 	public static $plugins = array();
 	/**
 	 * List of loaded plugins.
-	 *
-	 * @var unknown_type
 	 */
 	public static $pluginsLoaded = array();
 	public static $pluginsMethods = array();
@@ -4721,7 +4708,7 @@ abstract class phpQuery {
 		$php = preg_replace($regex, '\\1<php><!-- \\3 --></php>', $php);
 		return $php;
 	}
-	public static function _phpToMarkupCallback($php, $charset = 'utf-8') {
+	public static function _phpToMarkupCallback($m, $charset = 'utf-8') {
 		return $m[1].$m[2]
 			.htmlspecialchars("<"."?php".$m[4]."?".">", ENT_QUOTES|ENT_NOQUOTES, $charset)
 			.$m[5].$m[2];
@@ -5011,7 +4998,6 @@ abstract class phpQuery {
 	/**
 	 * Checks if $input is HTML string, which has to start with '<'.
 	 *
-	 * @deprecated
 	 * @param String $input
 	 * @return Bool
 	 * @todo still used ?
@@ -5226,7 +5212,7 @@ abstract class phpQuery {
 	 *
 	 */
 	public static function param($data) {
-		return http_build_query($data, null, '&');
+		return http_build_query($data, '', '&');
 	}
 	public static function get($url, $data = null, $callback = null, $type = null) {
 		if (!is_array($data)) {
@@ -5354,8 +5340,8 @@ abstract class phpQuery {
 	public static function getDOMDocument($source) {
 		if ($source instanceof DOMDOCUMENT)
 			return $source;
-		$source = self::getDocumentID($source);
-		return $source
+		$id = self::getDocumentID($source);
+		return $id
 			? self::$documents[$id]['document']
 			: null;
 	}
@@ -5368,7 +5354,7 @@ abstract class phpQuery {
 	 * @return unknown_type
 	 * @link http://docs.jquery.com/Utilities/jQuery.makeArray
 	 */
-	public static function makeArray($obj) {
+	public static function makeArray($object) {
 		$array = array();
 		if (is_object($object) && $object instanceof DOMNODELIST) {
 			foreach($object as $value)
@@ -5467,12 +5453,12 @@ abstract class phpQuery {
 	}
 	/**
 	 * Merge 2 phpQuery objects.
-	 * @param array $one
-	 * @param array $two
+	 * @param phpQueryObject $one
+	 * @param phpQueryObject $two
 	 * @protected
 	 * @todo node lists, phpQueryObject
 	 */
-	public static function merge($one, $two) {
+	public static function merge(object $one, object $two): array {
 		$elements = $one->elements;
 		foreach($two->elements as $node) {
 			$exists = false;

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -19,10 +19,10 @@ if (COPY_SYSLOG_TO_STDERR) {
 /**
  * Build a directory path by concatenating a list of directory names.
  *
- * @param string $path_parts a list of directory names
+ * @param string ...$path_parts a list of directory names
  * @return string corresponding to the final pathname
  */
-function join_path(...$path_parts) {
+function join_path(...$path_parts): string {
 	return join(DIRECTORY_SEPARATOR, $path_parts);
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/4012

Taking advantage of https://github.com/FreshRSS/FreshRSS/pull/4121

Contributes to https://github.com/FreshRSS/FreshRSS/issues/4112

Allow our default CI to pass without warnings

```sh
# Run all tests with newest PHP 8.1:
docker run --rm -v $PWD:/var/www/FreshRSS freshrss/freshrss:newest bin/composer test

# Run all tests with default PHP 7.4
docker run --rm -v $PWD:/var/www/FreshRSS freshrss/freshrss bin/composer test
# Two inconsequential warnings in PHPStan due to method signatures updated from PHP7 to PHP8:
# ob_implicit_flush and simplexml_load_string

# Run minimal syntax tests with oldest PHP 7.0:
docker run --rm -v $PWD:/var/www/FreshRSS freshrss/freshrss:oldest \
  sh -c "find . -type d -name 'vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l 1>/dev/null"
```