### PR TITLE
Fix SCSS differences to the final CSS

### DIFF
--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -368,7 +368,6 @@
 	code {
 		padding: 2px 5px;
 		background: $grey-lighter;
-		color: $grey-light;
 		border: 1px solid $grey-light;
 		border-radius: 3px;
 	}

--- a/p/themes/Ansum/_list-view.scss
+++ b/p/themes/Ansum/_list-view.scss
@@ -71,7 +71,7 @@
 		}
 	}
 
-	.date {
+	.item.date {
 		color: scale-color($main-font-color, $alpha: -50%);
 		font-size: 0.85rem;
 	}

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -72,9 +72,6 @@
 	vertical-align: middle;
 	cursor: pointer;
 	overflow: hidden;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .btn.btn-important {
@@ -121,8 +118,8 @@ label {
 }
 
 textarea {
-	width: 360px;
 	max-width: 100%;
+	width: 360px;
 	height: 100px;
 }
 
@@ -256,9 +253,6 @@ form th {
 	letter-spacing: 1px;
 }
 .dropdown-menu .item {
-	-webkit-transition: all 0.075s ease-in-out;
-	-moz-transition: all 0.075s ease-in-out;
-	-o-transition: all 0.075s ease-in-out;
 	transition: all 0.075s ease-in-out;
 }
 .dropdown-menu .item a, .dropdown-menu .item span, .dropdown-menu .item .as-link {
@@ -468,9 +462,6 @@ form th {
 	text-decoration: none;
 	background: #fdf6ef;
 	color: #ca7227;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 #bigMarkAsRead:hover {
@@ -575,9 +566,6 @@ form th {
 	line-height: 2.5rem;
 	font-size: 1rem;
 	font-weight: 400;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .tree .tree-folder .tree-folder-items .item.active {
@@ -662,9 +650,6 @@ form th {
 }
 .nav-list .item {
 	background: #fbf9f6;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav-list .item a {
@@ -822,9 +807,6 @@ form th {
 	border: none;
 	border-radius: 2px 0 0 2px;
 	background-color: #f7f2ea;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .header .item.search input:hover {
@@ -960,9 +942,6 @@ form th {
 	background-color: #fcfaf8;
 	background-position: center;
 	background-repeat: no-repeat;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn:hover {
@@ -1002,9 +981,6 @@ form th {
 	padding: 5px 16px;
 	color: #363330;
 	background-color: #fcfaf8;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn.read_all:hover {
@@ -1166,9 +1142,6 @@ form th {
 /*=== Feed articles */
 .flux {
 	background: #fff;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux:hover {
@@ -1198,9 +1171,6 @@ form th {
 }
 .flux.favorite {
 	border-left-color: #ffc300;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux.favorite:not(.current) {
@@ -1455,9 +1425,6 @@ form th {
 		display: inline-block;
 		width: 100%;
 		color: #363330;
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	ul.nav .item a:hover, ul.nav .item a:active {
@@ -1471,9 +1438,6 @@ form th {
 	}
 
 	.aside {
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	.aside.aside_feed {
@@ -1484,9 +1448,9 @@ form th {
 	}
 
 	.aside .toggle_aside,
-	#panel .close,
-	#close-slider.active,
-	.dropdown-menu .toggle_aside {
+#panel .close,
+#close-slider.active,
+.dropdown-menu .toggle_aside {
 		background: #b7641d;
 		display: block;
 		width: 100%;
@@ -1498,11 +1462,11 @@ form th {
 	.header {
 		padding: 0.5rem;
 	}
-	.header .item.search form {
-		display: inherit;
-	}
 	.header .item.search {
 		display: block;
+	}
+	.header .item.search form {
+		display: inherit;
 	}
 	.header .item.search .stick {
 		display: flex;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -72,9 +72,6 @@
 	vertical-align: middle;
 	cursor: pointer;
 	overflow: hidden;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .btn.btn-important {
@@ -121,8 +118,8 @@ label {
 }
 
 textarea {
-	width: 360px;
 	max-width: 100%;
+	width: 360px;
 	height: 100px;
 }
 
@@ -256,9 +253,6 @@ form th {
 	letter-spacing: 1px;
 }
 .dropdown-menu .item {
-	-webkit-transition: all 0.075s ease-in-out;
-	-moz-transition: all 0.075s ease-in-out;
-	-o-transition: all 0.075s ease-in-out;
 	transition: all 0.075s ease-in-out;
 }
 .dropdown-menu .item a, .dropdown-menu .item span, .dropdown-menu .item .as-link {
@@ -468,9 +462,6 @@ form th {
 	text-decoration: none;
 	background: #fdf6ef;
 	color: #ca7227;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 #bigMarkAsRead:hover {
@@ -575,9 +566,6 @@ form th {
 	line-height: 2.5rem;
 	font-size: 1rem;
 	font-weight: 400;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .tree .tree-folder .tree-folder-items .item.active {
@@ -662,9 +650,6 @@ form th {
 }
 .nav-list .item {
 	background: #fbf9f6;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav-list .item a {
@@ -822,9 +807,6 @@ form th {
 	border: none;
 	border-radius: 0 2px 2px 0;
 	background-color: #f7f2ea;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .header .item.search input:hover {
@@ -960,9 +942,6 @@ form th {
 	background-color: #fcfaf8;
 	background-position: center;
 	background-repeat: no-repeat;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn:hover {
@@ -1002,9 +981,6 @@ form th {
 	padding: 5px 16px;
 	color: #363330;
 	background-color: #fcfaf8;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn.read_all:hover {
@@ -1166,9 +1142,6 @@ form th {
 /*=== Feed articles */
 .flux {
 	background: #fff;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux:hover {
@@ -1198,9 +1171,6 @@ form th {
 }
 .flux.favorite {
 	border-right-color: #ffc300;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux.favorite:not(.current) {
@@ -1455,9 +1425,6 @@ form th {
 		display: inline-block;
 		width: 100%;
 		color: #363330;
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	ul.nav .item a:hover, ul.nav .item a:active {
@@ -1471,9 +1438,6 @@ form th {
 	}
 
 	.aside {
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	.aside.aside_feed {
@@ -1484,9 +1448,9 @@ form th {
 	}
 
 	.aside .toggle_aside,
-	#panel .close,
-	#close-slider.active,
-	.dropdown-menu .toggle_aside {
+#panel .close,
+#close-slider.active,
+.dropdown-menu .toggle_aside {
 		background: #b7641d;
 		display: block;
 		width: 100%;
@@ -1498,11 +1462,11 @@ form th {
 	.header {
 		padding: 0.5rem;
 	}
-	.header .item.search form {
-		display: inherit;
-	}
 	.header .item.search {
 		display: block;
+	}
+	.header .item.search form {
+		display: inherit;
 	}
 	.header .item.search .stick {
 		display: flex;
@@ -1603,3 +1567,5 @@ a, button.as-link {
 	outline: none;
 	color: #ca7227;
 }
+
+/*# sourceMappingURL=ansum.css.map */

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1567,5 +1567,3 @@ a, button.as-link {
 	outline: none;
 	color: #ca7227;
 }
-
-/*# sourceMappingURL=ansum.css.map */

--- a/p/themes/Mapco/_layout.scss
+++ b/p/themes/Mapco/_layout.scss
@@ -8,6 +8,11 @@
 	width: auto;
 	table-layout: none;
 
+	.logo {
+		margin: 11px 0 5px;
+		filter: grayscale(100%) brightness(100);
+	}
+
 	.item {
 		vertical-align: middle;
 		// text-align: center;
@@ -97,12 +102,6 @@
 			}
 		}
 	}
-
-	.logo {
-		margin: 11px 0 5px;
-		filter: grayscale(100%) brightness(100);
-	}
-
 }
 
 /*=== Body */
@@ -372,7 +371,6 @@
 	code {
 		padding: 2px 5px;
 		background: $grey-lighter;
-		color: $grey-light;
 		border: 1px solid $grey-light;
 		border-radius: 3px;
 	}

--- a/p/themes/Mapco/_list-view.scss
+++ b/p/themes/Mapco/_list-view.scss
@@ -72,7 +72,7 @@
 		}
 	}
 
-	.date {
+	.item.date {
 		color: scale-color($main-font-color, $alpha: -50%);
 		font-size: 0.85rem;
 	}

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -72,10 +72,6 @@
 	vertical-align: middle;
 	cursor: pointer;
 	overflow: hidden;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .btn.btn-important {
@@ -122,8 +118,8 @@ label {
 }
 
 textarea {
-	width: 360px;
 	max-width: 100%;
+	width: 360px;
 	height: 100px;
 }
 
@@ -257,10 +253,6 @@ form th {
 	letter-spacing: 1px;
 }
 .dropdown-menu .item {
-	-webkit-transition: all 0.075s ease-in-out;
-	-moz-transition: all 0.075s ease-in-out;
-	-o-transition: all 0.075s ease-in-out;
-	-ms-transition: all 0.075s ease-in-out;
 	transition: all 0.075s ease-in-out;
 }
 .dropdown-menu .item a, .dropdown-menu .item span, .dropdown-menu .item .as-link {
@@ -470,10 +462,6 @@ form th {
 	text-decoration: none;
 	background: #effcfd;
 	color: #36c;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 #bigMarkAsRead:hover {
@@ -577,10 +565,6 @@ form th {
 	line-height: 2.5rem;
 	font-size: 1rem;
 	font-weight: 400;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .tree .tree-folder .tree-folder-items .item.active {
@@ -664,10 +648,6 @@ form th {
 }
 .nav-list .item {
 	background: #303136;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav-list .item a {
@@ -808,16 +788,16 @@ form th {
 	width: auto;
 	table-layout: none;
 }
+.header .logo {
+	margin: 11px 0 5px;
+	filter: grayscale(100%) brightness(100);
+}
 .header .item {
 	vertical-align: middle;
 }
 .header .item.title {
 	width: 280px;
 	font-weight: 400;
-}
-.header .logo {
-	margin: 11px 0 5px;
-	filter: grayscale(100%) brightness(100);
 }
 .header .item.title a img {
 	margin-right: 0.5rem;
@@ -828,10 +808,6 @@ form th {
 	border: none;
 	border-radius: 2px 0 0 2px;
 	background-color: #26272a;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .header .item.search input:hover {
@@ -967,10 +943,6 @@ form th {
 	background-color: #f9fafb;
 	background-position: center;
 	background-repeat: no-repeat;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn:hover {
@@ -1010,10 +982,6 @@ form th {
 	padding: 5px 16px;
 	color: #303136;
 	background-color: #f9fafb;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn.read_all:hover {
@@ -1175,10 +1143,6 @@ form th {
 /*=== Feed articles */
 .flux {
 	background: #fff;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux:hover {
@@ -1208,10 +1172,6 @@ form th {
 }
 .flux.favorite {
 	border-left-color: #ffc300;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux.favorite:not(.current) {
@@ -1466,10 +1426,6 @@ form th {
 		display: inline-block;
 		width: 100%;
 		color: #fff;
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
-		-ms-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	ul.nav .item a:hover, ul.nav .item a:active {
@@ -1482,10 +1438,6 @@ form th {
 	}
 
 	.aside {
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
-		-ms-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	.aside.aside_feed {
@@ -1496,9 +1448,9 @@ form th {
 	}
 
 	.aside .toggle_aside,
-	#panel .close,
-	#close-slider.active,
-	.dropdown-menu .toggle_aside {
+#panel .close,
+#close-slider.active,
+.dropdown-menu .toggle_aside {
 		background: #25c;
 		display: block;
 		width: 100%;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -72,10 +72,6 @@
 	vertical-align: middle;
 	cursor: pointer;
 	overflow: hidden;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .btn.btn-important {
@@ -122,8 +118,8 @@ label {
 }
 
 textarea {
-	width: 360px;
 	max-width: 100%;
+	width: 360px;
 	height: 100px;
 }
 
@@ -238,14 +234,13 @@ form th {
 	text-align: right;
 }
 .dropdown-menu::after {
-	background: #f9fafb;
+	background: white;
 	width: 10px;
 	height: 10px;
 	content: "";
 	position: absolute;
 	top: -4px;
 	left: 18px;
-	bottom: -14px;
 	z-index: -10;
 	transform: rotate(-45deg);
 }
@@ -258,10 +253,6 @@ form th {
 	letter-spacing: 1px;
 }
 .dropdown-menu .item {
-	-webkit-transition: all 0.075s ease-in-out;
-	-moz-transition: all 0.075s ease-in-out;
-	-o-transition: all 0.075s ease-in-out;
-	-ms-transition: all 0.075s ease-in-out;
 	transition: all 0.075s ease-in-out;
 }
 .dropdown-menu .item a, .dropdown-menu .item span, .dropdown-menu .item .as-link {
@@ -471,10 +462,6 @@ form th {
 	text-decoration: none;
 	background: #effcfd;
 	color: #36c;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 #bigMarkAsRead:hover {
@@ -578,10 +565,6 @@ form th {
 	line-height: 2.5rem;
 	font-size: 1rem;
 	font-weight: 400;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .tree .tree-folder .tree-folder-items .item.active {
@@ -665,10 +648,6 @@ form th {
 }
 .nav-list .item {
 	background: #303136;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav-list .item a {
@@ -809,16 +788,16 @@ form th {
 	width: auto;
 	table-layout: none;
 }
+.header .logo {
+	margin: 11px 0 5px;
+	filter: grayscale(100%) brightness(100);
+}
 .header .item {
 	vertical-align: middle;
 }
 .header .item.title {
 	width: 280px;
 	font-weight: 400;
-}
-.header .logo {
-	margin: 11px 0 5px;
-	filter: grayscale(100%) brightness(100);
 }
 .header .item.title a img {
 	margin-left: 0.5rem;
@@ -829,10 +808,6 @@ form th {
 	border: none;
 	border-radius: 0 2px 2px 0;
 	background-color: #26272a;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .header .item.search input:hover {
@@ -968,10 +943,6 @@ form th {
 	background-color: #f9fafb;
 	background-position: center;
 	background-repeat: no-repeat;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn:hover {
@@ -1011,10 +982,6 @@ form th {
 	padding: 5px 16px;
 	color: #303136;
 	background-color: #f9fafb;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .nav_menu .stick .btn.read_all:hover {
@@ -1176,10 +1143,6 @@ form th {
 /*=== Feed articles */
 .flux {
 	background: #fff;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux:hover {
@@ -1209,10 +1172,6 @@ form th {
 }
 .flux.favorite {
 	border-right-color: #ffc300;
-	-webkit-transition: all 0.15s ease-in-out;
-	-moz-transition: all 0.15s ease-in-out;
-	-o-transition: all 0.15s ease-in-out;
-	-ms-transition: all 0.15s ease-in-out;
 	transition: all 0.15s ease-in-out;
 }
 .flux.favorite:not(.current) {
@@ -1467,10 +1426,6 @@ form th {
 		display: inline-block;
 		width: 100%;
 		color: #fff;
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
-		-ms-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	ul.nav .item a:hover, ul.nav .item a:active {
@@ -1483,10 +1438,6 @@ form th {
 	}
 
 	.aside {
-		-webkit-transition: all 0.2s ease-in-out;
-		-moz-transition: all 0.2s ease-in-out;
-		-o-transition: all 0.2s ease-in-out;
-		-ms-transition: all 0.2s ease-in-out;
 		transition: all 0.2s ease-in-out;
 	}
 	.aside.aside_feed {
@@ -1497,9 +1448,9 @@ form th {
 	}
 
 	.aside .toggle_aside,
-	#panel .close,
-	#close-slider.active,
-	.dropdown-menu .toggle_aside {
+#panel .close,
+#close-slider.active,
+.dropdown-menu .toggle_aside {
 		background: #25c;
 		display: block;
 		width: 100%;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -234,13 +234,14 @@ form th {
 	text-align: right;
 }
 .dropdown-menu::after {
-	background: white;
+	background: #f9fafb;
 	width: 10px;
 	height: 10px;
 	content: "";
 	position: absolute;
 	top: -4px;
 	left: 18px;
+	bottom: -14px;
 	z-index: -10;
 	transform: rotate(-45deg);
 }


### PR DESCRIPTION
While I worked on the themes, I found out that some SCSS files does not compile to the existing CSS file content. In some cases there are some differences.
So I clean it up with this PR

Changes proposed in this pull request:

- delete browser prefixes for transitions (I checked the compatibility. Safari, Firefox and Opera does not have been needed the prefix minimum since 2015)
- little corrections (leading is the existing CSS file).

How to test the feature manually:

1. check around the themes

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested