### PR TITLE
Fix: dropdown menu triangle in mobile view

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -304,18 +304,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	display: none;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #ddd;
-	border-left: 1px solid #ddd;
-	content: "";
-	position: absolute;
-	top: -6px;
-	right: 13px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border-color: #ddd;
 }
 
 .dropdown-header {

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -304,18 +304,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	display: none;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #ddd;
-	border-right: 1px solid #ddd;
-	content: "";
-	position: absolute;
-	top: -6px;
-	left: 13px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border-color: #ddd;
 }
 
 .dropdown-header {

--- a/p/themes/Ansum/_components.scss
+++ b/p/themes/Ansum/_components.scss
@@ -30,18 +30,8 @@
 	text-align: left;
 
 	&::after {
-		background: $grey-lighter;
-		width: 10px;
-		height: 10px;
-		content: "";
-		position: absolute;
-		top: -4px;
-		right: 18px;
-		bottom: -14px;
-		z-index: -10;
-		transform: rotate(45deg);
-		// border-top: 1px solid #95a5a6;
-		// border-left: 1px solid #95a5a6;
+		border: none;
+		right: 17px;
 	}
 
 	.dropdown-header {

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -234,16 +234,8 @@ form th {
 	text-align: left;
 }
 .dropdown-menu::after {
-	background: #fcfaf8;
-	width: 10px;
-	height: 10px;
-	content: "";
-	position: absolute;
-	top: -4px;
-	right: 18px;
-	bottom: -14px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border: none;
+	right: 17px;
 }
 .dropdown-menu .dropdown-header {
 	margin: 1.75rem 0 0.5rem 2rem;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -234,16 +234,8 @@ form th {
 	text-align: right;
 }
 .dropdown-menu::after {
-	background: #fcfaf8;
-	width: 10px;
-	height: 10px;
-	content: "";
-	position: absolute;
-	top: -4px;
-	left: 18px;
-	bottom: -14px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border: none;
+	left: 17px;
 }
 .dropdown-menu .dropdown-header {
 	margin: 1.75rem 2rem 0.5rem 0;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -340,17 +340,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #1a1a1a;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #888;
-	border-left: 1px solid #888;
-	content: "";
-	position: absolute;
-	top: -6px;
-	right: 13px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border-color: #888;
 }
 
 .dropdown-header {

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -1166,6 +1166,7 @@ a.btn {
 		background-color: #1a1a1a;
 		border-top: 1px solid #888;
 		border-left: 1px solid #888;
+		right: 12px;
 	}
 
 	.day .name {

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -1166,6 +1166,7 @@ a.btn {
 		background-color: #1a1a1a;
 		border-top: 1px solid #888;
 		border-right: 1px solid #888;
+		left: 12px;
 	}
 
 	.day .name {

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -340,17 +340,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #1a1a1a;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #888;
-	border-right: 1px solid #888;
-	content: "";
-	position: absolute;
-	top: -6px;
-	left: 13px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border-color: #888;
 }
 
 .dropdown-header {

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -340,17 +340,8 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #95a5a6;
-	border-left: 1px solid #95a5a6;
-	content: "";
-	position: absolute;
-	top: -6px;
-	right: 13px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border-color: #95a5a6;
+	right: 12px;
 }
 
 .dropdown-header {

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -340,17 +340,8 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #95a5a6;
-	border-right: 1px solid #95a5a6;
-	content: "";
-	position: absolute;
-	top: -6px;
-	left: 13px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border-color: #95a5a6;
+	left: 12px;
 }
 
 .dropdown-header {

--- a/p/themes/Mapco/_components.scss
+++ b/p/themes/Mapco/_components.scss
@@ -30,18 +30,8 @@
 	text-align: left;
 
 	&::after {
-		background: $grey-lighter;
-		width: 10px;
-		height: 10px;
-		content: "";
-		position: absolute;
-		top: -4px;
+		border: none;
 		right: 18px;
-		bottom: -14px;
-		z-index: -10;
-		transform: rotate(45deg);
-		// border-top: 1px solid #95a5a6;
-		// border-left: 1px solid #95a5a6;
 	}
 
 	.dropdown-header {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -234,16 +234,8 @@ form th {
 	text-align: left;
 }
 .dropdown-menu::after {
-	background: #f9fafb;
-	width: 10px;
-	height: 10px;
-	content: "";
-	position: absolute;
-	top: -4px;
+	border: none;
 	right: 18px;
-	bottom: -14px;
-	z-index: -10;
-	transform: rotate(45deg);
 }
 .dropdown-menu .dropdown-header {
 	margin: 1.75rem 0 0.5rem 2rem;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -234,16 +234,8 @@ form th {
 	text-align: right;
 }
 .dropdown-menu::after {
-	background: #f9fafb;
-	width: 10px;
-	height: 10px;
-	content: "";
-	position: absolute;
-	top: -4px;
+	border: none;
 	left: 18px;
-	bottom: -14px;
-	z-index: -10;
-	transform: rotate(-45deg);
 }
 .dropdown-menu .dropdown-header {
 	margin: 1.75rem 2rem 0.5rem 0;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -359,18 +359,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #ddd;
-	/* @noflip */
-	border-left: 1px solid #ddd;
-	content: "";
-	position: absolute;
-	top: -6px;
-	right: 13px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border-color: #ddd;
 }
 
 .dropdown-header {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -359,18 +359,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #ddd;
-	/* @noflip */
-	border-right: 1px solid #ddd;
-	content: "";
-	position: absolute;
-	top: -6px;
-	left: 13px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border-color: #ddd;
 }
 
 .dropdown-header {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -327,17 +327,8 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #aaa;
-	border-left: 1px solid #aaa;
-	content: "";
-	position: absolute;
-	top: -6px;
-	right: 13px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border-color: #aaa;
+	right: 8px;
 }
 
 .dropdown-header {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -327,17 +327,8 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #fff;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #aaa;
-	border-right: 1px solid #aaa;
-	content: "";
-	position: absolute;
-	top: -6px;
-	left: 13px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border-color: #aaa;
+	left: 8px;
 }
 
 .dropdown-header {

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -373,17 +373,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #222;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #171717;
-	border-left: 1px solid #171717;
-	content: "";
-	position: absolute;
-	top: -6px;
-	right: 13px;
-	z-index: -10;
-	transform: rotate(45deg);
+	border-color: #171717;
 }
 
 .configure .dropdown-header {

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -373,17 +373,7 @@ a.btn {
 }
 
 .dropdown-menu::after {
-	background: #222;
-	width: 10px;
-	height: 10px;
-	border-top: 1px solid #171717;
-	border-right: 1px solid #171717;
-	content: "";
-	position: absolute;
-	top: -6px;
-	left: 13px;
-	z-index: -10;
-	transform: rotate(-45deg);
+	border-color: #171717;
 }
 
 .configure .dropdown-header {

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -296,6 +296,9 @@ form th {
 .dropdown-menu .dropdown-header {
 	cursor: default;
 }
+.dropdown-menu::after {
+	content: none;
+}
 .dropdown-menu > .item {
 	padding: 0;
 	margin-left: 10px;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -296,6 +296,9 @@ form th {
 .dropdown-menu .dropdown-header {
 	cursor: default;
 }
+.dropdown-menu::after {
+	content: none;
+}
 .dropdown-menu > .item {
 	padding: 0;
 	margin-right: 10px;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -376,6 +376,10 @@ form {
 		cursor: default;
 	}
 
+	&::after {
+		content: none;
+	}
+
 	> {
 		.item {
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -336,6 +336,20 @@ a.btn {
 	right: 0;
 }
 
+.dropdown-menu::after {
+	background-color: inherit;
+	width: 10px;
+	height: 10px;
+	border-width: 1px 0 0 1px;
+	border-style: solid;
+	content: "";
+	position: absolute;
+	top: -6px;
+	right: 13px;
+	z-index: -10;
+	transform: rotate(45deg);
+}
+
 .dropdown-menu-scrollable {
 	max-height: min(75vh, 50em);
 	overflow-x: hidden;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1465,6 +1465,10 @@ input:checked + .slide-container .properties {
 		box-shadow: -3px 0 3px #aaa;
 	}
 
+	.configure .dropdown-target:target ~ .dropdown-toggle::after {
+		content: none;
+	}
+
 	.dropdown-target:target ~ .dropdown-menu {
 		display: table-cell;
 		z-index: 1000;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -336,6 +336,20 @@ a.btn {
 	left: 0;
 }
 
+.dropdown-menu::after {
+	background-color: inherit;
+	width: 10px;
+	height: 10px;
+	border-width: 1px 1px 0 0;
+	border-style: solid;
+	content: "";
+	position: absolute;
+	top: -6px;
+	left: 13px;
+	z-index: -10;
+	transform: rotate(-45deg);
+}
+
 .dropdown-menu-scrollable {
 	max-height: min(75vh, 50em);
 	overflow-x: hidden;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1465,6 +1465,10 @@ input:checked + .slide-container .properties {
 		box-shadow: 3px 0 3px #aaa;
 	}
 
+	.configure .dropdown-target:target ~ .dropdown-toggle::after {
+		content: none;
+	}
+
 	.dropdown-target:target ~ .dropdown-menu {
 		display: table-cell;
 		z-index: 1000;


### PR DESCRIPTION
fixes #4141

before:
![grafik](https://user-images.githubusercontent.com/1645099/150657347-e23bb815-6149-4591-8f18-eefe83b4c437.png)


Changes proposed in this pull request:

- triangle was shown in config menu in mobile view
- improved the position of the triangle in theme "dark"
- improved at all the themes. Triangle style is now in template.css. Less lines of style in themes css. much easier to maintain the code

How to test the feature manually:

check 1.: open the config menu in mobile view
check 2.: theme "dark": open the user query menue in mobile view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
