### PR TITLE
Fixed: wrong dropdown triangle of labels category

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -52,7 +52,7 @@
 		?>
 		<li id="tags" class="tree-folder category tags<?= $t_active ? ' active' : '' ?>" data-unread="<?= format_number($this->nbUnreadTags) ?>">
 			<div class="tree-folder-title">
-				<a class="dropdown-toggle" href="#"><?= _i($t_active ? 'up' : 'down') ?></a>
+				<a class="dropdown-toggle" href="#"><?= _i($t_active || (strlen($class) < 1) || (format_number($this->nbUnreadTags) > 0) ? 'up' : 'down') ?></a>
 				<a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter_fav ?>"><?= _t('index.menu.tags') ?></a>
 			</div>
 			<ul class="tree-folder-items<?= $t_show ? ' active' : '' ?>">

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -52,7 +52,7 @@
 		?>
 		<li id="tags" class="tree-folder category tags<?= $t_active ? ' active' : '' ?>" data-unread="<?= format_number($this->nbUnreadTags) ?>">
 			<div class="tree-folder-title">
-				<a class="dropdown-toggle" href="#"><?= _i($t_active || (strlen($class) < 1) || (format_number($this->nbUnreadTags) > 0) ? 'up' : 'down') ?></a>
+				<a class="dropdown-toggle" href="#"><?= _i($t_show ? 'up' : 'down') ?></a>
 				<a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter_fav ?>"><?= _t('index.menu.tags') ?></a>
 			</div>
 			<ul class="tree-folder-items<?= $t_show ? ' active' : '' ?>">


### PR DESCRIPTION
Summary:
shows the triangle to bottom: dropdown is closed
shows the triangle to top: dropdown is open

## Example 1
Before:
![grafik](https://user-images.githubusercontent.com/1645099/151052757-46791f35-2729-4f05-86a6-968b9d9608dc.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/151052786-0052ca9c-f31d-45e4-b09d-bbe3df50c884.png)

## Example 2
Before:
![grafik](https://user-images.githubusercontent.com/1645099/151052809-987670d1-557f-465a-bf34-a283dce2fb67.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/151052839-9a99f57d-32bb-411e-8924-245afa5732a3.png)

## Example 3
Before:
![grafik](https://user-images.githubusercontent.com/1645099/151052866-2869ed34-f4df-46eb-b2fb-bea659192845.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/151052881-99feebc2-684c-4a8f-8eea-aa9896da1537.png)




Changes proposed in this pull request:

- improved the logic of the triangle icon

How to test the feature manually:

1. filter: show `only `unread articles, labels has some unread articles
2. filter: show unread `and ` read articles, labels has some unread articles
3. filter: show unread `and ` read articles, labels has `no `unread articles

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
