### PR TITLE
Nord: fix nav_menu sidebar toggle overlap and mark-read dropdown edge

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -237,6 +237,7 @@ People are sorted by name so please keep this order.
 * [Pim Snel](https://github.com/mipmip): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is%3Apr+author%3Amipmip), [Web](https://www.pimsnel.com)
 * [plopoyop](https://github.com/plopoyop): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:plopoyop)
 * [Pofilo](https://github.com/Pofilo): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Pofilo), [Web](https://www.pofilo.fr/)
+* [polybjorn](https://github.com/polybjorn): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:polybjorn), [Web](https://polybjorn.com/)
 * [Poorchop](https://github.com/Poorchop): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Poorchop)
 * [Prashant Tholia](https://github.com/prashanttholia): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:prashanttholia)
 * [primaeval](https://github.com/primaeval): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:primaeval)

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -331,6 +331,14 @@ svg:hover {
 	border-bottom-left-radius: 0;
 }
 
+@media (max-width: 840px) {
+	.nav_menu .stick #mark-read-menu .dropdown-toggle.btn {
+		border-left: 1px solid var(--border-elements);
+		border-top-left-radius: 6px;
+		border-bottom-left-radius: 6px;
+	}
+}
+
 
 .stick .btn:last-child {
 	margin-right: 0;
@@ -985,6 +993,10 @@ li.item.active {
 .nav_menu {
 	padding: 5px 0;
 	text-align: center;
+}
+
+.nav_menu #nav_menu_toggle_aside {
+	position: static;
 }
 
 .nav_menu .btn {

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -331,14 +331,6 @@ svg:hover {
 	border-bottom-left-radius: 0;
 }
 
-@media (max-width: 840px) {
-	.nav_menu .stick #mark-read-menu .dropdown-toggle.btn {
-		border-left: 1px solid var(--border-elements);
-		border-top-left-radius: 6px;
-		border-bottom-left-radius: 6px;
-	}
-}
-
 
 .stick .btn:last-child {
 	margin-right: 0;
@@ -1297,6 +1289,12 @@ optgroup::before {
 
 	.nav_menu .btn {
 		margin-bottom: .5rem;
+	}
+
+	.nav_menu .stick #mark-read-menu .dropdown-toggle.btn {
+		border-left: 1px solid var(--border-elements);
+		border-top-left-radius: 6px;
+		border-bottom-left-radius: 6px;
 	}
 
 	.nav_menu .search input {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -331,14 +331,6 @@ svg:hover {
 	border-bottom-right-radius: 0;
 }
 
-@media (max-width: 840px) {
-	.nav_menu .stick #mark-read-menu .dropdown-toggle.btn {
-		border-right: 1px solid var(--border-elements);
-		border-top-right-radius: 6px;
-		border-bottom-right-radius: 6px;
-	}
-}
-
 
 .stick .btn:last-child {
 	margin-left: 0;
@@ -1297,6 +1289,12 @@ optgroup::before {
 
 	.nav_menu .btn {
 		margin-bottom: .5rem;
+	}
+
+	.nav_menu .stick #mark-read-menu .dropdown-toggle.btn {
+		border-right: 1px solid var(--border-elements);
+		border-top-right-radius: 6px;
+		border-bottom-right-radius: 6px;
 	}
 
 	.nav_menu .search input {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -331,6 +331,14 @@ svg:hover {
 	border-bottom-right-radius: 0;
 }
 
+@media (max-width: 840px) {
+	.nav_menu .stick #mark-read-menu .dropdown-toggle.btn {
+		border-right: 1px solid var(--border-elements);
+		border-top-right-radius: 6px;
+		border-bottom-right-radius: 6px;
+	}
+}
+
 
 .stick .btn:last-child {
 	margin-left: 0;
@@ -985,6 +993,10 @@ li.item.active {
 .nav_menu {
 	padding: 5px 0;
 	text-align: center;
+}
+
+.nav_menu #nav_menu_toggle_aside {
+	position: static;
 }
 
 .nav_menu .btn {


### PR DESCRIPTION
Fixes #8707

Two small layout issues in the Nord theme's top button row, both only visible in Nord.

### 1. Sidebar toggle overlapping the first button

`#nav_menu_toggle_aside` is absolute-positioned by `base-theme/frss.css`, which expects `.nav_menu` to reserve space via `padding-left: 3rem`. Nord's `.nav_menu` rule replaces that padding with `padding: 5px 0`, so at narrow widths the toggle overlaps the first button in the row.

Fix: set `position: static` on the toggle inside Nord so it flows inline with the other buttons.

I also considered restoring `padding-left` on `.nav_menu` instead, but couldn't find a single value that looked right across all viewport widths. Happy to switch approach if preferred.

### 2. Missing left border on the mark-read dropdown

At `max-width: 840px`, `base-theme` hides the "Mark as read" text button and only the dropdown toggle remains. Nord strips that toggle's left border and radius so it visually joins the text button (lines 326-332), but once the text button is hidden the toggle renders with a flat, borderless left edge.

Fix: restore the border and radius on the toggle inside the same media query.

### Notes

- `nord.rtl.css` regenerated with `make rtl`.
- `npm run stylelint` passes.
- Tested locally against FreshRSS 1.28.2-dev in LibreWolf.

Screenshots are on the linked issue.