### PR TITLE
delete the no-mobile css class

### DIFF
--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -38,7 +38,7 @@
 
 				<li class="dropdown-header">
 					<?= _t('index.menu.queries') ?>
-					<a class="no-mobile" href="<?= _url('configure', 'queries') ?>"><?= _i('configure') ?></a>
+					<a href="<?= _url('configure', 'queries') ?>"><?= _i('configure') ?></a>
 				</li>
 
 				<?php foreach (FreshRSS_Context::$user_conf->queries as $query) { ?>
@@ -48,7 +48,7 @@
 				<?php } ?>
 
 				<?php if (count(FreshRSS_Context::$user_conf->queries) > 0) { ?>
-				<li class="separator no-mobile"></li>
+				<li class="separator"></li>
 				<?php } ?>
 
 				<?php
@@ -56,7 +56,7 @@
 					$url_query['c'] = 'configure';
 					$url_query['a'] = 'bookmarkQuery';
 				?>
-				<li class="item no-mobile"><a href="<?= Minz_Url::display($url_query) ?>"><?= _i('bookmark-add') ?> <?= _t('index.menu.bookmark_query') ?></a></li>
+				<li class="item"><a href="<?= Minz_Url::display($url_query) ?>"><?= _i('bookmark-add') ?> <?= _t('index.menu.bookmark_query') ?></a></li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
Partially #4127

Changes proposed in this pull request:

- show the full dropdown menu of user query menu
- deleted the no-mobile CSS class

How to test the feature manually:

1. open the dropdown of the user query menu
2. see the cog icon
3. see the bookmark menu entry


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
